### PR TITLE
feat(seed-prompt): expand ecosystem coverage (multi-lang + GitOps + observability)

### DIFF
--- a/templates/SEED-PROMPT.md
+++ b/templates/SEED-PROMPT.md
@@ -51,6 +51,12 @@ Read in order:
      - Flux (GitOps): `flux-system/` directory (typically under `clusters/<env>/`); CRDs identified by `kind:` — `GitRepository`, `Kustomization`, `HelmRelease`, `HelmRepository`; `gotk-components.yaml` / `gotk-sync.yaml`; `.sops.yaml` if SOPS is in use
      - ArgoCD (GitOps): CRDs identified by `apiVersion: argoproj.io/v1alpha1` + `kind: Application` / `ApplicationSet` / `AppProject`; conventional `argocd/` directory; `app-of-apps` pattern
      - Raw Kubernetes manifests: `*.yaml` files with `apiVersion: v1|apps/v1|networking.k8s.io/v1|batch/v1|...` and `kind: Deployment|Service|Ingress|ConfigMap|Secret|StatefulSet|DaemonSet|Job|CronJob|...` — detect by content, not path
+   - **Observability / monitoring stack:**
+     - Prometheus: `prometheus.yml` / `prometheus.yaml`, `alerts/*.yml` + `rules/*.yml` (PromQL recording / alerting rules), `alertmanager.yml` / `alertmanager.yaml`, `*.rules` files, `targets/*.json` (file SD)
+     - Grafana: `grafana.ini` / `custom.ini`, `provisioning/{datasources,dashboards,alerting,notifiers,plugins}/*.yaml`, `dashboards/*.json` (treat as large / often generated — skim for inventory, don't full-read each)
+     - Loki: `loki.yaml` / `loki-config.yaml`, `promtail.yaml` / `promtail-config.yaml` (log shipper), `loki-*-rules.yaml` (LogQL alerts)
+     - Alloy / Grafana Agent: `config.alloy`, `*.alloy`; legacy `agent.yaml` / `grafana-agent.yaml` / `grafana-agent.river`
+     - Adjacent observability tools: Tempo (`tempo.yaml`), Mimir (`mimir.yaml`), Pyroscope (`pyroscope.yaml`), OpenTelemetry Collector (`otel-*config.yaml`)
    - **Runtime / container / version pinning:** `Dockerfile`, `docker-compose.yml` / `compose.yml`, `.tool-versions` (asdf), `.nvmrc`, `.python-version`, `.ruby-version`, `.editorconfig`.
    - **Framework signals** (read only at top-of-tree; don't deep-scan): `app.py` / `wsgi.py` / `asgi.py` / `manage.py` / `settings.py` (Python web); `config/application.rb` / `bin/rails` (Rails); `next.config.*` / `vite.config.*` / `nuxt.config.*` / `webpack.config.*` / `rollup.config.*` (JS/TS frameworks).
    - If you see a manifest or config file you don't recognize, note it as a `[HUMAN-CONFIRM]` question rather than guessing.

--- a/templates/SEED-PROMPT.md
+++ b/templates/SEED-PROMPT.md
@@ -46,6 +46,11 @@ Read in order:
      - Terraform / Terragrunt: `*.tf` (especially `providers.tf`, `versions.tf`, `main.tf`, `variables.tf`, `outputs.tf`), `.terraform.lock.hcl`, `*.tfvars.example`, `terragrunt.hcl`
      - Puppet: `metadata.json`, `Puppetfile`, `manifests/init.pp`, `environment.conf`, `hiera.yaml`
      - Ansible: `ansible.cfg`, `inventory*`, `playbook*.yml`, `roles/*/tasks/main.yml`, `roles/*/meta/main.yml`, `requirements.yml`, `group_vars/`, `host_vars/`
+     - Helm: `Chart.yaml`, `values.yaml` + `values-*.yaml` (treat env-specific values files as potentially secret-containing), `Chart.lock`, `templates/*.yaml`, `charts/` (subchart dir), `.helmignore`
+     - Kustomize: `kustomization.yaml` / `kustomization.yml` / `Kustomization`; conventional `base/` + `overlays/` directory layout; `patches/` subdirs
+     - Flux (GitOps): `flux-system/` directory (typically under `clusters/<env>/`); CRDs identified by `kind:` — `GitRepository`, `Kustomization`, `HelmRelease`, `HelmRepository`; `gotk-components.yaml` / `gotk-sync.yaml`; `.sops.yaml` if SOPS is in use
+     - ArgoCD (GitOps): CRDs identified by `apiVersion: argoproj.io/v1alpha1` + `kind: Application` / `ApplicationSet` / `AppProject`; conventional `argocd/` directory; `app-of-apps` pattern
+     - Raw Kubernetes manifests: `*.yaml` files with `apiVersion: v1|apps/v1|networking.k8s.io/v1|batch/v1|...` and `kind: Deployment|Service|Ingress|ConfigMap|Secret|StatefulSet|DaemonSet|Job|CronJob|...` — detect by content, not path
    - **Runtime / container / version pinning:** `Dockerfile`, `docker-compose.yml` / `compose.yml`, `.tool-versions` (asdf), `.nvmrc`, `.python-version`, `.ruby-version`, `.editorconfig`.
    - **Framework signals** (read only at top-of-tree; don't deep-scan): `app.py` / `wsgi.py` / `asgi.py` / `manage.py` / `settings.py` (Python web); `config/application.rb` / `bin/rails` (Rails); `next.config.*` / `vite.config.*` / `nuxt.config.*` / `webpack.config.*` / `rollup.config.*` (JS/TS frameworks).
    - If you see a manifest or config file you don't recognize, note it as a `[HUMAN-CONFIRM]` question rather than guessing.
@@ -55,7 +60,7 @@ Read in order:
 
 Do not read lockfiles in full (only enough to confirm ecosystem and note pinned major-version deps), `node_modules/`, `vendor/`, `.terraform/`, generated code, or files over ~1000 lines unless a specific field requires it.
 
-**Secrets guard — do NOT read contents of:** `*.tfvars` (unless explicitly `*.tfvars.example`), `terraform.tfstate` / `*.tfstate.backup`, `.env*`, files named `secrets*`, anything under `secrets/`, SSH / GPG private keys. Note their presence in your summary so the user can verify `.gitignore` coverage, but never read the contents — they commonly hold credentials.
+**Secrets guard — do NOT read contents of:** `*.tfvars` (unless explicitly `*.tfvars.example`), `terraform.tfstate` / `*.tfstate.backup`, `.env*`, files named `secrets*`, anything under `secrets/`, SSH / GPG private keys, Kubernetes `Secret` kind YAMLs (`kind: Secret` — the base64 `data` / `stringData` fields are *encoded*, not encrypted), SOPS-encrypted YAMLs (identifiable by a `sops:` metadata block — safe to note existence, do not attempt to decrypt). Note their presence in your summary so the user can verify `.gitignore` coverage, but never read the contents — they commonly hold credentials.
 
 ### Step 2 — classify every CONTEXT.md field
 

--- a/templates/SEED-PROMPT.md
+++ b/templates/SEED-PROMPT.md
@@ -31,13 +31,31 @@ You are bootstrapping the working folder for the target repo you are currently r
 Read in order:
 
 1. `CONTEXT.md` in the working folder — the template you'll fill. Note its sections and placeholders.
-2. Target repo's `README.md` if it exists.
-3. Package manifests (whichever exist): `package.json`, `Cargo.toml`, `go.mod`, `pyproject.toml`, `pom.xml`, `build.gradle`, `Gemfile`, `requirements.txt`, `composer.json`.
-4. CI config: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `.circleci/config.yml`, `Jenkinsfile`, `azure-pipelines.yml`.
-5. Top-level directory layout (one level) and `src/` / `lib/` / main source tree (one or two levels).
-6. Recent git activity: `git log --oneline -20`, `git branch -a`, `git remote -v`.
+2. Target repo's `README.md`, plus `CONTRIBUTING.md` / `ARCHITECTURE.md` if present at the root.
+3. **Language / framework / IaC signals** — read whichever of these exist at or near the repo root. The examples below are starting points, not exhaustive; recognize what's actually there and reason from it.
+   - **Manifests & lockfiles:**
+     - TypeScript / JavaScript: `package.json` plus any lockfile (`pnpm-lock.yaml`, `yarn.lock`, `package-lock.json`, `bun.lockb`), `tsconfig.json`, `deno.json`
+     - Python (incl. Flask / Django / FastAPI): `pyproject.toml`, `requirements*.txt`, `Pipfile`, `poetry.lock`, `uv.lock`, `setup.py`, `setup.cfg`, `tox.ini`
+     - Ruby (incl. Rails): `Gemfile`, `Gemfile.lock`, `*.gemspec`, `Rakefile`
+     - Go: `go.mod`, `go.sum`, `go.work`
+     - Rust: `Cargo.toml`, `Cargo.lock`
+     - C / C++: `CMakeLists.txt`, `Makefile`, `conanfile.*`, `vcpkg.json`, `meson.build`, `configure.ac`
+     - Java / Kotlin / Scala: `pom.xml`, `build.gradle(.kts)`, `settings.gradle(.kts)`, `build.sbt`
+     - PHP: `composer.json`
+   - **Infrastructure-as-code / config management:**
+     - Terraform / Terragrunt: `*.tf` (especially `providers.tf`, `versions.tf`, `main.tf`, `variables.tf`, `outputs.tf`), `.terraform.lock.hcl`, `*.tfvars.example`, `terragrunt.hcl`
+     - Puppet: `metadata.json`, `Puppetfile`, `manifests/init.pp`, `environment.conf`, `hiera.yaml`
+     - Ansible: `ansible.cfg`, `inventory*`, `playbook*.yml`, `roles/*/tasks/main.yml`, `roles/*/meta/main.yml`, `requirements.yml`, `group_vars/`, `host_vars/`
+   - **Runtime / container / version pinning:** `Dockerfile`, `docker-compose.yml` / `compose.yml`, `.tool-versions` (asdf), `.nvmrc`, `.python-version`, `.ruby-version`, `.editorconfig`.
+   - **Framework signals** (read only at top-of-tree; don't deep-scan): `app.py` / `wsgi.py` / `asgi.py` / `manage.py` / `settings.py` (Python web); `config/application.rb` / `bin/rails` (Rails); `next.config.*` / `vite.config.*` / `nuxt.config.*` / `webpack.config.*` / `rollup.config.*` (JS/TS frameworks).
+   - If you see a manifest or config file you don't recognize, note it as a `[HUMAN-CONFIRM]` question rather than guessing.
+4. **CI config:** `.github/workflows/*.yml`, `.gitlab-ci.yml`, `.circleci/config.yml`, `Jenkinsfile`, `azure-pipelines.yml`.
+5. **Top-level directory layout** (one level deep) and main source tree (one or two levels — whatever the repo uses: `src/`, `lib/`, `pkg/`, `cmd/`, `internal/`, `app/`, `modules/`, `manifests/`, `roles/`, `environments/`, `terraform/`, `live/`, or the repo's own convention).
+6. **Recent git activity:** `git log --oneline -20`, `git branch -a`, `git remote -v`.
 
-Do not read lockfiles, node_modules, vendor directories, generated code, or anything >1000 lines unless a specific field requires it.
+Do not read lockfiles in full (only enough to confirm ecosystem and note pinned major-version deps), `node_modules/`, `vendor/`, `.terraform/`, generated code, or files over ~1000 lines unless a specific field requires it.
+
+**Secrets guard — do NOT read contents of:** `*.tfvars` (unless explicitly `*.tfvars.example`), `terraform.tfstate` / `*.tfstate.backup`, `.env*`, files named `secrets*`, anything under `secrets/`, SSH / GPG private keys. Note their presence in your summary so the user can verify `.gitignore` coverage, but never read the contents — they commonly hold credentials.
 
 ### Step 2 — classify every CONTEXT.md field
 


### PR DESCRIPTION
## Summary

Expand `templates/SEED-PROMPT.md` Step 1 to cover ecosystems the user actually works in — at work (Terraform + k8s GitOps + observability) and on personal projects. The v1 list was JS/Rust/Python/Go-flavored and would miss the majority of real target repos.

Scope grew mid-flight across three granular commits, all on this branch:

### Commit 1 — `feat(seed-prompt): expand ecosystem coverage` (`1db1c70`)

**Multi-language base coverage** for the user's 8 listed ecosystems + adjacent additions:

- **C / C++** — `CMakeLists.txt`, `Makefile`, `conanfile.*`, `vcpkg.json`, `meson.build`, `configure.ac`
- **Python** — extended with `Pipfile`, `poetry.lock`, `uv.lock`, `setup.py`, `setup.cfg`, `tox.ini`, plus Flask/Django/FastAPI framework signals (`app.py`, `wsgi.py`, `asgi.py`, `manage.py`, `settings.py`)
- **Ruby** — extended with `Gemfile.lock`, `*.gemspec`, `Rakefile`, Rails signals (`config/application.rb`, `bin/rails`)
- **TypeScript / JavaScript** — extended with lockfiles, `tsconfig.json`, framework configs (`next.config.*`, `vite.config.*`, `nuxt.config.*`, `webpack.config.*`, `rollup.config.*`), `deno.json`
- **Go** — extended with `go.sum`, `go.work`
- **Terraform / Terragrunt** — `*.tf` (especially `providers.tf`, `versions.tf`, `main.tf`, `variables.tf`, `outputs.tf`), `.terraform.lock.hcl`, `*.tfvars.example`, `terragrunt.hcl`
- **Puppet** — `metadata.json`, `Puppetfile`, `manifests/init.pp`, `environment.conf`, `hiera.yaml`
- **Ansible** — `ansible.cfg`, `inventory*`, `playbook*.yml`, `roles/*/tasks/main.yml`, `roles/*/meta/main.yml`, `requirements.yml`, `group_vars/`, `host_vars/`

Plus adjacent: Java/JVM, Rust lockfile, runtime/container/version-pinning (`Dockerfile`, `docker-compose.yml`, `.tool-versions`, `.nvmrc`, etc.). Introduced the first secrets guard (`*.tfvars`, `.env*`, `terraform.tfstate`, `secrets*`, SSH/GPG keys).

### Commit 2 — `feat(seed-prompt): add GitOps and Kubernetes ecosystem coverage` (`6334685`)

**Kubernetes GitOps stack:**

- **Helm** — `Chart.yaml`, `values.yaml` + `values-*.yaml`, `Chart.lock`, `templates/*.yaml`, `charts/`, `.helmignore`
- **Kustomize** — `kustomization.yaml` / `Kustomization`, `base/` + `overlays/` layout, `patches/`
- **Flux (GitOps)** — `flux-system/` dir, CRDs by `kind:` (`GitRepository`, `Kustomization`, `HelmRelease`, `HelmRepository`), `gotk-*.yaml`, `.sops.yaml`
- **ArgoCD (GitOps)** — CRDs by `apiVersion: argoproj.io/v1alpha1` (`Application`, `ApplicationSet`, `AppProject`), `argocd/` dir, app-of-apps pattern
- **Raw Kubernetes manifests** — detect by content (`apiVersion: v1|apps/v1|...` + `kind:` values), not by path

Secrets guard extended: Kubernetes `Secret` kind YAMLs (base64 ≠ encryption) and SOPS-encrypted YAMLs (note existence, don't attempt to decrypt).

### Commit 3 — `feat(seed-prompt): add observability stack coverage` (`cb21403`)

**New top-level bucket, Observability / monitoring stack:**

- **Prometheus** — `prometheus.yml`, `alerts/*.yml`, `rules/*.yml`, `alertmanager.yml`, `*.rules`, `targets/*.json`
- **Grafana** — `grafana.ini`, `provisioning/{datasources,dashboards,alerting,notifiers,plugins}/*.yaml`, `dashboards/*.json` (skim — often large / generated)
- **Loki** — `loki.yaml`, `promtail.yaml` (log shipper), `loki-*-rules.yaml` (LogQL alerts)
- **Alloy / Grafana Agent** — `config.alloy`, `*.alloy`; legacy `agent.yaml` / `grafana-agent.river`
- **Adjacent observability:** Tempo, Mimir, Pyroscope, OpenTelemetry Collector

---

**Structural change across all commits:** Step 1 item 3 reframed from "Package manifests (whichever exist): [flat list]" to **categorized signals by role** — *Manifests & lockfiles / IaC & config management / Observability / Runtime & container / Framework signals*. Scales better than a flat-list-grows-forever, reasons by ecosystem rather than filename pattern, preserves the "if you see a manifest you don't recognize, mark it `[HUMAN-CONFIRM]` rather than guessing" fallback.

## Test plan

- [x] Three commits all carry only `Signed-off-by: Aaron Cupp` — no `Co-Authored-By` trailer (dogfoods [#6](https://github.com/IamMrCupp/claude-project-kit/pull/6)). ✅
- [x] CI link-check ran green on all three pushes to this branch (runs 24818777550, 24818985818 — 7s and 5s respectively). ✅
- [ ] Manual acceptance (reviewer): SEED-PROMPT.md renders on GitHub; the categorized subsections under Step 1 item 3 are clearly delimited and readable; secrets guard paragraph is hard to miss (bolded callout).
- [ ] **Tomorrow's live-test (Test 6) against the Discord Terraform repo** is the real acceptance test. If Claude correctly reads Terraform-specific files, respects the secrets guard, and produces a sensible inference summary, this PR is validated for the Terraform case. If the target is also running GitOps or observability tooling, those paths get tested too.

**What's still not covered (gaps if anyone spots them, file a follow-up):** Helm-specific per-chart operators (Operator Framework, Helm Hooks), Crossplane, Pulumi, Bazel (`BUILD` / `WORKSPACE`), Nix (`flake.nix`, `default.nix`), container-image-level tooling (Buildah, ko), serverless frameworks (SAM, Serverless Framework), monorepo orchestrators (Nx, Turborepo). Add in a follow-up when a real target repo surfaces them.