### PR TITLE
docs: add CHANGELOG and Upgrading-an-existing-project guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to `claude-project-kit`. Format loosely follows [Keep a Changelog](https://keepachangelog.com/). No formal version tags yet — entries use merge-commit SHAs and dates as reference points.
+
+See [Upgrading an existing project](SETUP.md#upgrading-an-existing-project) for the general migration pattern. Each entry below has a **For existing adopters** section with specifics for that release.
+
+---
+
+## 2026-04-22 — Phase 2: zero manual-fill onboarding
+
+### Added
+- `templates/SEED-PROMPT.md` — one-shot project bootstrap instruction prompt. Claude deep-reads the target repo, classifies `CONTEXT.md` fields into derivable / `[CLAUDE-INFERRED]` / `[HUMAN-CONFIRM]` buckets, drafts `research.md` from code, summarizes, asks ≤5 targeted questions, and stops for user review. ([#7](https://github.com/IamMrCupp/claude-project-kit/pull/7))
+- `bootstrap.sh` — auto-substitutes four memory-template placeholders post-copy: `{{WORKING_FOLDER}}`, `{{REPO_PATH}}`, `{{PROJECT_NAME}}` (default = basename of working folder), `{{REPO_SLUG}}` (opportunistic from `git remote get-url origin`, graceful fallback if no remote). ([#8](https://github.com/IamMrCupp/claude-project-kit/pull/8))
+- `bootstrap.sh` — new `--project-name NAME` flag to override the auto-derived project name. ([#8](https://github.com/IamMrCupp/claude-project-kit/pull/8))
+
+### Changed
+- `bootstrap.sh` next-steps message leads with the seed-prompt invocation line (working-folder path pre-substituted). ([#7](https://github.com/IamMrCupp/claude-project-kit/pull/7))
+- `README.md` + `SETUP.md` — onboarding flow rewritten around the seed-prompt; manual placeholder fill-in demoted to the `Manual alternative` appendix. SETUP.md §4 reframed around memory auto-fill. ([#7](https://github.com/IamMrCupp/claude-project-kit/pull/7), [#8](https://github.com/IamMrCupp/claude-project-kit/pull/8))
+
+### For existing adopters
+- **To use the seed-prompt flow:** copy `templates/SEED-PROMPT.md` into your existing working folder:
+  ```bash
+  cp <kit-dir>/templates/SEED-PROMPT.md <your-working-folder>/
+  ```
+- **Stale placeholders won't auto-upgrade.** If your `reference_ai_working_folder.md` in auto-memory still has `{{PROJECT_NAME}}` / `{{WORKING_FOLDER}}` / `{{REPO_PATH}}` / `{{REPO_SLUG}}` placeholders from a pre-#8 bootstrap, fill them manually once — future bootstraps on *new* projects will auto-fill them.
+- The `--project-name` flag is opt-in and only affects new bootstraps; existing projects' behavior is unchanged.
+
+---
+
+## 2026-04-22 — CONVENTIONS: human-only commit attribution
+
+### Added
+- `CONVENTIONS.md` — explicit rule forbidding AI co-author trailers on commits (complements the existing "single line, signed off, no body" rule). ([#6](https://github.com/IamMrCupp/claude-project-kit/pull/6))
+- `memory-templates/feedback_no_ai_coauthor.md` — starter auto-memory file so new projects inherit the rule pre-seeded. ([#6](https://github.com/IamMrCupp/claude-project-kit/pull/6))
+
+### For existing adopters
+- Going forward, commit with `git commit -s -m "type(scope): description"` — single line, no HEREDOC body, no `Co-Authored-By` trailer.
+- Optionally copy `memory-templates/feedback_no_ai_coauthor.md` into your project's auto-memory to bind the rule at the memory layer.
+- **Do not rewrite already-merged history** to remove past trailers — destructive and visible to anyone with a clone.
+
+---
+
+## 2026-04-22 — Phase 1: polish + dogfood fixes
+
+### Added
+- `bootstrap.sh` — one-command onboarding helper. Creates the working folder, seeds auto-memory, prints next-steps. Flags: `--skip-memory`, `--force`, `-h`/`--help`. ([#2](https://github.com/IamMrCupp/claude-project-kit/pull/2))
+- `examples/widget-tracker/` — filled-in reference project (fictional Go CLI, mid-Phase-1 snapshot) with `CONTEXT.md`, `plan.md`, `phase-1-checklist.md`, `SESSION-LOG.md`. ([#3](https://github.com/IamMrCupp/claude-project-kit/pull/3))
+- `examples/README.md` — framing doc explaining the "read, don't copy" distinction between `templates/` and `examples/`. ([#3](https://github.com/IamMrCupp/claude-project-kit/pull/3))
+
+### Fixed
+- `README.md` memory-templates file list drift — replaced hard-coded `*_example.md` names with pattern-based listing that stays accurate as the starter set grows. ([#1](https://github.com/IamMrCupp/claude-project-kit/pull/1))
+- `{{PLATFORM_TARGETS}}` placeholder added to `templates/CONTEXT.md` — was referenced in `SETUP.md` but didn't exist in the template. ([#1](https://github.com/IamMrCupp/claude-project-kit/pull/1))
+- `{{REPO_URL}}` listed in `SETUP.md` step 3 fill-in — was in the template but missing from the fill-in instructions. ([#4](https://github.com/IamMrCupp/claude-project-kit/pull/4))
+- `SETUP.md` + `README.md` — clarified that the kit works for existing repos, not just greenfield. ([#5](https://github.com/IamMrCupp/claude-project-kit/pull/5))
+
+### For existing adopters
+- Copy `bootstrap.sh` from the new kit checkout if you want the scripted flow — your existing manual-setup still works.
+- New memory-templates files — copy any that apply into your project's auto-memory.
+- Re-read `SETUP.md`: numbering and content shifted (manual alternative is now an appendix; `bootstrap.sh` is the primary flow).
+
+---
+
+## Initial — 2026-04-21 (`13fd99d`)
+
+First commit. Seeded the kit with:
+
+- `README.md`, `SETUP.md`, `CONVENTIONS.md`, `PROMPTS.md`, `LICENSE`
+- `templates/` — `CONTEXT.md`, `SESSION-LOG.md`, `plan.md`, `implementation.md`, `phase-N-checklist.md`, `acceptance-test-results.md`, `research.md`
+- `memory-templates/` — `MEMORY.md`, `user_role.md`, feedback starters (commit format, docs in sync, merge strategy, PR test plans, PR check-off, push branches, watch CI in background), `project_current.md`, `reference_ai_working_folder.md`

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The working folder is project-specific knowledge ("what are we building, how far
 ├── SETUP.md                 ← step-by-step: starting a new project
 ├── CONVENTIONS.md           ← generic working rules (commits, PRs, etc.)
 ├── PROMPTS.md               ← ready-to-paste session-opening prompts
+├── CHANGELOG.md             ← what's landed; upgrade notes for existing adopters
 ├── LICENSE
 ├── bootstrap.sh             ← one-command setup (see SETUP.md step 2)
 ├── templates/               ← copied into a new working folder

--- a/SETUP.md
+++ b/SETUP.md
@@ -159,6 +159,27 @@ For a fully filled-in reference, see [`examples/widget-tracker/CONTEXT.md`](exam
 
 ---
 
+## Upgrading an existing project
+
+`bootstrap.sh` is deliberately **write-once** — it won't touch a working folder or auto-memory dir that's already populated. When the kit evolves, existing adopters upgrade manually:
+
+1. Check [`CHANGELOG.md`](CHANGELOG.md) to see what's landed since your bootstrap SHA (or since the last time you upgraded). Each entry has a **For existing adopters** section with specifics.
+2. **New files in `templates/`** — copy into your working folder manually:
+   ```bash
+   cp <kit-dir>/templates/<NEW_FILE>.md <working-folder>/
+   ```
+3. **New files in `memory-templates/`** — copy into your auto-memory dir:
+   ```bash
+   cp <kit-dir>/memory-templates/<NEW_FILE>.md ~/.claude/projects/<sanitized-path>/memory/
+   ```
+4. **Changed prose in kit-level files** (e.g. `CONVENTIONS.md`, `SETUP.md`, `README.md`) — re-read them. Your local copies of working-folder templates and memory files are yours; they don't auto-upgrade.
+5. **New `bootstrap.sh` flags or behavior** — apply only to *new* projects you bootstrap going forward. Already-bootstrapped projects keep their current state.
+6. **Don't re-run `bootstrap.sh`** on a populated working folder — it errors by design. If you really need to re-seed, clear the auto-memory dir manually and pass `--force` to the working folder, but you'll lose local customizations.
+
+If a future change is *not* backwards-compatible (rare for a docs-only kit — only likely if a template structure fundamentally changes), the CHANGELOG entry will call that out explicitly.
+
+---
+
 ## Troubleshooting
 
 **Claude doesn't read the working folder automatically.** It has to be told each session. Either say it explicitly ("Read CONTEXT.md and SESSION-LOG.md…") or rely on the `reference_ai_working_folder.md` memory entry to remind it.


### PR DESCRIPTION
## Summary

Pulled forward from the parked Phase 3 list — a migration guide so existing kit adopters know how to pick up new features when the kit evolves.

- **New `CHANGELOG.md`** at repo root, format loosely follows [Keep a Changelog](https://keepachangelog.com/). No formal SemVer yet; entries use merge-commit SHAs and dates as reference points. Seeded with four entries covering all landed work: Initial commit (2026-04-21), Phase 1 polish + dogfood fixes, CONVENTIONS human-only commits (PR #6), Phase 2 seed-prompt + memory auto-fill (PRs #7 + #8). Each entry includes a **For existing adopters** section with specific copy/fill actions.
- **New `SETUP.md` section "Upgrading an existing project"** — explains the write-once design of `bootstrap.sh`, the general migration pattern (check CHANGELOG, manually copy new `templates/` and `memory-templates/` files, re-read changed prose, don't re-run bootstrap on populated state), and points at CHANGELOG for release-specific specifics.
- `README.md` file tree now lists `CHANGELOG.md` for discoverability.

**Motivation:** the kit has accumulated real delta since initial commit (`13fd99d` → now includes `bootstrap.sh`, `examples/`, `SEED-PROMPT.md`, memory auto-fill, `--project-name` flag, no-AI-coauthor rule, and SETUP.md restructuring). Anyone who bootstrapped a project on 2026-04-21 and wants today's features faces a real migration question. This PR answers it without requiring formal versioning.

**Intentionally lightweight:** no SemVer tags, no release automation, no `gh release` artifacts. If any of those prove valuable later, they're easy to layer on top of the CHANGELOG. For now the doc is the source of truth.

**Backwards-compat note:** none of the changes so far have been breaking — all existing-adopter actions in the CHANGELOG are additive copies and optional re-reads. The doc does call out what *would* trigger a breaking-change callout in the future (fundamental template structure changes).

## Test plan

Static checks (done locally):

- [x] `CHANGELOG.md` renders and lists all four landed PR groups with PR links.
- [x] `SETUP.md` "Upgrading an existing project" section inserted before Troubleshooting; all internal links resolve (`CHANGELOG.md` link, code-block paths).
- [x] `README.md` file tree includes `CHANGELOG.md` entry.
- [x] Both commits carry only `Signed-off-by: Aaron Cupp` (no `Co-Authored-By` — dogfoods PR #6). ✅

Manual acceptance (reviewer):
- [ ] CHANGELOG entries render cleanly on GitHub — headings, "For existing adopters" sections, PR links.
- [ ] SETUP "Upgrading" section reads as a coherent migration pattern — the 6 steps cover the realistic upgrade scenarios without over-prescribing.
- [ ] No style drift from existing kit prose (terse, pragmatic, concrete — matches the audience profile).