### PR TITLE
feat(bootstrap): prompt for issue tracker and seed a tracker-specific memory file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ See [Upgrading an existing project](SETUP.md#upgrading-an-existing-project) for 
 
 ---
 
+## 2026-04-23 — Issue tracker awareness
+
+**Tag:** [v0.4.0](https://github.com/IamMrCupp/claude-project-kit/releases/tag/v0.4.0)
+
+### Added
+- `bootstrap.sh` — new `--tracker TYPE` (`github` | `jira` | `other` | `none`) and `--jira-project KEY` flags. In interactive mode, bootstrap prompts for tracker type (default: `github`) and, when `jira` is selected, the JIRA project key. Non-interactive invocations without either flag behave as before — no tracker file seeded. ([#15](https://github.com/IamMrCupp/claude-project-kit/pull/15))
+- `memory-templates/trackers/` — three reference memory variants (`github.md`, `jira.md`, `other.md`). Bootstrap copies the selected variant into the project's auto-memory as `reference_issue_tracker.md`, substitutes `{{JIRA_PROJECT_KEY}}` when applicable, and appends an index line to `MEMORY.md`. ([#15](https://github.com/IamMrCupp/claude-project-kit/pull/15))
+
+### For existing adopters
+- No breaking changes. Non-interactive invocations without the new flags behave identically — no tracker file is seeded, no existing memory file is touched.
+- To add tracker awareness to an already-bootstrapped project: copy the appropriate `memory-templates/trackers/<TYPE>.md` from the kit into your project's auto-memory folder as `reference_issue_tracker.md`, fill in `{{JIRA_PROJECT_KEY}}` / `{{PROJECT_NAME}}` / `{{REPO_SLUG}}` by hand, and add a line referencing it in your `MEMORY.md`.
+
+---
+
 ## 2026-04-22 — Phase 2: zero manual-fill onboarding
 
 **Tag:** [v0.2.0](https://github.com/IamMrCupp/claude-project-kit/releases/tag/v0.2.0)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ The working folder is project-specific knowledge ("what are we building, how far
     ├── user_role.md         ← who you are, how to calibrate
     ├── feedback_*.md        ← rules & preferences (commits, PRs, CI, etc.)
     ├── project_*.md         ← project context
-    └── reference_*.md       ← external pointers (working folder, etc.)
+    ├── reference_*.md       ← external pointers (working folder, etc.)
+    └── trackers/            ← per-tracker reference memory (github / jira / other)
 ```
 
 ## How to use (new or existing project)
@@ -64,7 +65,9 @@ Works the same for greenfield repos and ones you're adopting it on mid-stream �
 
 1. Read [SETUP.md](SETUP.md) — it walks you through the full bootstrap in ~10 minutes.
 2. Pick a private working folder location (e.g. `~/Documents/Claude/Projects/<Project Name>/`).
-3. From your target repo root, run `bootstrap.sh <working-folder>` — it scaffolds the working folder and seeds auto-memory.
+3. From your target repo root, run `bootstrap.sh` — either of:
+   - **Interactive (hand-held):** `bootstrap.sh` with no arguments prompts for working-folder path, project name, whether to seed auto-memory, and your issue tracker (GitHub Issues / JIRA / other / none). When JIRA is picked, it also prompts for the project key.
+   - **Non-interactive (scripted):** `bootstrap.sh <working-folder> [--tracker TYPE] [--jira-project KEY]` — see `bootstrap.sh -h` for the full flag list.
 4. Open Claude Code in the target repo and say *"Follow the instructions in `<working-folder>/SEED-PROMPT.md`."* Claude deep-reads your repo, fills the templates, flags anything it inferred or can't derive, and stops for your review.
 5. Answer Claude's questions, confirm the inferences, and start working. The normal per-session prompt lives in [PROMPTS.md](PROMPTS.md).
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -33,17 +33,28 @@ Whatever you pick, the **repo stays the repo; the working folder stays separate*
 
 ## 2. Run `bootstrap.sh`
 
-From the root of the project repo you're bootstrapping:
+From the root of the project repo you're bootstrapping, run bootstrap in whichever mode fits:
 
+**Non-interactive (scripted):**
 ```bash
 cd <project-repo>
-<framework-dir>/bootstrap.sh <working-folder>
+<framework-dir>/bootstrap.sh <working-folder> [options]
 ```
 
-That creates the working folder, copies the templates, renames `phase-N-checklist.md` → `phase-0-checklist.md`, and seeds the project's auto-memory at the Claude harness's expected path (`~/.claude/projects/<sanitized>/memory/`).
+**Interactive (hand-held — omit the path argument):**
+```bash
+cd <project-repo>
+<framework-dir>/bootstrap.sh
+```
+Bootstrap prompts for the working-folder path, project name, whether to seed auto-memory, and your issue tracker (`github` / `jira` / `other` / `none`, default `github`). For JIRA, it also prompts for the project key. It then shows a summary and asks to confirm before any file writes. Scripted invocations (piped/redirected stdin) without a path argument still error rather than hanging.
+
+Both modes create the working folder, copy the templates, rename `phase-N-checklist.md` → `phase-0-checklist.md`, and seed the project's auto-memory at the Claude harness's expected path (`~/.claude/projects/<sanitized>/memory/`). When an issue tracker is selected, a `reference_issue_tracker.md` file is seeded into auto-memory with tracker-specific guidance.
 
 Flags:
 - `--skip-memory` — skip the memory-seeding step (leaves `~/.claude/projects/…` alone)
+- `--project-name NAME` — override the auto-derived project name
+- `--tracker TYPE` — issue tracker: `github`, `jira`, `other`, or `none`. Skipped if omitted in non-interactive mode.
+- `--jira-project KEY` — JIRA project key (e.g. `INFRA`). Implies `--tracker jira` if `--tracker` isn't also passed.
 - `--force` — proceed even if the working folder is already non-empty
 - `-h` / `--help` — show usage
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -40,6 +40,12 @@ Options:
                      Override the auto-derived project name used to fill
                      {{PROJECT_NAME}} placeholders in seeded memory files.
                      Defaults to the basename of <working-folder>.
+  --tracker TYPE     Issue tracker type: github, jira, other, or none.
+                     Seeds a tracker-specific reference_issue_tracker.md
+                     into the project's auto-memory. If omitted in non-
+                     interactive mode, tracker setup is skipped entirely.
+  --jira-project KEY Set the JIRA project key (e.g. INFRA). Implies
+                     --tracker jira if --tracker isn't also passed.
   --force            Proceed even if the working folder already exists
                      and is non-empty. Does NOT override the auto-memory
                      safety check — existing memory files are never
@@ -66,6 +72,8 @@ SKIP_MEMORY=0
 FORCE=0
 WORKING_FOLDER=""
 PROJECT_NAME=""
+TRACKER=""
+JIRA_PROJECT_KEY=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -78,6 +86,24 @@ while [ $# -gt 0 ]; do
         exit 2
       fi
       PROJECT_NAME="$2"
+      shift 2
+      ;;
+    --tracker)
+      if [ $# -lt 2 ]; then
+        echo "error: --tracker requires a value (github|jira|other|none)" >&2
+        usage >&2
+        exit 2
+      fi
+      TRACKER="$2"
+      shift 2
+      ;;
+    --jira-project)
+      if [ $# -lt 2 ]; then
+        echo "error: --jira-project requires a value" >&2
+        usage >&2
+        exit 2
+      fi
+      JIRA_PROJECT_KEY="$2"
       shift 2
       ;;
     -h|--help) usage; exit 0 ;;
@@ -94,6 +120,20 @@ while [ $# -gt 0 ]; do
       ;;
   esac
 done
+
+if [ -n "$JIRA_PROJECT_KEY" ] && [ -z "$TRACKER" ]; then
+  TRACKER="jira"
+fi
+
+case "$TRACKER" in
+  ""|github|jira|other|none) ;;
+  *) echo "error: --tracker must be one of: github, jira, other, none (got: $TRACKER)" >&2; exit 2 ;;
+esac
+
+if [ "$TRACKER" = "jira" ] && [ -z "$JIRA_PROJECT_KEY" ] && [ ! -t 0 ]; then
+  echo "error: --tracker jira requires --jira-project <KEY> in non-interactive mode" >&2
+  exit 2
+fi
 
 INTERACTIVE=0
 if [ -z "$WORKING_FOLDER" ]; then
@@ -156,6 +196,24 @@ if [ "$INTERACTIVE" -eq 1 ]; then
     n|no) SKIP_MEMORY=1 ;;
     *) echo "error: invalid response: $INPUT" >&2; exit 2 ;;
   esac
+
+  if [ "$SKIP_MEMORY" -eq 0 ] && [ -z "$TRACKER" ]; then
+    read -r -p "Issue tracker? [github/jira/other/none, default github]: " INPUT
+    TRACKER="$(printf '%s' "$INPUT" | tr '[:upper:]' '[:lower:]')"
+    TRACKER="${TRACKER:-github}"
+    case "$TRACKER" in
+      github|jira|other|none) ;;
+      *) echo "error: invalid tracker: $TRACKER" >&2; exit 2 ;;
+    esac
+
+    if [ "$TRACKER" = "jira" ] && [ -z "$JIRA_PROJECT_KEY" ]; then
+      read -r -p "JIRA project key (e.g. INFRA): " JIRA_PROJECT_KEY
+      if [ -z "$JIRA_PROJECT_KEY" ]; then
+        echo "error: JIRA project key is required when tracker is jira" >&2
+        exit 2
+      fi
+    fi
+  fi
 fi
 
 REPO_SLUG=""
@@ -171,6 +229,13 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
   echo "Memory folder:  $MEMORY_DIR"
   if [ -n "$REPO_SLUG" ]; then
     echo "Repo slug:      $REPO_SLUG (from git remote origin)"
+  fi
+  if [ -n "$TRACKER" ] && [ "$TRACKER" != "none" ]; then
+    if [ "$TRACKER" = "jira" ]; then
+      echo "Issue tracker:  jira (project: $JIRA_PROJECT_KEY)"
+    else
+      echo "Issue tracker:  $TRACKER"
+    fi
   fi
 fi
 echo
@@ -215,6 +280,24 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
   cp "$KIT_ROOT/memory-templates/"*.md "$MEMORY_DIR/"
   echo "  ✓ Copied memory files to $MEMORY_DIR"
 
+  if [ -n "$TRACKER" ] && [ "$TRACKER" != "none" ]; then
+    TRACKER_SRC="$KIT_ROOT/memory-templates/trackers/$TRACKER.md"
+    if [ ! -f "$TRACKER_SRC" ]; then
+      echo "error: tracker template not found: $TRACKER_SRC" >&2
+      exit 1
+    fi
+    cp "$TRACKER_SRC" "$MEMORY_DIR/reference_issue_tracker.md"
+    {
+      printf -- '- [Issue tracker for %s](reference_issue_tracker.md) — ' "$PROJECT_NAME"
+      case "$TRACKER" in
+        github) printf 'tickets live in GitHub Issues on this repo\n' ;;
+        jira)   printf 'tickets live in JIRA project `%s`\n' "$JIRA_PROJECT_KEY" ;;
+        other)  printf 'tickets live in an external system — fill in the placeholders\n' ;;
+      esac
+    } >> "$MEMORY_DIR/MEMORY.md"
+    echo "  ✓ Seeded tracker memory ($TRACKER) → reference_issue_tracker.md"
+  fi
+
   FILLED_FILES=0
   for f in "$MEMORY_DIR"/*.md; do
     tmp="$(mktemp)"
@@ -223,11 +306,13 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
           -e "s|{{REPO_PATH}}|$REPO_ROOT|g" \
           -e "s|{{PROJECT_NAME}}|$PROJECT_NAME|g" \
           -e "s|{{REPO_SLUG}}|$REPO_SLUG|g" \
+          -e "s|{{JIRA_PROJECT_KEY}}|$JIRA_PROJECT_KEY|g" \
           "$f" > "$tmp"
     else
       sed -e "s|{{WORKING_FOLDER}}|$WORKING_FOLDER|g" \
           -e "s|{{REPO_PATH}}|$REPO_ROOT|g" \
           -e "s|{{PROJECT_NAME}}|$PROJECT_NAME|g" \
+          -e "s|{{JIRA_PROJECT_KEY}}|$JIRA_PROJECT_KEY|g" \
           "$f" > "$tmp"
     fi
     if ! cmp -s "$f" "$tmp"; then
@@ -262,6 +347,10 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
   else
     echo "  3. Review memory at $MEMORY_DIR —"
     echo "     {{REPO_SLUG}} needs manual fill in project_current.md; others done."
+  fi
+  if [ "$TRACKER" = "other" ]; then
+    echo "     Also fill in the {{placeholders}} in reference_issue_tracker.md"
+    echo "     — the 'other' tracker template needs your specifics."
   fi
 else
   echo "  3. Memory was skipped (--skip-memory). See SETUP.md §Manual alternative"

--- a/memory-templates/trackers/github.md
+++ b/memory-templates/trackers/github.md
@@ -1,0 +1,17 @@
+---
+name: Issue tracker for {{PROJECT_NAME}}
+description: Tickets for this project are tracked via GitHub Issues on {{REPO_SLUG}}.
+type: reference
+---
+
+Tickets for **{{PROJECT_NAME}}** live in GitHub Issues on `{{REPO_SLUG}}`.
+
+- **Ticket URLs:** `https://github.com/{{REPO_SLUG}}/issues/<number>`
+- **Reference format:** `#123` in-repo, `{{REPO_SLUG}}#123` for cross-repo references.
+
+**Why:** the repo is the single source of truth for work tracking; commits, PRs, and issues all cross-link natively.
+
+**How to apply:**
+- When the user mentions a ticket (e.g. `#42`), fetch it via `gh issue view 42` before reasoning about it — never guess contents.
+- When opening a PR that resolves an issue, include `Closes #42` in the PR body so GitHub auto-closes on merge.
+- When a commit references an issue, follow the Conventional Commits description with the reference (e.g. `fix(auth): handle expired tokens (#42)`).

--- a/memory-templates/trackers/jira.md
+++ b/memory-templates/trackers/jira.md
@@ -1,0 +1,19 @@
+---
+name: Issue tracker for {{PROJECT_NAME}}
+description: Tickets for this project are tracked in JIRA project {{JIRA_PROJECT_KEY}}.
+type: reference
+---
+
+Tickets for **{{PROJECT_NAME}}** are tracked in **JIRA project `{{JIRA_PROJECT_KEY}}`**.
+
+- **Reference format:** `{{JIRA_PROJECT_KEY}}-123` — always include the project key, never bare ticket numbers.
+- **MCP:** if a JIRA MCP server is connected in the session, use it to fetch ticket details; don't guess contents.
+
+**Why:** work at this project is driven by JIRA tickets. Commit messages, branch names, and PR titles should reference the ticket so work is traceable from any layer.
+
+**How to apply:**
+- When the user mentions a ticket (e.g. `{{JIRA_PROJECT_KEY}}-42`), attempt to fetch it via the JIRA MCP first. If the MCP isn't connected, ask the user to paste the relevant ticket details rather than guessing.
+- Branch names should include the ticket key: `feat/{{JIRA_PROJECT_KEY}}-42-short-slug`.
+- PR titles should lead with the ticket key: `{{JIRA_PROJECT_KEY}}-42: <Conventional Commit summary>`.
+- Commit messages follow Conventional Commits but should reference the ticket in the description when applicable: `fix(auth): handle expired tokens ({{JIRA_PROJECT_KEY}}-42)`.
+- If the user references a ticket from a *different* JIRA project, flag it — the memorized project key is `{{JIRA_PROJECT_KEY}}` and cross-project work may need confirmation.

--- a/memory-templates/trackers/other.md
+++ b/memory-templates/trackers/other.md
@@ -1,0 +1,18 @@
+---
+name: Issue tracker for {{PROJECT_NAME}}
+description: Tickets for this project are tracked in an external system — fill in the details below.
+type: reference
+---
+
+Tickets for **{{PROJECT_NAME}}** are tracked in: **{{describe the tracker — Linear, Asana, Shortcut, custom, etc.}}**
+
+- **Ticket URL pattern:** {{e.g. https://linear.app/acme/issue/ENG-123}}
+- **Reference format:** {{e.g. `ENG-123`, `T-4567`, `[task 42]`}}
+- **MCP or API access:** {{if a dedicated MCP server is available, name it; otherwise describe how ticket lookup happens — web, CLI, manual paste}}
+
+**Why:** this project uses a tracker that isn't GitHub Issues or JIRA. Without this reference, Claude has no way to know the naming or lookup conventions and will guess incorrectly.
+
+**How to apply:**
+- Fill in the placeholders above before relying on this memory.
+- When the user mentions a ticket, use the reference format above to identify it; use the MCP or lookup method named above to fetch details.
+- Include the ticket reference in commit messages, branch names, and PR titles per your team's convention.


### PR DESCRIPTION
## Summary
- `bootstrap.sh` — new `--tracker TYPE` (`github` | `jira` | `other` | `none`) and `--jira-project KEY` flags. Interactive mode prompts for tracker type (default: `github`) and, when `jira` is selected, the JIRA project key.
- `memory-templates/trackers/` — new subdirectory with `github.md` / `jira.md` / `other.md` reference-memory variants. Bootstrap copies the chosen variant into the project's auto-memory as `reference_issue_tracker.md`, substitutes `{{JIRA_PROJECT_KEY}}` when applicable, and appends an index line to `MEMORY.md`.
- `CHANGELOG.md` — v0.4.0 entry (new feature, backward-compatible; in-PR per the per-release convention).

## Motivation
Work projects often drive development off JIRA tickets; personal repos off GitHub Issues. Capturing that preference at bootstrap time — and seeding a tracker-aware memory file — means Claude sessions know how to reference tickets and (for JIRA) attempt lookups via the JIRA MCP if one is connected. The kit stays MCP-agnostic: it records "this repo uses JIRA"; whether an MCP is connected is a per-session runtime concern.

## Design notes
- **Backward compatible.** Non-interactive invocations without the new flags behave identically — no tracker file seeded, no existing memory touched.
- **`none` is explicit opt-out.** Same end state as "not specified", but lets scripts be explicit about the choice.
- **JIRA project key is required.** In non-interactive mode with `--tracker jira`, omitting `--jira-project` is an error (no sensible default). In interactive mode, the prompt loops until a non-empty value is given.
- **`--jira-project` implies `--tracker jira`.** Saves one flag for the common JIRA case.
- **Validation.** `--tracker` values are checked against the known set; bad values error at startup, not mid-copy.
- **Trackers live in a subdir.** `memory-templates/trackers/*.md` isn't picked up by the existing `memory-templates/*.md` glob — good, otherwise GitHub users would get all three tracker files by default.

## Test plan
- [x] `bash -n bootstrap.sh` — syntax OK.
- [x] `--tracker jira --jira-project INFRA /tmp/wf` — reference_issue_tracker.md created with `INFRA` substituted throughout; MEMORY.md index appended.
- [x] Bootstrap with no `--tracker` flag — no tracker file created, no MEMORY.md change (backward compat).
- [ ] Interactive mode at a real TTY: accept defaults (github tracker, no project key prompt) → `reference_issue_tracker.md` seeded from `github.md` variant.
- [ ] Interactive mode at a real TTY: pick `jira` → prompted for project key, tracker file seeded with the key substituted.
- [ ] Interactive mode at a real TTY: pick `none` → no tracker file seeded.
- [ ] `--tracker jira` without `--jira-project` in a non-TTY: errors cleanly.

## CHANGELOG
v0.4.0 — minor bump (new user-visible feature, backward-compatible). Entry included in this PR.