### PR TITLE
feat: auto-substitute memory-template placeholders on bootstrap

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -69,12 +69,15 @@ Prefer to fill everything by hand? See [Manual alternative](#manual-alternative)
 
 ## 4. Tune your auto-memory
 
-`bootstrap.sh` already dropped the starter memory files into your project's memory folder. Now edit them to match your actual rules and tooling:
+`bootstrap.sh` already dropped the starter memory files into your project's memory folder and auto-filled the common placeholders (`{{WORKING_FOLDER}}`, `{{REPO_PATH}}`, `{{PROJECT_NAME}}`, and `{{REPO_SLUG}}` if your repo has a `git remote origin`). What's left is optional personalization:
 
-- `reference_ai_working_folder.md` — fill in `{{WORKING_FOLDER}}` and `{{PROJECT_NAME}}` so Claude knows where to look
 - `user_role.md` — your role and background *as it relates to this project* (Claude uses this to calibrate explanations)
+- `project_current.md` — if `bootstrap.sh` couldn't derive `{{REPO_SLUG}}` (e.g. no git remote yet), fill it manually
+- `reference_ai_working_folder.md` — review the `{{public/private}}` marker and decide visibility
 - Prune feedback/project files that don't apply; tune the ones that do
 - Keep `MEMORY.md` in sync with whatever files you end up with
+
+Pass `--project-name "<name>"` to `bootstrap.sh` if the working folder basename doesn't match the project name you want in memory.
 
 If you ran bootstrap with `--skip-memory`, see the [Manual alternative](#manual-alternative) for how to seed it by hand.
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -30,6 +30,10 @@ Arguments:
 Options:
   --skip-memory      Skip copying memory-templates/ into the auto-memory
                      folder. Only the working folder will be seeded.
+  --project-name NAME
+                     Override the auto-derived project name used to fill
+                     {{PROJECT_NAME}} placeholders in seeded memory files.
+                     Defaults to the basename of <working-folder>.
   --force            Proceed even if the working folder already exists
                      and is non-empty. Does NOT override the auto-memory
                      safety check — existing memory files are never
@@ -41,6 +45,8 @@ Example:
   ~/Code/claude-project-kit/bootstrap.sh ~/Documents/Claude/Projects/my-new-project
 
 After running, edit the copied files (placeholders marked {{LIKE_THIS}}).
+Most common memory placeholders are auto-filled; any that couldn't be
+derived (e.g. {{REPO_SLUG}} when no git remote is set) stay as-is.
 See SETUP.md in the kit repo for the full walk-through.
 EOF
 }
@@ -48,11 +54,21 @@ EOF
 SKIP_MEMORY=0
 FORCE=0
 WORKING_FOLDER=""
+PROJECT_NAME=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --skip-memory) SKIP_MEMORY=1; shift ;;
     --force) FORCE=1; shift ;;
+    --project-name)
+      if [ $# -lt 2 ]; then
+        echo "error: --project-name requires a value" >&2
+        usage >&2
+        exit 2
+      fi
+      PROJECT_NAME="$2"
+      shift 2
+      ;;
     -h|--help) usage; exit 0 ;;
     --*) echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
     *)
@@ -93,10 +109,24 @@ REPO_ROOT="$(pwd)"
 SANITIZED="$(echo "$REPO_ROOT" | sed 's|/|-|g')"
 MEMORY_DIR="$HOME/.claude/projects/${SANITIZED}/memory"
 
+if [ -z "$PROJECT_NAME" ]; then
+  PROJECT_NAME="$(basename "$WORKING_FOLDER")"
+fi
+
+REPO_SLUG=""
+if REMOTE_URL="$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null)"; then
+  REPO_SLUG="$(printf '%s\n' "$REMOTE_URL" \
+    | sed -E 's|^https?://[^/]+/||; s|^git@[^:]+:||; s|\.git$||')"
+fi
+
 echo "Working folder: $WORKING_FOLDER"
 echo "Repo root:      $REPO_ROOT"
+echo "Project name:   $PROJECT_NAME"
 if [ "$SKIP_MEMORY" -eq 0 ]; then
   echo "Memory folder:  $MEMORY_DIR"
+  if [ -n "$REPO_SLUG" ]; then
+    echo "Repo slug:      $REPO_SLUG (from git remote origin)"
+  fi
 fi
 echo
 
@@ -130,6 +160,33 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
   mkdir -p "$MEMORY_DIR"
   cp "$KIT_ROOT/memory-templates/"*.md "$MEMORY_DIR/"
   echo "  ✓ Copied memory files to $MEMORY_DIR"
