### PR TITLE
docs: clarify kit works for existing repos, not just greenfield

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,14 @@ The working folder is project-specific knowledge ("what are we building, how far
     └── reference_*.md       ← external pointers (working folder, etc.)
 ```
 
-## How to use for a new project
+## How to use (new or existing project)
+
+Works the same for greenfield repos and ones you're adopting it on mid-stream — the kit never modifies the target repo, it just creates an external working folder and seeds per-project auto-memory.
 
 1. Read [SETUP.md](SETUP.md) — it walks you through the full bootstrap in ~10 minutes.
 2. Pick a private working folder location (e.g. `~/Documents/Claude/Projects/<Project Name>/`).
 3. Copy templates, fill in placeholders (marked `{{LIKE_THIS}}`).
-4. Seed auto-memory with relevant starters from `memory-templates/` — edit to match the new project.
+4. Seed auto-memory with relevant starters from `memory-templates/` — edit to match the project.
 5. Open a Claude session and use a prompt from [PROMPTS.md](PROMPTS.md) to load project context before you start working.
 
 ## When to update this framework

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,6 +1,6 @@
-# Setup — starting a new project with this framework
+# Setup — adopting this framework on a project
 
-Target: you have a new repo (or idea) and want Claude sessions productive from day one.
+Target: you have a repo (new, or existing and already in flight) and want Claude sessions productive from day one. The steps are identical either way — for an existing repo, `CONTEXT.md` should describe the *current* architecture, conventions, and in-flight work rather than a greenfield plan.
 
 ---
 


### PR DESCRIPTION
## Summary
- Reframe README "How to use for a new project" → "How to use (new or existing project)" and add a one-line note that the kit never modifies the target repo.
- Broaden SETUP.md target line to cover existing/in-flight repos and note that for existing repos, `CONTEXT.md` should describe current state rather than a greenfield plan.

Motivation: someone asked how to use the kit on an existing Terraform repo. The bootstrap already works identically for new vs. existing repos — only the framing in the docs implied greenfield. Two surgical edits close the gap without adding domain-specific content.

## Test plan
- [x] Read [README.md](README.md) — section title and intro sentence make the new/existing scope clear.
- [x] Read [SETUP.md](SETUP.md) — title and Target line accurately describe both cases.
- [x] Confirm no functional changes to `bootstrap.sh`, templates, or memory starters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)