### PR TITLE
fix(docs): correct README file list and CONTEXT.md placeholder drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ The working folder is project-specific knowledge ("what are we building, how far
 │   ├── acceptance-test-results.md
 │   └── research.md
 └── memory-templates/        ← starter auto-memory for a new project
-    ├── MEMORY.md
-    ├── user_role.md
-    ├── feedback_example.md
-    ├── project_example.md
-    └── reference_example.md
+    ├── MEMORY.md            ← index of memory files
+    ├── user_role.md         ← who you are, how to calibrate
+    ├── feedback_*.md        ← rules & preferences (commits, PRs, CI, etc.)
+    ├── project_*.md         ← project context
+    └── reference_*.md       ← external pointers (working folder, etc.)
 ```
 
 ## How to use for a new project

--- a/templates/CONTEXT.md
+++ b/templates/CONTEXT.md
@@ -18,6 +18,7 @@ At the start of any new Claude session, say:
 
 - **GitHub / host:** {{REPO_URL}}
 - **Visibility:** {{public | private | internal}}
+- **Platform targets:** {{PLATFORM_TARGETS}}
 - **This folder:** Private AI working context — never commit to repo
 
 ---


### PR DESCRIPTION
## Summary

- `README.md` listed three `*_example.md` files in `memory-templates/` that don't exist (actual files are topic-specific: `feedback_commit_format.md`, etc.). Replaced with a pattern-based listing (`feedback_*.md`, `project_*.md`, `reference_*.md`) that stays accurate as the set grows.
- `SETUP.md:47` told users to fill a `{{PLATFORM_TARGETS}}` placeholder that didn't exist in `templates/CONTEXT.md`. Added it under Project Overview.

## Why

Found during the first dogfood review. A kit that preaches "keep docs in sync" shouldn't ship with doc drift on day one.

## Test plan — ✅ PASS

- [x] `grep -R '{{PLATFORM_TARGETS}}' .` returns hits in both `SETUP.md` and `templates/CONTEXT.md`
  ```
  templates/CONTEXT.md:21:- **Platform targets:** {{PLATFORM_TARGETS}}
  SETUP.md:47:- `{{PLATFORM_TARGETS}}` — macOS / Linux / Windows / web / etc.
  ```
- [x] `grep -R 'feedback_example\|project_example\|reference_example' .` returns no matches (verified)
- [x] `README.md` tree block renders cleanly — verified the block at `README.md:26-47` in its post-edit form; tree pipes intact, no orphaned lines
- [x] Every `{{PLACEHOLDER}}` mentioned in `SETUP.md` step 3 resolves to at least one template/memory file:
  - `{{PROJECT_NAME}}` → 7 files (templates + memory-templates)
  - `{{REPO_SLUG}}` → `templates/CONTEXT.md`, `templates/plan.md`
  - `{{REPO_PATH}}` → `templates/CONTEXT.md`, `memory-templates/reference_ai_working_folder.md`
  - `{{WORKING_FOLDER}}` → `memory-templates/reference_ai_working_folder.md`
  - `{{ONE_PARAGRAPH_DESCRIPTION}}` → `templates/CONTEXT.md`
  - `{{PLATFORM_TARGETS}}` → `templates/CONTEXT.md` (this PR)