### PR TITLE
fix(docs): list {{REPO_URL}} in SETUP.md placeholder fill-in

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -50,6 +50,7 @@ Every template uses `{{PLACEHOLDER}}` markers. Search-and-replace in your editor
 
 - `{{PROJECT_NAME}}` — human-friendly name
 - `{{REPO_SLUG}}` — e.g. `owner/repo`
+- `{{REPO_URL}}` — full URL, e.g. `https://github.com/owner/repo`
 - `{{REPO_PATH}}` — absolute local path
 - `{{WORKING_FOLDER}}` — path to this folder
 - `{{ONE_PARAGRAPH_DESCRIPTION}}` — what the project is, in plain English


### PR DESCRIPTION
## Summary

One-line fix: `{{REPO_URL}}` was in `templates/CONTEXT.md:19` but missing from `SETUP.md` step 3's "minimum fill-in" list. Users bootstrapping a new project would see the placeholder in CONTEXT.md but not know to fill it from the SETUP walk-through.

## Why

Caught during Phase 1 acceptance testing (placeholder consistency check). Same class of drift as [#1](https://github.com/IamMrCupp/claude-project-kit/pull/1) — the exact thing Phase 1 exit criteria were meant to eliminate. Fixing now so Phase 1 can close cleanly with "no remaining placeholder drift" actually true.

## Test plan — ✅ PASS

- [x] `grep -n 'REPO_URL' SETUP.md templates/CONTEXT.md` now returns hits in both files (previously only in `templates/CONTEXT.md`)
- [x] Placeholder ordering in SETUP.md is logical — `{{REPO_URL}}` sits next to `{{REPO_SLUG}}`, both identifying the repo