### PR TITLE
docs: call out all three Claude-related file locations upfront

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A reusable scaffold for starting new projects with Claude. Battle-tested on real projects and generalized so it works for personal code, open-source, or work projects.
 
+> **Heads up — Claude state for a bootstrapped project lives in three places, none of them your repo:**
+> 1. **Kit checkout** (wherever you cloned this repo) — templates, `bootstrap.sh`, docs.
+> 2. **Working folder** (you pick the path — [SETUP.md §1](SETUP.md#1-pick-a-working-folder-location) lists options) — per-project context.
+> 3. **Auto-memory** at `~/.claude/projects/<sanitized-path>/memory/` (fixed by the Claude harness) — per-project preferences.
+>
+> The kit never modifies your repo. All three locations above are private and local.
+
 ## Why this works
 
 The templates aren't the point — what they do *to* Claude is:
@@ -17,7 +24,7 @@ Net effect: prompts get more responsive and code output tightens up, because Cla
 Every project gets **two parallel sets of files**:
 
 1. **A private AI working folder** (outside the repo) — the canonical source of truth across sessions. Holds `CONTEXT.md`, `SESSION-LOG.md`, plan docs, phase checklists.
-2. **Auto-memory** at `~/.claude/projects/<hash>/memory/` — durable facts about *you* and *how you want to work*: feedback, preferences, references, project context. One file per fact, indexed by `MEMORY.md`.
+2. **Auto-memory** at `~/.claude/projects/<sanitized-path>/memory/` — durable facts about *you* and *how you want to work*: feedback, preferences, references, project context. One file per fact, indexed by `MEMORY.md`.
 
 The working folder is project-specific knowledge ("what are we building, how far are we, what landed last week"). Auto-memory is cross-session behavior ("always use merge commits", "I prefer terse responses"). Neither is committed to the repo.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -2,6 +2,13 @@
 
 Target: you have a repo (new, or existing and already in flight) and want Claude sessions productive from day one. The steps are identical either way — for an existing repo, `CONTEXT.md` should describe the *current* architecture, conventions, and in-flight work rather than a greenfield plan.
 
+> **Before you start — three locations get populated** (none is your repo):
+> - **Kit checkout** (wherever you cloned this repo) — templates and `bootstrap.sh`; you interact with it only when running the script or pulling updates.
+> - **Working folder** — you pick the path in step 1 below (several options listed); per-project context lives here.
+> - **Auto-memory** at `~/.claude/projects/<sanitized-path>/memory/` — fixed by the Claude harness, derived from your repo path; per-project preferences live here.
+>
+> Step 2's `bootstrap.sh` creates the working folder and seeds auto-memory in one pass.
+
 ---
 
 ## 1. Pick a working-folder location


### PR DESCRIPTION
## Summary
- **README.md** — add a callout right under the title naming the three locations Claude state gets written to: kit checkout, working folder, auto-memory. Working folder is flagged as user-chosen (SETUP.md §1 lists options); auto-memory is flagged as harness-fixed.
- **SETUP.md** — add a matching preface before step 1 so linear readers see the full picture before picking a working-folder path.
- **README.md** — fix `<hash>` → `<sanitized-path>` (the harness sanitizes the repo path, doesn't hash it).

Motivation: existing "two parallel sets of files" framing was the second section on the page, and a skimmer could miss that auto-memory is a distinct location on top of the working folder. This makes the split visible before any of the how-to content.

## Test plan
- [ ] README renders: callout appears under the title, before "Why this works".
- [ ] SETUP renders: preface appears between the target-audience paragraph and step 1.
- [ ] Anchor link `SETUP.md#1-pick-a-working-folder-location` resolves (GitHub slugifies the heading).
- [ ] No other references to `<hash>` remain (grep already confirmed).