### PR TITLE
feat(bootstrap): add bootstrap.sh and use it in SETUP.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -24,14 +24,23 @@ Whatever you pick, the **repo stays the repo; the working folder stays separate*
 
 ---
 
-## 2. Copy the templates
+## 2. Run `bootstrap.sh`
+
+From the root of the project repo you're bootstrapping:
 
 ```bash
-mkdir -p "<working-folder>"
-cp <framework-dir>/templates/*.md "<working-folder>/"
+cd <project-repo>
+<framework-dir>/bootstrap.sh <working-folder>
 ```
 
-Rename `phase-N-checklist.md` → `phase-0-checklist.md` to start.
+That creates the working folder, copies the templates, renames `phase-N-checklist.md` → `phase-0-checklist.md`, and seeds the project's auto-memory at the Claude harness's expected path (`~/.claude/projects/<sanitized>/memory/`).
+
+Flags:
+- `--skip-memory` — skip the memory-seeding step (leaves `~/.claude/projects/…` alone)
+- `--force` — proceed even if the working folder is already non-empty
+- `-h` / `--help` — show usage
+
+Prefer to see what's happening step-by-step? See [Manual alternative](#manual-alternative) at the bottom of this doc.
 
 ---
 
@@ -50,28 +59,16 @@ The other docs (`plan.md`, `implementation.md`, etc.) can stay mostly skeletal u
 
 ---
 
-## 4. Seed auto-memory
+## 4. Tune your auto-memory
 
-Find the project's memory folder. When you launch `claude` in the repo for the first time, the harness creates:
+`bootstrap.sh` already dropped the starter memory files into your project's memory folder. Now edit them to match your actual rules and tooling:
 
-```
-~/.claude/projects/<sanitized-repo-path>/memory/
-```
-
-The sanitization rule: absolute path with `/` replaced by `-`, prefixed with `-`. For example `/Users/you/Code/acme/foo` → `-Users-you-Code-acme-foo`.
-
-Copy starter memory files:
-
-```bash
-PROJECT_MEMORY=~/.claude/projects/<sanitized-path>/memory
-mkdir -p "$PROJECT_MEMORY"
-cp <framework-dir>/memory-templates/*.md "$PROJECT_MEMORY/"
-```
-
-Then edit each one: delete what doesn't apply, tune what does. Especially:
-- `reference_ai_working_folder.md` — point it at the working folder you picked in step 1
+- `reference_ai_working_folder.md` — fill in `{{WORKING_FOLDER}}` and `{{PROJECT_NAME}}` so Claude knows where to look
 - `user_role.md` — your role and background *as it relates to this project* (Claude uses this to calibrate explanations)
