### PR TITLE
ci: add markdown link-check workflow (lychee, offline mode)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,28 @@
+name: markdown link check
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '.github/workflows/link-check.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.md'
+      - '.github/workflows/link-check.yml'
+
+jobs:
+  lychee:
+    name: Check internal markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # --offline: skip external HTTP checks (avoids flakiness); only
+          # validate relative-path links to files in the repo.
+          args: --no-progress --verbose --offline './**/*.md'
+          fail: true


### PR DESCRIPTION
## Summary

Introduces CI to the repo for the first time — Open Question #3 from Phase 2 planning (Test 3's manual link-check was non-trivial; CI automation pays for itself).

- **New `.github/workflows/link-check.yml`** — runs [lychee](https://github.com/lycheeverse/lychee-action) on every PR that touches any `*.md` file (and on pushes to `main`). Uses `--offline` mode: only validates relative-path links to files in the repo; skips external HTTP checks entirely to avoid network flakiness.
- Triggers are `paths`-filtered so the workflow only fires when a change actually could affect markdown links.
- Pinned to `lycheeverse/lychee-action@v2` (tracks latest v2, auto-gets security/bug fixes within v2, doesn't auto-adopt breaking changes).

**What this catches:** any future PR that introduces a broken internal link (e.g. a file rename that doesn't update references, a typo in a path, a missing file that's referenced from docs). This was Phase 1 Test 3's pain point — manual detection was tedious, a custom script had its own bugs, CI closes the loop.

**What this intentionally does NOT do:**
- **No external URL checking.** HTTPS links (GitHub PRs, external docs, https://keepachangelog.com, etc.) are skipped via `--offline`. External-link checks are flaky (rate limiting, transient 503s, redirect chains) and would cause false-positive CI failures. Low-value for the cost.
- **No markdown linting.** Style/formatting rules (headings, list markers, code-fence consistency) are cosmetic and would need a tuning config pass against existing prose to avoid noise. Higher-value link-check lands first; lint stays parked and can be added as a follow-up if value emerges.
- **No branch protection configuration.** The workflow runs and reports, but doesn't yet gate merges. If you want failures to block merges, configure branch protection on `main` separately in the GitHub UI.

**Knock-on cleanup after merge:** `CONTEXT.md` working-folder note says "CI platform: none currently" — should update to reflect GitHub Actions is now in use. Minor; out of scope for this PR.

## Test plan

- [x] Workflow syntax is valid YAML (`.github/workflows/link-check.yml` parses cleanly; no `yq`/`actionlint` errors locally).
- [x] Single commit carries only `Signed-off-by: Aaron Cupp` — no `Co-Authored-By` trailer (dogfoods [#6](https://github.com/IamMrCupp/claude-project-kit/pull/6)). ✅
- [x] **Post-push verification:** workflow ran on this PR and passed in 9s. ✅ [Run 24818063260](https://github.com/IamMrCupp/claude-project-kit/actions/runs/24818063260). Lychee validated all relative-path links in current markdown files against the introduced workflow — zero broken internal links (consistent with Phase 1 Test 3's clean state).
- [ ] **Post-merge interaction check with [#9](https://github.com/IamMrCupp/claude-project-kit/pull/9):** whichever of #9 and this PR merges second will get its CI run against the combined state. Both should pass — #9's new `CHANGELOG.md` exists as a file, and SETUP.md's `[CHANGELOG.md](CHANGELOG.md)` reference resolves cleanly in the merged state. If #9 merges before #10, manually re-trigger #9's CI once #10 is in main by pushing any small update to #9 (or wait for a subsequent PR to exercise the workflow).