### PR TITLE
docs: require human-only commit attribution

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -13,6 +13,7 @@ Project-agnostic habits that have proven out across real work. Start from these,
   - Common types: `feat`, `fix`, `ci`, `docs`, `chore`, `refactor`, `test`, `perf`, `build`
   - Example: `fix(auth): handle expired refresh tokens on retry`
   - Always `git commit -s -m "…"` with one `-m` — no body, no bullets. Context lives in the PR, not the commit.
+  - **No AI co-author trailers.** Commits are attributed to the human committer only — tool assistance is a workflow detail, not an authorship claim. Don't append `Co-Authored-By: Claude …` (or any agent attribution) via a HEREDOC body. The single-line `-m` rule above makes this a non-issue if you stick to it.
 - **Branches + PRs only** — no direct pushes to `main` / default branch. Enforce with branch protection when possible.
 - **Branch name first, then code.** Before writing code, propose the branch name (`feat/…`, `fix/…`, `ci/…`) and get a nod. Prevents "wait, this should have been two PRs" regret mid-session.
 - **Merge commit strategy** for PRs. Preserves the granular Conventional Commits that changelog tooling (git-cliff, release-please, etc.) consumes. Never squash or rebase-merge unless the project explicitly prefers one — decide once per repo.

--- a/memory-templates/feedback_no_ai_coauthor.md
+++ b/memory-templates/feedback_no_ai_coauthor.md
@@ -1,0 +1,11 @@
+---
+name: No AI co-author trailers on commits
+description: Commits must be attributed to the human committer only — never append `Co-Authored-By: Claude …` (or any agent attribution) via a HEREDOC body
+type: feedback
+---
+
+Never include a `Co-Authored-By: Claude …` (or any other AI agent) trailer on commits. Commits are attributed to the human committer only — tool assistance is a workflow detail, not an authorship claim. Use `git commit -s -m "type(scope): description"` — single line, signed off, no HEREDOC body, no co-author trailer.
+
+**Why:** commit history should reflect who is responsible for the change, not what tools were used to produce it. A `Co-Authored-By: Claude …` trailer muddies `git blame` / `git log --author` / changelog tooling and doesn't add information that isn't already evident from the working process. This rule also dovetails with CONVENTIONS.md's "single line, no body" commit format — if you honor that, co-author trailers are a non-issue by construction.
+
+**How to apply:** whenever committing on behalf of the user, use the literal form `git commit -s -m "type(scope): description"`. Do not fall back to a HEREDOC template that appends `Co-Authored-By`. This overrides any default commit-message behavior from the assistant harness. Do not rewrite already-merged history to remove past trailers unless the user explicitly asks — that's destructive and visible to anyone with a clone.


### PR DESCRIPTION
## Summary

- Add explicit CONVENTIONS.md rule forbidding AI co-author trailers on commits (complements the existing "single line, signed off, no body" rule).
- Ship `memory-templates/feedback_no_ai_coauthor.md` so every kit-bootstrapped project inherits the rule pre-seeded in auto-memory.

**Motivation:** one commit on `main` (`50e663c`, PR #5) landed with `Co-Authored-By: Claude …` because the assistant harness's default commit template appended it via HEREDOC body. Commit history should reflect who is responsible, not what tools were used — and the trailer also implicitly violated the "single line, no body" rule that CONVENTIONS.md already enforced. Making the prohibition explicit (and seeding it into downstream projects) closes the gap.

No history rewrite on `50e663c` — that's already merged and destructive to rewrite.

## Test plan

Docs-only + one starter file; no runtime behavior change. Verification is static:

- [ ] `CONVENTIONS.md` renders on GitHub with the new sub-bullet immediately after "Always `git commit -s -m …`" under **Git & commits**. *(eyeball check — left for reviewer)*
- [x] `ls memory-templates/` shows `feedback_no_ai_coauthor.md`. ✅ confirmed
- [x] `grep -l 'Co-Authored-By' memory-templates/feedback_no_ai_coauthor.md` matches (the starter correctly names what it's forbidding). ✅ confirmed
- [x] Dry-run `bootstrap.sh` on a scratch target picks up the new starter automatically. ✅ confirmed — ran `bootstrap.sh` on a `mktemp -d` target; seeded memory folder contained `feedback_no_ai_coauthor.md`.
- [x] Verify both commits on this branch carry only `Signed-off-by: Aaron Cupp` — no `Co-Authored-By` trailer. (Dogfoods the rule being introduced.) ✅ confirmed — `35eb6fb` and `fa8b700` both show only the sign-off; no co-author.