### PR TITLE
feat(examples): add filled-in widget-tracker reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The working folder is project-specific knowledge ("what are we building, how far
 ├── CONVENTIONS.md           ← generic working rules (commits, PRs, etc.)
 ├── PROMPTS.md               ← ready-to-paste session-opening prompts
 ├── LICENSE
+├── bootstrap.sh             ← one-command setup (see SETUP.md step 2)
 ├── templates/               ← copy these into a new working folder
 │   ├── CONTEXT.md
 │   ├── SESSION-LOG.md
@@ -38,6 +39,8 @@ The working folder is project-specific knowledge ("what are we building, how far
 │   ├── phase-N-checklist.md
 │   ├── acceptance-test-results.md
 │   └── research.md
+├── examples/                ← filled-in reference — read, don't copy
+│   └── widget-tracker/      ← fictional Go CLI, mid-Phase-1 snapshot
 └── memory-templates/        ← starter auto-memory for a new project
     ├── MEMORY.md            ← index of memory files
     ├── user_role.md         ← who you are, how to calibrate

--- a/SETUP.md
+++ b/SETUP.md
@@ -55,6 +55,8 @@ Every template uses `{{PLACEHOLDER}}` markers. Search-and-replace in your editor
 - `{{ONE_PARAGRAPH_DESCRIPTION}}` — what the project is, in plain English
 - `{{PLATFORM_TARGETS}}` — macOS / Linux / Windows / web / etc.
 
+For a fully filled-in reference, see [`examples/widget-tracker/CONTEXT.md`](examples/widget-tracker/CONTEXT.md) — a fictional Go CLI project at a plausible mid-phase state. The matching `plan.md`, `SESSION-LOG.md`, and `phase-1-checklist.md` live alongside it. Read them when you want to see what "populated" looks like rather than what the template dictates.
+
 The other docs (`plan.md`, `implementation.md`, etc.) can stay mostly skeletal until you're ready to plan real work.
 
 ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,27 @@
+# Examples
+
+Filled-in reference copies of what a project's working folder looks like partway through real work. These are **read-me-for-reference**, not copy-me-and-fill.
+
+## Why this exists
+
+The kit's `templates/` directory ships skeleton files with `{{PLACEHOLDER}}` markers meant to be copied into your project's working folder and filled in (see [SETUP.md](../SETUP.md)). That shows you the shape, but not the *substance* — the hard question is always "what does a plausible, populated `CONTEXT.md` actually read like?"
+
+This folder answers that. Each subfolder is a fictional project at a realistic mid-phase state — not a perfect exemplar, just an honest snapshot.
+
+## What's here
+
+- `widget-tracker/` — a made-up small Go CLI. Mid-Phase 1: Phase 0 shipped, Phase 1 partially complete. Demonstrates populated `CONTEXT.md`, a multi-phase `plan.md`, a `phase-1-checklist.md` with mixed ✅ / ⏳ / [ ] states, and a `SESSION-LOG.md` with a few chronological entries.
+
+## How to use
+
+- Read. Don't copy.
+- Compare against the matching file in `templates/` — the example shows what's concrete, the template shows where to put your own content.
+- Use as a reference when you're halfway through filling your own working folder and you're unsure how formal or verbose to be.
+
+## Conventions for this folder
+
+If you add a new example here:
+- Keep the project fictional. Don't seed examples from real work unless the real project is fully public already.
+- Show a realistic state, not a perfect one. A checklist where every item is ✅ isn't instructive — mixed states are.
+- Skip files that don't add value. Not every example needs all seven template files.
+- Update this `README.md` to mention the new example.

--- a/examples/widget-tracker/CONTEXT.md
+++ b/examples/widget-tracker/CONTEXT.md
@@ -1,0 +1,121 @@
+# Claude Working Context — widget-tracker
+**Last updated:** 2026-04-12
+**Project:** `exampleco/widget-tracker`
+**Repo path:** `/Users/dev/Code/widget-tracker`
+
+---
+
+## How to load this context
+
+At the start of any new Claude session, say:
+> "Read CONTEXT.md and SESSION-LOG.md in this folder before we start."
+
+Or rely on `reference_ai_working_folder.md` in auto-memory, which points here.
+
+---
+
+## Project Overview
+
+`widget-tracker` is a single-binary Go CLI for tracking inventory of physical widgets across multiple storage locations. SQLite storage, no server, no GUI. Built because spreadsheet-based tracking kept losing data to concurrent edits and the team didn't want to introduce a cloud service. Each operator runs a local instance; CSV import/export is the sync mechanism between operators.
+
+- **GitHub / host:** https://github.com/exampleco/widget-tracker
+- **Visibility:** public
+- **Platform targets:** macOS (arm64 + x86_64), Linux (x86_64 primary; arm64 P1), Windows-via-WSL (P2)
+- **This folder:** private AI working context — never commit to repo
+
+---
+
+## Planning Document System
+
+- **`plan.md`** — phases, goals, open questions, risks
+- **`implementation.md`** — detailed specs per numbered task; other docs reference (§X.Y)
+- **`phase-N-checklist.md`** — trackable items for one phase; one file per phase
+- **`acceptance-test-results.md`** — manual verification log for the current phase
+- **`research.md`** — frozen technical research (SQLite vs. key-value store, etc.)
+- **`SESSION-LOG.md`** — chronological session history, append-only
+- **`CONTEXT.md`** — this file
+
+---
+
+## Working Rules
+
+### Git & commits
+- Conventional Commits, single line, signed off (`git commit -s -m "type(scope): message"`)
+- Branch naming: `feat/…`, `fix/…`, `ci/…`, `docs/…`, `test/…`, `chore/…`
+- Merge-commit PR strategy (preserves granular commits for git-cliff changelog generation at release time)
+- Push branches to origin by default after committing
+
+### PRs
+- Title ≤ 70 chars, Conventional Commit form
+- Body includes a manual test plan for any change touching runtime behavior
+- Tick the test plan off with evidence after passing
+- Required CI checks: `lint`, `test-macos`, `test-linux`
+
+### Shell / build
+- Shell: zsh (macOS) / bash (Linux); scripts target Bash 3+
+- Local build: `go build ./cmd/widget-tracker`
+- Local test: `go test ./...`
+- Lint: `golangci-lint run` (config in `.golangci.yml`)
+
+### File editing
+- Repo is mounted at `/Users/dev/Code/widget-tracker`
+- Claude reads + edits directly; never copy-paste code through chat
+
+---
+
+## Current Phase Status
+
+**Phase 0 — Setup: ✅ complete** (wrapped 2026-03-22; see `SESSION-LOG.md`).
+
+**Phase 1 — Core CRUD + SQLite: ⏳ in progress.** Section A done (schema + `add`), Section B mid-flight (`list` command works, filters pending), Section C not yet started (SQLite backend swap).
+
+**Known issues / open threads:**
+- `list` currently uses the in-memory store — will be swapped to SQLite in Section C
+- Composite-unique-key decision for `(name, location)` still open (Open Question #2 in `plan.md`)
+- CI on Linux-arm64 is P1 — matrix not yet expanded, acceptable for Phase 1
+
+---
+
+## Key Dependencies
+
+- Go 1.22+ (generics used in `internal/store/`)
+- `modernc.org/sqlite` — pure-Go SQLite driver. Avoids CGO so we can statically cross-compile. Trade-off: slightly slower than cgo-based `mattn/go-sqlite3`, but acceptable for single-operator CLI workloads. See `research.md` §1.
+- `golangci-lint` v1.57+ — pinned in CI
+- No runtime network dependencies — fully offline tool
+
+---
+
+## CI Overview
+
+- **CI platform:** GitHub Actions
+- **Targets:** macOS-latest (arm64), ubuntu-latest (x86_64)
+- **Quality gates:** `golangci-lint`, `go test ./...` with race detector, cross-compile check for linux/arm64
+- **Release:** `gh release create` + GoReleaser for multi-arch binary builds (Phase 2 scope)
+
+---
+
+## Acceptance Testing Setup
+
+Manual acceptance testing runs against a fresh SQLite file at `~/.local/share/widget-tracker/db.sqlite` (Linux) or `~/Library/Application Support/widget-tracker/db.sqlite` (macOS). See `acceptance-test-results.md` for the current phase's test log and reset procedure.
+
+---
+
+## Open Questions
+
+| # | Question | Status |
+|---|---|---|
+| 2 | Should `add` allow duplicate widget names? | ⏳ Open — see `plan.md` §Open Questions |
+| 3 | Concurrent SQLite access across terminals — WAL mode enough? | ⏳ Open |
+| 4 | Data file location — XDG vs. dotfile? | ⏳ Open |
+
+(Open Question #1 — SQLite vs. key-value store — resolved in Phase 0; see `research.md` §1.)
+
+---
+
+## Reference
+
+- `plan.md` — phase breakdown and scope
+- `phase-1-checklist.md` — current phase, with branch/PR info per item
+- `implementation.md` — numbered specs referenced from checklists
+- `research.md` — frozen technical research (SQLite driver choice, data file location)
+- `SESSION-LOG.md` — chronological session history

--- a/examples/widget-tracker/SESSION-LOG.md
+++ b/examples/widget-tracker/SESSION-LOG.md
@@ -1,0 +1,76 @@
+# Session Log — widget-tracker
+
+Chronological record of Claude working sessions. Each entry captures what was done, decisions made, and anything non-obvious that future sessions should know.
+
+**Append-only.** Never delete past entries. If something in an old entry turns out wrong, note the correction in the current session's entry rather than editing history.
+
+---
+
+## Session: 2026-03-15 — Bootstrap + Phase 0 kickoff
+
+**Focus:** Initial project bootstrap. Set up repo, working folder, auto-memory, CI skeleton.
+
+**Branches/PRs:**
+- `chore/initial-scaffold` → PR [#1](https://github.com/exampleco/widget-tracker/pull/1) (merged) — Go module init, dir layout
+- `ci/github-actions-baseline` → PR [#2](https://github.com/exampleco/widget-tracker/pull/2) (merged) — lint, test, cross-compile matrix
+
+**Key decisions:**
+- **Layout:** `cmd/widget-tracker/` for main, `internal/store/` for storage, `internal/widget/` for domain types. Rejected `pkg/` (not an exported library).
+- **SQLite driver:** `modernc.org/sqlite` (pure Go). Rationale: avoids CGO so we can static-cross-compile from any host. Slightly slower than `mattn/go-sqlite3` but acceptable for single-operator CLI. See `research.md` §1.
+- **License:** Apache 2.0 (matches team's other public tools).
+
+**Non-obvious findings:**
+- `golangci-lint` 1.57 has a regression on Go 1.22 generics — pinned to 1.56 in CI for now, tracked upstream.
+- GitHub Actions cache for Go modules cuts CI time from ~2 min to ~45 s — worth the config.
+
+**Open threads / next steps:**
+- Start Phase 0 acceptance: hello-world binary should build and run from the CI artifact.
+- Scaffold `phase-0-checklist.md`.
+
+---
+
+## Session: 2026-03-22 — Phase 0 complete, Phase 1 schema work begins
+
+**Focus:** Close out Phase 0 acceptance, scaffold Phase 1 checklist, start on SQLite schema.
+
+**Branches/PRs:**
+- `feat/hello-world` → PR [#3](https://github.com/exampleco/widget-tracker/pull/3) (merged) — minimal main that prints version, proves CI artifact pipeline
+- `feat/schema-and-migrations` → PR [#4](https://github.com/exampleco/widget-tracker/pull/4) (open → merged 2026-03-28)
+
+**Key decisions:**
+- **Migration strategy:** forward-only, idempotent numbered migrations under `internal/store/migrations/`. No rollback — too much complexity for a single-operator tool. If a migration breaks, users restore from CSV export.
+- **Schema v1:** `widgets(id, name, location, tags, created_at, updated_at)`. Tags stored as JSON array in a TEXT column for v1 — room to normalize later if search perf matters.
+
+**Non-obvious findings:**
+- The `modernc.org/sqlite` driver doesn't support `PRAGMA journal_mode=WAL` via the standard DSN params — have to issue it as a query after opening. Found the hard way when WAL file wasn't appearing in testing.
+- Phase 0 acceptance tests took longer than planned because the cross-compile matrix surfaced a darwin/arm64 specific build tag issue (fixed in PR #3).
+
+**Open threads / next steps:**
+- Finish migration runner (PR #4 still open)
+- Next session: start on `add` command (§A.2)
+- Reconcile Open Question #4 (data file location) before Section C — affects docs, not code, so deferrable.
+
+---
+
+## Session: 2026-04-05 — `add` done, starting `list`
+
+**Focus:** Acceptance-test `add` end-to-end, kick off `list` command.
+
+**Branches/PRs:**
+- `test/add-integration` → PR [#6](https://github.com/exampleco/widget-tracker/pull/6) (merged 2026-04-03)
+- `feat/list-command` → PR [#7](https://github.com/exampleco/widget-tracker/pull/7) (open)
+
+**Key decisions:**
+- **Table output format:** fixed-width columns for now; will add `--json` output in Phase 2. Rejected `tabwriter` flush-on-every-row because it flickered in tailed scenarios — buffer-and-flush-once is fine for the expected row counts.
+- **Empty-list behavior:** `list` on empty store exits 0 with message "no widgets found" on stderr, nothing on stdout. Matches `grep`-friendly conventions.
+
+**Non-obvious findings:**
+- Feedback from Aaron: single-word `list` output header was ambiguous when piping into `awk`. Switched to `NAME    LOCATION    TAGS` with explicit column headers. Saved as feedback memory "stdout headers are data too".
+- Integration test for `add` initially flaked in CI because the test dir was being created inside the repo — migrated to `t.TempDir()` and flakes disappeared.
+
+**Open threads / next steps:**
+- B.2 filter flags next — AND vs OR semantics decision needed. Lean AND.
+- Start thinking about Section C's in-memory → SQLite swap. Not urgent; Section B first.
+- Open Question #4 still unresolved; try to resolve before Section C so README docs can be authoritative.
+
+---

--- a/examples/widget-tracker/phase-1-checklist.md
+++ b/examples/widget-tracker/phase-1-checklist.md
@@ -1,0 +1,131 @@
+# Phase 1 Checklist — Core CRUD + SQLite
+
+**Goal:** Ship `add` + `list` commands backed by SQLite, with tests covering happy path and common error paths.
+**Status:** ⏳ In progress (Section A done, Section B mid-flight, Section C not started)
+**Exit criteria:** `add` + `list` work against a real SQLite file; CI green on macOS and Linux; README quickstart walkable in under 5 min by a new user.
+
+---
+
+## How to use this doc
+
+- One item ≈ one branch ≈ one PR.
+- Each item records branch name, commit message(s), and PR number once merged.
+- Reference `implementation.md` specs by number (`see §A.2`).
+- Tick items ✅ the moment the PR merges — not at end of phase.
+
+---
+
+## Section A — Schema & `add` command
+
+### A.1 Schema design + migration runner
+
+- **Spec:** `implementation.md` §A.1
+- **Branch:** `feat/schema-and-migrations`
+- **Commits:**
+  - `feat(store): add schema v1 with widgets table`
+  - `feat(store): add migration runner with version tracking`
+- **PR:** [#4](https://github.com/exampleco/widget-tracker/pull/4) — merged 2026-03-28
+- **Status:** [x] merged ✅
+
+### A.2 `add` command — required fields validation
+
+- **Spec:** `implementation.md` §A.2
+- **Branch:** `feat/add-command`
+- **Commits:**
+  - `feat(cmd): add 'add' subcommand with name/location/tag flags`
+  - `test(add): cover missing-required-field error paths`
+- **PR:** [#5](https://github.com/exampleco/widget-tracker/pull/5) — merged 2026-04-02
+- **Status:** [x] merged ✅
+
+### A.3 Integration test for `add` against real SQLite file
+
+- **Spec:** `implementation.md` §A.3
+- **Branch:** `test/add-integration`
+- **Commits:**
+  - `test(integration): round-trip add through sqlite file`
+- **PR:** [#6](https://github.com/exampleco/widget-tracker/pull/6) — merged 2026-04-03
+- **Status:** [x] merged ✅
+
+---
+
+**Checkpoint A:** ✅ `add` works end-to-end. SQLite file on disk matches stdout output. Proceeded to B.
+
+---
+
+## Section B — `list` command
+
+### B.1 `list` command — table output
+
+- **Spec:** `implementation.md` §B.1
+- **Branch:** `feat/list-command`
+- **Commits:**
+  - `feat(cmd): add 'list' subcommand with table output`
+- **PR:** [#7](https://github.com/exampleco/widget-tracker/pull/7) — merged 2026-04-08
+- **Status:** [x] merged ✅
+
+### B.2 `list` — `--location` and `--tag` filter flags
+
+- **Spec:** `implementation.md` §B.2
+- **Branch:** `feat/list-filters`
+- **Commits:**
+  - `feat(cmd): add --location and --tag filters to list` (WIP)
+- **PR:** [#8](https://github.com/exampleco/widget-tracker/pull/8) — ⏳ open, awaiting filter-precedence decision
+- **Status:** [ ] in progress
+- **Blocker:** need to decide whether `--location X --tag Y` is AND or OR semantics. Discussion in PR thread; leaning AND.
+
+### B.3 Integration tests for `list` filters
+
+- **Spec:** `implementation.md` §B.3
+- **Branch:** `test/list-filters-integration`
+- **Depends on:** B.2 merging first
+- **Status:** [ ] not started
+
+---
+
+**Checkpoint B:** ⏳ blocked on B.2 filter semantics. Once decided, B.3 tests flow naturally.
+
+---
+
+## Section C — SQLite-backed store
+
+### C.1 Replace in-memory store with SQLite-backed implementation
+
+- **Spec:** `implementation.md` §C.1
+- **Branch:** `refactor/sqlite-store` (not yet created)
+- **Status:** [ ] not started
+- **Notes:** depends on Section B completing so we have a stable `list` behavior to port. Section A's migration runner is already SQLite-native; only the in-memory path in `internal/store/mem.go` needs retiring.
+
+### C.2 Document data file location + backup guidance in README
+
+- **Spec:** `implementation.md` §C.2
+- **Branch:** `docs/data-file-guidance`
+- **Status:** [ ] not started
+- **Notes:** depends on Open Question #4 (XDG vs. dotfile) being resolved.
+
+---
+
+**Checkpoint C:** end of Phase 1. Run acceptance tests before marking Phase 1 done.
+
+---
+
+## Acceptance testing
+
+Before marking Phase 1 ✅ complete:
+
+- [ ] Fresh-install: delete data dir, run `widget-tracker add` three times, `widget-tracker list` — confirm output matches insert order
+- [ ] Filter correctness: `--location X`, `--tag Y`, `--location X --tag Y` all return expected rows
+- [ ] Cross-platform: binary built on macOS runs on Linux without libc issues
+- [ ] Quickstart: a new user can follow the README from clone → first `list` in under 5 minutes (time it)
+- [ ] Upgrade path: older-schema DB file migrates cleanly without data loss
+
+Record results in `acceptance-test-results.md`.
+
+---
+
+## Phase exit
+
+- [ ] All items in A, B, C ticked
+- [ ] Acceptance tests pass
+- [ ] `plan.md` status line updated to "Phase 1 complete"
+- [ ] `CONTEXT.md` updated — current phase, open threads reset for Phase 2
+- [ ] Session entry appended to `SESSION-LOG.md`

--- a/examples/widget-tracker/plan.md
+++ b/examples/widget-tracker/plan.md
@@ -1,0 +1,108 @@
+# PLAN: widget-tracker
+**Repository:** `exampleco/widget-tracker`
+**Last updated:** 2026-04-12
+**Status:** Phase 1 in progress — list command + SQLite backend
+
+---
+
+## Overview
+
+`widget-tracker` is a small command-line tool for tracking inventory of physical widgets across multiple storage locations. It's built for a single operator who needs to add, list, and search items without spinning up a database server — SQLite is the storage backend, the binary is a single static Go executable.
+
+The project exists because spreadsheet-based tracking has repeatedly lost data when users overwrite each other's edits, and the team doesn't want to introduce a cloud service for something this small. A local CLI with an import/export path lets each operator run their own instance and swap data files when they need to collaborate.
+
+Public on GitHub under Apache 2.0.
+
+---
+
+## Goals
+
+- Add / list / search widgets by name, location, tag
+- SQLite storage — single file, portable, scriptable with `sqlite3` CLI
+- Cross-platform: macOS + Linux (Windows via WSL acceptable; not a primary target)
+- Import / export as CSV so the tool doesn't lock data in
+- Binary size ≤ 15 MB; startup ≤ 50 ms on commodity laptops
+
+## Non-Goals (for now)
+
+- No multi-user / server mode
+- No GUI
+- No realtime sync between instances — CSV round-trip is the sync mechanism
+- No web UI / TUI — plain stdout + stderr
+
+---
+
+## Platform / Target Environment
+
+| Platform | Architecture | Priority |
+|---|---|---|
+| macOS | arm64 + x86_64 | P0 |
+| Linux | x86_64 | P0 |
+| Linux | arm64 | P1 |
+| Windows (WSL) | x86_64 | P2 |
+
+---
+
+## Phases
+
+### Phase 0 — Setup ✅ complete
+
+**Goal:** Scaffold the repo, CI, and a "hello world" binary that proves the build + test pipeline works end-to-end.
+
+**Status:** Complete. See `SESSION-LOG.md` entries from 2026-03-15 and 2026-03-22.
+
+**Summary of landed work:**
+- Go module init, layout chosen (`cmd/widget-tracker/`, `internal/`)
+- GitHub Actions CI: lint (golangci-lint), test, cross-compile for macOS/Linux
+- License, README, AI disclosure
+- Hello-world binary confirmed CI artifact pipeline
+
+---
+
+### Phase 1 — Core CRUD + SQLite ⏳ in progress
+
+**Goal:** Ship the core commands (`add`, `list`) backed by SQLite, with tests covering the happy path and common error paths. End of Phase 1 = a usable tool for single-operator inventory work.
+
+**Tasks** — tracked in `phase-1-checklist.md`:
+- [x] A.1: Schema design + migration system
+- [x] A.2: `add` command with required fields
+- [x] A.3: Integration test for `add`
+- [x] B.1: `list` command — table output
+- [ ] B.2: `list` — `--location` and `--tag` filters
+- [ ] B.3: Integration tests for `list` filters
+- [ ] C.1: Replace in-memory store with SQLite-backed store
+- [ ] C.2: Document the data file location and backup expectations in README
+
+**Exit criteria:** `add` + `list` work against a real SQLite file; CI green on macOS and Linux; README has a quickstart that a new user can follow in under 5 minutes.
+
+---
+
+### Phase 2 — Search + import/export
+
+**Goal:** Make the tool useful for a second operator by adding search and CSV import/export.
+
+**Scoped but not detailed yet** — promote to `phase-2-checklist.md` when Phase 1 closes.
+
+- `search <term>` — substring match across name, location, tags
+- `export --format csv` — dump the entire DB to stdout
+- `import --format csv` — load from a CSV file, with conflict handling (skip / overwrite / merge)
+- Shell completion (zsh + bash) — stretch goal
+
+---
+
+## Open Questions
+
+| # | Question | Status | Notes |
+|---|---|---|---|
+| 1 | SQLite in-process vs. a lightweight embedded key-value store? | ✅ Resolved | Chose SQLite — see `research.md` §1 |
+| 2 | Should `add` allow duplicate widget names? | ⏳ Open | Leaning "unique by (name, location)" composite; final call at end of Phase 1 |
+| 3 | How do we handle concurrent access to the SQLite file across terminals? | ⏳ Open | SQLite has WAL mode; confirm it's enough or add advisory lock |
+| 4 | Data file location — `~/.local/share/widget-tracker/db.sqlite` (XDG) or `~/.widget-tracker/db.sqlite`? | ⏳ Open | Leaning XDG on Linux, `~/Library/Application Support/widget-tracker/` on macOS |
+
+---
+
+## Risks
+
+- **SQLite migration churn** — if the schema changes a lot during Phase 1, users who tried early builds may end up with orphaned data files. Mitigation: stamp a schema version early, implement migration runner before shipping the first release.
+- **CSV round-trip fidelity** — free-text fields with commas/quotes/newlines. Mitigation: use the standard library's `encoding/csv`, not a hand-rolled parser.
+- **Binary size creep** — Go binaries with SQLite (pure-Go driver) are already ~10 MB. Additional deps could push past 15 MB. Mitigation: review each new import; prefer stdlib.


### PR DESCRIPTION
## Summary

- Adds `examples/widget-tracker/` — a fictional Go CLI at a plausible mid-Phase-1 state, with four filled-in files: `CONTEXT.md`, `plan.md`, `phase-1-checklist.md`, `SESSION-LOG.md`. Demonstrates populated content, a multi-phase plan, a checklist with mixed ✅ / ⏳ / [ ] states, and an append-only session log with three chronological entries.
- Adds `examples/README.md` framing the folder as "read, don't copy" — reinforces the template-vs-example distinction.
- Wires `examples/` into the root `README.md` file tree and adds a pointer from `SETUP.md` step 3 so users can find the reference without going looking.

## Why

The kit's `templates/` directory shows the *shape* of a working folder — `{{PLACEHOLDER}}` skeletons. It doesn't show the *substance*: how verbose to be, what a populated Known Issues list looks like, what a mid-phase checklist actually reads like. A filled-in reference closes that gap.

Placed at **top-level `examples/`**, not `templates/examples/`, to prevent users from copying an example thinking it's a template. Physical separation reflects intended use.

Fixes P1.3 from the Phase 1 punch list.

## Test plan — ✅ PASS

Docs-only change, no runtime. Verification:

- [x] \`grep -R '{{.*}}' examples/\` — no unintended placeholder artifacts (only hit is a deliberate mention of \`{{PLACEHOLDER}}\` in \`examples/README.md:7\`, in backticks, as a term of art)
- [x] Cross-references within the example are internal — \`examples/widget-tracker/CONTEXT.md\` references sibling \`examples/widget-tracker/*.md\`, not the kit's own templates
- [x] \`examples/\` appears in the root \`README.md\` file tree in a natural reading position (between \`templates/\` and \`memory-templates/\`)
- [x] \`SETUP.md\` step 3 points readers at \`examples/widget-tracker/CONTEXT.md\` as the canonical "what does populated look like" reference
- [x] Checklist demonstrates realistic states: 4 items merged with linked PRs, 1 in-progress with a blocker, 3 pending