### PR TITLE
feat(bootstrap): add interactive mode when no working-folder arg is given

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,15 +17,21 @@ KIT_ROOT="$SCRIPT_DIR"
 
 usage() {
   cat <<EOF
-Usage: bootstrap.sh [options] <working-folder>
+Usage: bootstrap.sh [options] [<working-folder>]
 
 Create a Claude working folder and seed auto-memory for the project
 whose repo you run this from. The current working directory is assumed
 to be the repo root.
 
+If <working-folder> is omitted and stdin is a terminal, bootstrap.sh
+prompts interactively for path, project name, and whether to seed
+auto-memory — intended for first-time users. Scripted invocations
+without a path argument still error (no hang waiting for input).
+
 Arguments:
   <working-folder>   Absolute path where the Claude working folder will
                      be created (e.g. ~/Documents/Claude/Projects/foo).
+                     Omit to run interactively.
 
 Options:
   --skip-memory      Skip copying memory-templates/ into the auto-memory
@@ -40,9 +46,14 @@ Options:
                      overwritten.
   -h, --help         Show this help and exit.
 
-Example:
+Examples:
+  # Non-interactive
   cd ~/Code/my-new-project
   ~/Code/claude-project-kit/bootstrap.sh ~/Documents/Claude/Projects/my-new-project
+
+  # Interactive
+  cd ~/Code/my-new-project
+  ~/Code/claude-project-kit/bootstrap.sh
 
 After running, edit the copied files (placeholders marked {{LIKE_THIS}}).
 Most common memory placeholders are auto-filled; any that couldn't be
@@ -84,10 +95,32 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+INTERACTIVE=0
 if [ -z "$WORKING_FOLDER" ]; then
-  echo "error: missing <working-folder> argument" >&2
-  usage >&2
-  exit 2
+  if [ -t 0 ] && [ -t 1 ]; then
+    INTERACTIVE=1
+  else
+    echo "error: missing <working-folder> argument" >&2
+    usage >&2
+    exit 2
+  fi
+fi
+
+if [ "$INTERACTIVE" -eq 1 ]; then
+  REPO_BASENAME="$(basename "$(pwd)")"
+  DEFAULT_WF="$HOME/Documents/Claude/Projects/$REPO_BASENAME"
+
+  echo "bootstrap.sh — interactive mode"
+  echo "(Run with -h for flags and non-interactive usage.)"
+  echo
+  echo "Repo: $(pwd)"
+  echo
+  echo "Working-folder path. Examples:"
+  echo "  $DEFAULT_WF"
+  echo "  $HOME/claude-projects/$REPO_BASENAME"
+  echo "  (any absolute path outside the repo — see SETUP.md §1)"
+  read -r -p "Path [$DEFAULT_WF]: " INPUT
+  WORKING_FOLDER="${INPUT:-$DEFAULT_WF}"
 fi
 
 case "$WORKING_FOLDER" in
@@ -113,6 +146,18 @@ if [ -z "$PROJECT_NAME" ]; then
   PROJECT_NAME="$(basename "$WORKING_FOLDER")"
 fi
 
+if [ "$INTERACTIVE" -eq 1 ]; then
+  read -r -p "Project name [$PROJECT_NAME]: " INPUT
+  PROJECT_NAME="${INPUT:-$PROJECT_NAME}"
+
+  read -r -p "Seed auto-memory? [Y/n]: " INPUT
+  case "$(printf '%s' "$INPUT" | tr '[:upper:]' '[:lower:]')" in
+    ""|y|yes) ;;
+    n|no) SKIP_MEMORY=1 ;;
+    *) echo "error: invalid response: $INPUT" >&2; exit 2 ;;
+  esac
+fi
+
 REPO_SLUG=""
 if REMOTE_URL="$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null)"; then
   REPO_SLUG="$(printf '%s\n' "$REMOTE_URL" \
@@ -129,6 +174,15 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
   fi
 fi
 echo
+
+if [ "$INTERACTIVE" -eq 1 ]; then
+  read -r -p "Proceed? [Y/n]: " INPUT
+  case "$(printf '%s' "$INPUT" | tr '[:upper:]' '[:lower:]')" in
+    ""|y|yes) ;;
+    *) echo "Aborted."; exit 0 ;;
+  esac
+  echo
+fi
 
 if [ -e "$WORKING_FOLDER" ]; then
   if [ ! -d "$WORKING_FOLDER" ]; then


### PR DESCRIPTION
## Summary
- `bootstrap.sh` with no positional argument and a TTY stdin now prompts for path, project name, and whether to seed auto-memory, then shows a summary and asks to confirm before any file writes.
- Scripted invocations (piped/redirected stdin) without a path argument still error — no hang waiting for input.
- `usage()` updated to document interactive mode + a second example block.

Motivation: lower the bar for first-time users. The path is already CLI-arg-driven (not an edit step), but a new adopter still has to read docs to know what to pass. Interactive fallback makes the hand-held path work.

## Design notes
- Default path suggested: `~/Documents/Claude/Projects/<repo-basename>`, but shown alongside `~/claude-projects/<repo-basename>` and "any absolute path" so it's clearly not prescriptive.
- Default project name: basename of working folder (same as non-interactive default).
- Seed auto-memory default: Y.
- Gated on `[ -t 0 ] && [ -t 1 ]` so scripts/CI don't accidentally trigger it.

## Test plan
- [x] `bash -n bootstrap.sh` — syntax OK.
- [x] Piped-stdin, no arg → errors with usage message (confirmed: scripted invocations stay safe).
- [x] Non-interactive with arg → copies templates + memory as before (confirmed with `/tmp` test repo).
- [ ] TTY, no arg → prompts for path / project name / memory / proceed, then runs. (Needs human test at a real terminal.)
- [ ] TTY, no arg, answer "n" to Proceed → exits cleanly without creating anything.
- [ ] TTY, no arg, accept all defaults → working folder created at `~/Documents/Claude/Projects/<repo-basename>`.