-- `MEMORY.md` — keep the index in sync with whatever files you end up with
+- Prune feedback/project files that don't apply; tune the ones that do
+- Keep `MEMORY.md` in sync with whatever files you end up with
+
+If you ran bootstrap with `--skip-memory`, see the [Manual alternative](#manual-alternative) for how to seed it by hand.
 
 ---
 
@@ -112,6 +109,28 @@ Every working session should end with:
 4. Auto-memory refreshed — if a rule came up twice, save it as feedback
 
 The habit that makes this work: the **last thing you do** before quitting is update these docs. It takes two minutes and rescues the next session from "where was I?"
+
+---
+
+## Manual alternative
+
+If you can't run `bootstrap.sh` (no Bash available, restricted environment, or you just want to see what it does), perform the same work by hand.
+
+### Copy templates
+```bash
+mkdir -p "<working-folder>"
+cp <framework-dir>/templates/*.md "<working-folder>/"
+mv "<working-folder>/phase-N-checklist.md" "<working-folder>/phase-0-checklist.md"
+```
+
+### Seed auto-memory
+The harness expects memory at `~/.claude/projects/<sanitized-path>/memory/`. Sanitization rule: absolute repo path with `/` replaced by `-`, prefixed with `-`. Example: `/Users/you/Code/acme/foo` → `-Users-you-Code-acme-foo`.
+
+```bash
+PROJECT_MEMORY=~/.claude/projects/<sanitized-path>/memory
+mkdir -p "$PROJECT_MEMORY"
+cp <framework-dir>/memory-templates/*.md "$PROJECT_MEMORY/"
+```
 
 ---
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# bootstrap.sh — create a Claude working folder and seed auto-memory
+# for the project whose repo you run this from.
+#
+# Run this from the root of the project repo you want to bootstrap. The
+# auto-memory path is derived from the current working directory using
+# the Claude harness's sanitization rule ('/' -> '-', prefixed with '-').
+set -euo pipefail
+
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "error: bootstrap.sh requires bash" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KIT_ROOT="$SCRIPT_DIR"
+
+usage() {
+  cat <<EOF
+Usage: bootstrap.sh [options] <working-folder>
+
+Create a Claude working folder and seed auto-memory for the project
+whose repo you run this from. The current working directory is assumed
+to be the repo root.
+
+Arguments:
+  <working-folder>   Absolute path where the Claude working folder will
+                     be created (e.g. ~/Documents/Claude/Projects/foo).
+
+Options:
+  --skip-memory      Skip copying memory-templates/ into the auto-memory
+                     folder. Only the working folder will be seeded.
+  --force            Proceed even if the working folder already exists
+                     and is non-empty. Does NOT override the auto-memory
+                     safety check — existing memory files are never
+                     overwritten.
+  -h, --help         Show this help and exit.
+
+Example:
+  cd ~/Code/my-new-project
+  ~/Code/claude-project-kit/bootstrap.sh ~/Documents/Claude/Projects/my-new-project
+
+After running, edit the copied files (placeholders marked {{LIKE_THIS}}).
+See SETUP.md in the kit repo for the full walk-through.
+EOF
+}
+
+SKIP_MEMORY=0
+FORCE=0
+WORKING_FOLDER=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --skip-memory) SKIP_MEMORY=1; shift ;;
+    --force) FORCE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --*) echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *)
+      if [ -z "$WORKING_FOLDER" ]; then
+        WORKING_FOLDER="$1"
+      else
+        echo "error: unexpected extra argument: $1" >&2
+        usage >&2
+        exit 2
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$WORKING_FOLDER" ]; then
+  echo "error: missing <working-folder> argument" >&2
+  usage >&2
+  exit 2
+fi
+
+case "$WORKING_FOLDER" in
+  "~") WORKING_FOLDER="$HOME" ;;
+  "~/"*) WORKING_FOLDER="$HOME/${WORKING_FOLDER#~/}" ;;
+esac
+
+case "$WORKING_FOLDER" in
+  /*) ;;
+  *) echo "error: <working-folder> must be an absolute path (got: $WORKING_FOLDER)" >&2; exit 2 ;;
+esac
+
+if [ ! -d "$KIT_ROOT/templates" ] || [ ! -d "$KIT_ROOT/memory-templates" ]; then
+  echo "error: bootstrap.sh must live alongside templates/ and memory-templates/ in a claude-project-kit checkout" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(pwd)"
+SANITIZED="$(echo "$REPO_ROOT" | sed 's|/|-|g')"
+MEMORY_DIR="$HOME/.claude/projects/${SANITIZED}/memory"
+
+echo "Working folder: $WORKING_FOLDER"
+echo "Repo root:      $REPO_ROOT"
+if [ "$SKIP_MEMORY" -eq 0 ]; then
+  echo "Memory folder:  $MEMORY_DIR"
+fi
+echo
+
+if [ -e "$WORKING_FOLDER" ]; then
+  if [ ! -d "$WORKING_FOLDER" ]; then
+    echo "error: $WORKING_FOLDER exists and is not a directory" >&2
+    exit 1
+  fi
+  if [ -n "$(ls -A "$WORKING_FOLDER" 2>/dev/null)" ] && [ "$FORCE" -eq 0 ]; then
+    echo "error: $WORKING_FOLDER is not empty. Use --force to proceed anyway." >&2
+    exit 1
+  fi
+fi
+
+if [ "$SKIP_MEMORY" -eq 0 ] && [ -d "$MEMORY_DIR" ]; then
+  if [ -n "$(ls -A "$MEMORY_DIR" 2>/dev/null)" ]; then
+    echo "error: $MEMORY_DIR already contains files." >&2
+    echo "       Bootstrap will never overwrite existing memory. Inspect and clear" >&2
+    echo "       manually, or re-run with --skip-memory to leave memory alone." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "$WORKING_FOLDER"
+cp "$KIT_ROOT/templates/"*.md "$WORKING_FOLDER/"
+mv "$WORKING_FOLDER/phase-N-checklist.md" "$WORKING_FOLDER/phase-0-checklist.md"
+echo "  ✓ Copied template files to $WORKING_FOLDER"
+echo "  ✓ Renamed phase-N-checklist.md → phase-0-checklist.md"
+
+if [ "$SKIP_MEMORY" -eq 0 ]; then
+  mkdir -p "$MEMORY_DIR"
+  cp "$KIT_ROOT/memory-templates/"*.md "$MEMORY_DIR/"
+  echo "  ✓ Copied memory files to $MEMORY_DIR"
+fi
+
+echo
+echo "Bootstrap complete."
+echo
+echo "Next steps:"
+echo "  1. cd $WORKING_FOLDER"
+echo "  2. Fill in {{PLACEHOLDERS}} — start with CONTEXT.md (see SETUP.md §3)"
+if [ "$SKIP_MEMORY" -eq 0 ]; then
+  echo "  3. Edit memory files at $MEMORY_DIR to match your preferences"
+  echo "     (especially reference_ai_working_folder.md — point it at the working folder)"
+  echo "  4. Open a Claude session and use a prompt from PROMPTS.md"
+else
+  echo "  3. Open a Claude session and use a prompt from PROMPTS.md"
+fi


### PR DESCRIPTION
## Summary

- Adds `bootstrap.sh` at repo root — one command to create a working folder, copy templates, rename `phase-N-checklist.md` → `phase-0-checklist.md`, and seed auto-memory at `~/.claude/projects/<sanitized>/memory/`.
- Rewrites `SETUP.md` steps 2 and 4 to use the script; keeps the manual instructions as a "Manual alternative" section at the bottom for transparency / fallback.

## Why

`SETUP.md` step 4's manual path sanitization (`/` → `-`, prefixed with `-`) was the most error-prone step in the old bootstrap flow. A team member brand new to the kit would trip on it. Script turns it into a one-liner.

Fixes P1.4 from the Phase 1 punch list.

## Design decisions

- **Seed auto-memory by default**, with `--skip-memory` escape hatch
- **No interactive prompts** — too brittle in Bash, breaks pipes/CI. Users fill `{{PLACEHOLDERS}}` after bootstrap.
- **Abort if target working folder is non-empty**; `--force` to proceed.
- **Abort if auto-memory already has files** — never overwrite existing memory. No `--force` override (too risky).
- **Bash 3-compatible** — works on stock macOS without `brew install bash`.
- **Derive auto-memory path from `\$(pwd)`** — user cd's into their project repo first.

## Test plan — ✅ PASS (all run locally)

- [x] \`--help\` prints usage, exits 0
- [x] Missing \`<working-folder>\` arg → error + usage, exits 2
- [x] Unknown option \`--bogus\` → error, exits 2
- [x] Non-absolute path → error, exits 2
- [x] Happy path with \`--skip-memory\` to scratch dir → copies 7 templates, renames phase-N → phase-0, exits 0
- [x] Re-run same target without \`--force\` → aborts with clear error (non-empty), exits 1
- [x] Re-run with \`--force\` → succeeds, overwrites, exits 0
- [x] Memory safety: cd to a repo with populated memory (this kit's own repo), run without \`--skip-memory\` → aborts, existing memory untouched
- [x] Full end-to-end with memory creation (fresh tmp repo + tmp working folder) → copies 7 templates + 11 memory files, prints correct next steps, cleanup leaves no trace in \`~/.claude/projects/\`

Evidence: 9/9 tests passed in pre-commit run. Tempdir artifacts cleaned up. No pollution of real memory folders.