+
+  FILLED_FILES=0
+  for f in "$MEMORY_DIR"/*.md; do
+    tmp="$(mktemp)"
+    if [ -n "$REPO_SLUG" ]; then
+      sed -e "s|{{WORKING_FOLDER}}|$WORKING_FOLDER|g" \
+          -e "s|{{REPO_PATH}}|$REPO_ROOT|g" \
+          -e "s|{{PROJECT_NAME}}|$PROJECT_NAME|g" \
+          -e "s|{{REPO_SLUG}}|$REPO_SLUG|g" \
+          "$f" > "$tmp"
+    else
+      sed -e "s|{{WORKING_FOLDER}}|$WORKING_FOLDER|g" \
+          -e "s|{{REPO_PATH}}|$REPO_ROOT|g" \
+          -e "s|{{PROJECT_NAME}}|$PROJECT_NAME|g" \
+          "$f" > "$tmp"
+    fi
+    if ! cmp -s "$f" "$tmp"; then
+      mv "$tmp" "$f"
+      FILLED_FILES=$((FILLED_FILES + 1))
+    else
+      rm -f "$tmp"
+    fi
+  done
+  echo "  ✓ Filled placeholders in $FILLED_FILES memory files"
+  if [ -z "$REPO_SLUG" ]; then
+    echo "    (no git remote 'origin' found — {{REPO_SLUG}} left for manual fill)"
+  fi
 fi
 
 echo
@@ -145,8 +202,13 @@ echo "     Claude will deep-read the repo, fill the working-folder templates,"
 echo "     flag inferences with [CLAUDE-INFERRED] / [HUMAN-CONFIRM] markers,"
 echo "     and stop for your review before doing anything else."
 if [ "$SKIP_MEMORY" -eq 0 ]; then
-  echo "  3. After review, tune memory at $MEMORY_DIR —"
-  echo "     especially reference_ai_working_folder.md."
+  if [ -n "$REPO_SLUG" ]; then
+    echo "  3. (Optional) Review memory at $MEMORY_DIR —"
+    echo "     common placeholders pre-filled; tune feedback files to taste."
+  else
+    echo "  3. Review memory at $MEMORY_DIR —"
+    echo "     {{REPO_SLUG}} needs manual fill in project_current.md; others done."
+  fi
 else
   echo "  3. Memory was skipped (--skip-memory). See SETUP.md §Manual alternative"
   echo "     if you want to seed it by hand later."


### PR DESCRIPTION
## Summary

Companion to the seed-prompt work ([#7](https://github.com/IamMrCupp/claude-project-kit/pull/7)) — closes the last manual-fill gap in the onboarding flow. After this PR, the common case is **zero manual placeholder fill-in** end-to-end.

- `bootstrap.sh` — after copying memory templates, substitute four placeholders that it can reliably derive:
  - `{{WORKING_FOLDER}}` → working folder argument
  - `{{REPO_PATH}}` → repo root (`$(pwd)`)
  - `{{PROJECT_NAME}}` → `basename "$WORKING_FOLDER"` (overridable via `--project-name NAME`)
  - `{{REPO_SLUG}}` → parsed from `git remote get-url origin`; if no remote is set, gracefully leaves the placeholder for manual fill
- New `--project-name NAME` flag for when the working-folder basename doesn't match the desired project name.
- Usage/help text updated; new Project Name / Repo Slug lines in the bootstrap header; next-steps message adapts based on whether `{{REPO_SLUG}}` was filled.
- `SETUP.md` §4 updated to reflect that auto-fill handles the common placeholders; `user_role.md` and optional `{{public/private}}` visibility marker remain user-only concerns.

**Intentionally not touched:**
- Working-folder `CONTEXT.md` placeholders — those are the seed-prompt's job (single-responsibility: bootstrap seeds structure + auto-memory; seed-prompt handles contextual fields).
- `{{public/private}}` in `reference_ai_working_folder.md` — visibility is a user choice, not derivable.
- `user_role.md` — personal profile, user-only.

**Portability:** sed uses `|` as delimiter (paths contain `/`, not `|`); no `-i` flag (BSD/GNU divergence); temp-file + `cmp -s` + `mv` pattern for in-place update without platform branching.

## Test plan

All four scenarios ran locally pre-merge; results captured below.

- [x] **Scenario 1 — scratch repo WITH git remote.** `git remote add origin https://github.com/acme/widget-tracker.git` → bootstrap reports `Repo slug: acme/widget-tracker (from git remote origin)`. Only `{{public/private}}` remains in memory files; all four auto-fillable placeholders are filled. ✅
- [x] **Scenario 2 — scratch repo WITHOUT git remote.** No origin set → `{{REPO_SLUG}}` gracefully preserved in `project_current.md:8`; `{{WORKING_FOLDER}}`, `{{REPO_PATH}}`, `{{PROJECT_NAME}}` all filled. Next-steps message correctly tells the user `{{REPO_SLUG}} needs manual fill in project_current.md`. ✅
- [x] **Scenario 3 — `--project-name "Custom Project Name"` override.** Custom name appears in both `name: AI working folder for Custom Project Name` and the `How to apply` line of `reference_ai_working_folder.md`. ✅
- [x] **Scenario 4 — `--skip-memory` path unchanged.** No substitution runs (no memory copy at all); next-steps message still points at `SETUP.md §Manual alternative`. ✅
- [x] Both commits on this branch carry only `Signed-off-by: Aaron Cupp` — no `Co-Authored-By` trailer (dogfoods [#6](https://github.com/IamMrCupp/claude-project-kit/pull/6)'s rule). ✅

Manual acceptance (reviewer):
- [ ] `bootstrap.sh --help` output renders the new `--project-name` option alongside existing flags.
- [ ] `SETUP.md` §4 renders on GitHub with the updated "what's left after auto-fill" framing.
- [ ] **Live test (post-merge, Phase 2 acceptance):** run the full onboarding flow end-to-end on a real target repo — bootstrap → paste seed-prompt invocation → confirm Claude sees no residual `{{PLACEHOLDER}}` markers in memory during its seed-prompt run (other than intentional `{{public/private}}`).