### PR TITLE
feat(bootstrap): add linear, gitlab, and shortcut tracker variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ See [Upgrading an existing project](SETUP.md#upgrading-an-existing-project) for 
 
 ---
 
+## 2026-04-23 — More tracker variants
+
+**Tag:** [v0.5.0](https://github.com/IamMrCupp/claude-project-kit/releases/tag/v0.5.0)
+
+### Added
+- `memory-templates/trackers/linear.md`, `gitlab.md`, `shortcut.md` — three new reference-memory variants. Complements the existing `github.md` / `jira.md` / `other.md`. ([#16](https://github.com/IamMrCupp/claude-project-kit/pull/16))
+- `bootstrap.sh` — `--tracker` now accepts `linear`, `gitlab`, `shortcut` in addition to the existing values. ([#16](https://github.com/IamMrCupp/claude-project-kit/pull/16))
+- `bootstrap.sh` — new `--linear-team KEY` flag (analogous to `--jira-project`). Implies `--tracker linear`. Required in non-interactive mode when tracker is Linear. ([#16](https://github.com/IamMrCupp/claude-project-kit/pull/16))
+- Interactive mode now lists all seven tracker options and prompts for the team key when Linear is selected. ([#16](https://github.com/IamMrCupp/claude-project-kit/pull/16))
+
+### For existing adopters
+- No breaking changes. Existing `--tracker github` / `--tracker jira` invocations behave identically.
+- To add tracker awareness to an already-bootstrapped project using one of the new trackers, copy `memory-templates/trackers/<TYPE>.md` from the kit into your project's auto-memory folder as `reference_issue_tracker.md` and fill in placeholders by hand.
+
+---
+
 ## 2026-04-23 — Issue tracker awareness
 
 **Tag:** [v0.4.0](https://github.com/IamMrCupp/claude-project-kit/releases/tag/v0.4.0)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The working folder is project-specific knowledge ("what are we building, how far
     ├── feedback_*.md        ← rules & preferences (commits, PRs, CI, etc.)
     ├── project_*.md         ← project context
     ├── reference_*.md       ← external pointers (working folder, etc.)
-    └── trackers/            ← per-tracker reference memory (github / jira / other)
+    └── trackers/            ← per-tracker reference memory (github / jira / linear / gitlab / shortcut / other)
 ```
 
 ## How to use (new or existing project)
@@ -66,8 +66,8 @@ Works the same for greenfield repos and ones you're adopting it on mid-stream �
 1. Read [SETUP.md](SETUP.md) — it walks you through the full bootstrap in ~10 minutes.
 2. Pick a private working folder location (e.g. `~/Documents/Claude/Projects/<Project Name>/`).
 3. From your target repo root, run `bootstrap.sh` — either of:
-   - **Interactive (hand-held):** `bootstrap.sh` with no arguments prompts for working-folder path, project name, whether to seed auto-memory, and your issue tracker (GitHub Issues / JIRA / other / none). When JIRA is picked, it also prompts for the project key.
-   - **Non-interactive (scripted):** `bootstrap.sh <working-folder> [--tracker TYPE] [--jira-project KEY]` — see `bootstrap.sh -h` for the full flag list.
+   - **Interactive (hand-held):** `bootstrap.sh` with no arguments prompts for working-folder path, project name, whether to seed auto-memory, and your issue tracker (GitHub Issues / JIRA / Linear / GitLab / Shortcut / other / none). For JIRA and Linear, it also prompts for the project or team key.
+   - **Non-interactive (scripted):** `bootstrap.sh <working-folder> [--tracker TYPE] [--jira-project KEY | --linear-team KEY]` — see `bootstrap.sh -h` for the full flag list.
 4. Open Claude Code in the target repo and say *"Follow the instructions in `<working-folder>/SEED-PROMPT.md`."* Claude deep-reads your repo, fills the templates, flags anything it inferred or can't derive, and stops for your review.
 5. Answer Claude's questions, confirm the inferences, and start working. The normal per-session prompt lives in [PROMPTS.md](PROMPTS.md).
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -46,15 +46,16 @@ cd <project-repo>
 cd <project-repo>
 <framework-dir>/bootstrap.sh
 ```
-Bootstrap prompts for the working-folder path, project name, whether to seed auto-memory, and your issue tracker (`github` / `jira` / `other` / `none`, default `github`). For JIRA, it also prompts for the project key. It then shows a summary and asks to confirm before any file writes. Scripted invocations (piped/redirected stdin) without a path argument still error rather than hanging.
+Bootstrap prompts for the working-folder path, project name, whether to seed auto-memory, and your issue tracker (`github` / `jira` / `linear` / `gitlab` / `shortcut` / `other` / `none`, default `github`). For `jira` and `linear`, it also prompts for the project/team key. It then shows a summary and asks to confirm before any file writes. Scripted invocations (piped/redirected stdin) without a path argument still error rather than hanging.
 
 Both modes create the working folder, copy the templates, rename `phase-N-checklist.md` → `phase-0-checklist.md`, and seed the project's auto-memory at the Claude harness's expected path (`~/.claude/projects/<sanitized>/memory/`). When an issue tracker is selected, a `reference_issue_tracker.md` file is seeded into auto-memory with tracker-specific guidance.
 
 Flags:
 - `--skip-memory` — skip the memory-seeding step (leaves `~/.claude/projects/…` alone)
 - `--project-name NAME` — override the auto-derived project name
-- `--tracker TYPE` — issue tracker: `github`, `jira`, `other`, or `none`. Skipped if omitted in non-interactive mode.
+- `--tracker TYPE` — issue tracker: `github`, `jira`, `linear`, `gitlab`, `shortcut`, `other`, or `none`. Skipped if omitted in non-interactive mode.
 - `--jira-project KEY` — JIRA project key (e.g. `INFRA`). Implies `--tracker jira` if `--tracker` isn't also passed.
+- `--linear-team KEY` — Linear team key (e.g. `ENG`). Implies `--tracker linear` if `--tracker` isn't also passed.
 - `--force` — proceed even if the working folder is already non-empty
 - `-h` / `--help` — show usage
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -40,12 +40,15 @@ Options:
                      Override the auto-derived project name used to fill
                      {{PROJECT_NAME}} placeholders in seeded memory files.
                      Defaults to the basename of <working-folder>.
-  --tracker TYPE     Issue tracker type: github, jira, other, or none.
-                     Seeds a tracker-specific reference_issue_tracker.md
-                     into the project's auto-memory. If omitted in non-
-                     interactive mode, tracker setup is skipped entirely.
+  --tracker TYPE     Issue tracker type: github, jira, linear, gitlab,
+                     shortcut, other, or none. Seeds a tracker-specific
+                     reference_issue_tracker.md into the project's
+                     auto-memory. If omitted in non-interactive mode,
+                     tracker setup is skipped entirely.
   --jira-project KEY Set the JIRA project key (e.g. INFRA). Implies
                      --tracker jira if --tracker isn't also passed.
+  --linear-team KEY  Set the Linear team key (e.g. ENG). Implies
+                     --tracker linear if --tracker isn't also passed.
   --force            Proceed even if the working folder already exists
                      and is non-empty. Does NOT override the auto-memory
                      safety check — existing memory files are never
@@ -74,6 +77,7 @@ WORKING_FOLDER=""
 PROJECT_NAME=""
 TRACKER=""
 JIRA_PROJECT_KEY=""
+LINEAR_TEAM_KEY=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -106,6 +110,15 @@ while [ $# -gt 0 ]; do
       JIRA_PROJECT_KEY="$2"
       shift 2
       ;;
+    --linear-team)
+      if [ $# -lt 2 ]; then
+        echo "error: --linear-team requires a value" >&2
+        usage >&2
+        exit 2
+      fi
+      LINEAR_TEAM_KEY="$2"
+      shift 2
+      ;;
     -h|--help) usage; exit 0 ;;
     --*) echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
     *)
@@ -124,14 +137,21 @@ done
 if [ -n "$JIRA_PROJECT_KEY" ] && [ -z "$TRACKER" ]; then
   TRACKER="jira"
 fi
+if [ -n "$LINEAR_TEAM_KEY" ] && [ -z "$TRACKER" ]; then
+  TRACKER="linear"
+fi
 
 case "$TRACKER" in
-  ""|github|jira|other|none) ;;
-  *) echo "error: --tracker must be one of: github, jira, other, none (got: $TRACKER)" >&2; exit 2 ;;
+  ""|github|jira|linear|gitlab|shortcut|other|none) ;;
+  *) echo "error: --tracker must be one of: github, jira, linear, gitlab, shortcut, other, none (got: $TRACKER)" >&2; exit 2 ;;
 esac
 
 if [ "$TRACKER" = "jira" ] && [ -z "$JIRA_PROJECT_KEY" ] && [ ! -t 0 ]; then
   echo "error: --tracker jira requires --jira-project <KEY> in non-interactive mode" >&2
+  exit 2
+fi
+if [ "$TRACKER" = "linear" ] && [ -z "$LINEAR_TEAM_KEY" ] && [ ! -t 0 ]; then
+  echo "error: --tracker linear requires --linear-team <KEY> in non-interactive mode" >&2
   exit 2
 fi
 
@@ -198,11 +218,11 @@ if [ "$INTERACTIVE" -eq 1 ]; then
   esac
 
   if [ "$SKIP_MEMORY" -eq 0 ] && [ -z "$TRACKER" ]; then
-    read -r -p "Issue tracker? [github/jira/other/none, default github]: " INPUT
+    read -r -p "Issue tracker? [github/jira/linear/gitlab/shortcut/other/none, default github]: " INPUT
     TRACKER="$(printf '%s' "$INPUT" | tr '[:upper:]' '[:lower:]')"
     TRACKER="${TRACKER:-github}"
     case "$TRACKER" in
-      github|jira|other|none) ;;
+      github|jira|linear|gitlab|shortcut|other|none) ;;
       *) echo "error: invalid tracker: $TRACKER" >&2; exit 2 ;;
     esac
 
@@ -210,6 +230,14 @@ if [ "$INTERACTIVE" -eq 1 ]; then
       read -r -p "JIRA project key (e.g. INFRA): " JIRA_PROJECT_KEY
       if [ -z "$JIRA_PROJECT_KEY" ]; then
         echo "error: JIRA project key is required when tracker is jira" >&2
+        exit 2
+      fi
+    fi
+
+    if [ "$TRACKER" = "linear" ] && [ -z "$LINEAR_TEAM_KEY" ]; then
+      read -r -p "Linear team key (e.g. ENG): " LINEAR_TEAM_KEY
+      if [ -z "$LINEAR_TEAM_KEY" ]; then
+        echo "error: Linear team key is required when tracker is linear" >&2
         exit 2
       fi
     fi
@@ -231,11 +259,11 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
     echo "Repo slug:      $REPO_SLUG (from git remote origin)"
   fi
   if [ -n "$TRACKER" ] && [ "$TRACKER" != "none" ]; then
-    if [ "$TRACKER" = "jira" ]; then
-      echo "Issue tracker:  jira (project: $JIRA_PROJECT_KEY)"
-    else
-      echo "Issue tracker:  $TRACKER"
-    fi
+    case "$TRACKER" in
+      jira)   echo "Issue tracker:  jira (project: $JIRA_PROJECT_KEY)" ;;
+      linear) echo "Issue tracker:  linear (team: $LINEAR_TEAM_KEY)" ;;
+      *)      echo "Issue tracker:  $TRACKER" ;;
+    esac
   fi
 fi
 echo
@@ -290,9 +318,12 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
     {
       printf -- '- [Issue tracker for %s](reference_issue_tracker.md) — ' "$PROJECT_NAME"
       case "$TRACKER" in
-        github) printf 'tickets live in GitHub Issues on this repo\n' ;;
-        jira)   printf 'tickets live in JIRA project `%s`\n' "$JIRA_PROJECT_KEY" ;;
-        other)  printf 'tickets live in an external system — fill in the placeholders\n' ;;
+        github)   printf 'tickets live in GitHub Issues on this repo\n' ;;
+        jira)     printf 'tickets live in JIRA project `%s`\n' "$JIRA_PROJECT_KEY" ;;
+        linear)   printf 'issues live in Linear team `%s`\n' "$LINEAR_TEAM_KEY" ;;
+        gitlab)   printf 'tickets live in GitLab Issues on this repo\n' ;;
+        shortcut) printf 'stories live in Shortcut (sc-NNN refs)\n' ;;
+        other)    printf 'tickets live in an external system — fill in the placeholders\n' ;;
       esac
     } >> "$MEMORY_DIR/MEMORY.md"
     echo "  ✓ Seeded tracker memory ($TRACKER) → reference_issue_tracker.md"
@@ -307,12 +338,14 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
           -e "s|{{PROJECT_NAME}}|$PROJECT_NAME|g" \
           -e "s|{{REPO_SLUG}}|$REPO_SLUG|g" \
           -e "s|{{JIRA_PROJECT_KEY}}|$JIRA_PROJECT_KEY|g" \
+          -e "s|{{LINEAR_TEAM_KEY}}|$LINEAR_TEAM_KEY|g" \
           "$f" > "$tmp"
     else
       sed -e "s|{{WORKING_FOLDER}}|$WORKING_FOLDER|g" \
           -e "s|{{REPO_PATH}}|$REPO_ROOT|g" \
           -e "s|{{PROJECT_NAME}}|$PROJECT_NAME|g" \
           -e "s|{{JIRA_PROJECT_KEY}}|$JIRA_PROJECT_KEY|g" \
+          -e "s|{{LINEAR_TEAM_KEY}}|$LINEAR_TEAM_KEY|g" \
           "$f" > "$tmp"
     fi
     if ! cmp -s "$f" "$tmp"; then

--- a/memory-templates/trackers/gitlab.md
+++ b/memory-templates/trackers/gitlab.md
@@ -1,0 +1,20 @@
+---
+name: Issue tracker for {{PROJECT_NAME}}
+description: Tickets for this project are tracked via GitLab Issues on {{REPO_SLUG}}.
+type: reference
+---
+
+Tickets for **{{PROJECT_NAME}}** live in GitLab Issues on `{{REPO_SLUG}}`.
+
+- **Issue URLs:** `https://gitlab.com/{{REPO_SLUG}}/-/issues/<number>` (swap the host for self-hosted GitLab instances).
+- **Reference format:** `#123` in-repo; `group/project#123` cross-project.
+- **Merge requests:** GitLab calls them MRs, not PRs. Reference with `!123` (not `#`).
+- **CLI:** `glab` is the GitLab equivalent of `gh` — if installed, prefer it for fetching issue/MR details.
+
+**Why:** the repo is the single source of truth for work tracking; commits, MRs, and issues all cross-link natively within GitLab.
+
+**How to apply:**
+- When the user mentions an issue (e.g. `#42`), fetch it via `glab issue view 42` if the CLI is available; otherwise ask the user to paste the relevant issue details.
+- When opening an MR that resolves an issue, include `Closes #42` in the MR description so GitLab auto-closes on merge.
+- When a commit references an issue, follow Conventional Commits with the reference (e.g. `fix(auth): handle expired tokens (#42)`).
+- When a commit references an MR (unusual but happens), use `!NN` — don't confuse it with `#NN`.

--- a/memory-templates/trackers/linear.md
+++ b/memory-templates/trackers/linear.md
@@ -1,0 +1,19 @@
+---
+name: Issue tracker for {{PROJECT_NAME}}
+description: Tickets for this project are tracked in Linear team {{LINEAR_TEAM_KEY}}.
+type: reference
+---
+
+Tickets for **{{PROJECT_NAME}}** are tracked in **Linear team `{{LINEAR_TEAM_KEY}}`**.
+
+- **Reference format:** `{{LINEAR_TEAM_KEY}}-123` — always include the team key.
+- **MCP:** if a Linear MCP server is connected in the session, use it to fetch ticket details; don't guess contents.
+
+**Why:** work on this project is driven by Linear issues. Commit messages, branch names, and PR titles should reference the issue so work is traceable from any layer.
+
+**How to apply:**
+- When the user mentions an issue (e.g. `{{LINEAR_TEAM_KEY}}-42`), attempt to fetch it via the Linear MCP first. If the MCP isn't connected, ask the user to paste the relevant issue details rather than guessing.
+- Branch names should include the issue key: `feat/{{LINEAR_TEAM_KEY}}-42-short-slug`. Linear's "copy git branch name" feature in the issue view gives you this format.
+- PR titles should lead with the issue key: `{{LINEAR_TEAM_KEY}}-42: <Conventional Commit summary>`.
+- Commit messages follow Conventional Commits; reference the issue in the description when applicable: `fix(auth): handle expired tokens ({{LINEAR_TEAM_KEY}}-42)`.
+- If the user references an issue from a *different* Linear team, flag it — the memorized team key is `{{LINEAR_TEAM_KEY}}`.

--- a/memory-templates/trackers/shortcut.md
+++ b/memory-templates/trackers/shortcut.md
@@ -1,0 +1,19 @@
+---
+name: Issue tracker for {{PROJECT_NAME}}
+description: Stories for this project are tracked in Shortcut (formerly Clubhouse).
+type: reference
+---
+
+Stories for **{{PROJECT_NAME}}** are tracked in **Shortcut**.
+
+- **Reference format:** `sc-123` (common in commits/branches) or `[sc-123]` (Shortcut auto-links these). Also accepted: plain `#123` inside Shortcut's UI but prefer `sc-123` in git artifacts to disambiguate from GitHub-style issue refs.
+- **Story URLs:** `https://app.shortcut.com/<workspace>/story/<number>` — the workspace slug is fixed per account; the `<number>` is global (not per-team).
+- **MCP:** if a Shortcut MCP server is connected in the session, use it to fetch story details.
+
+**Why:** work on this project is driven by Shortcut stories. Referencing the story ID in commits, branches, and PRs keeps work traceable and triggers Shortcut's auto-linking.
+
+**How to apply:**
+- When the user mentions a story (e.g. `sc-42`), attempt to fetch details via the Shortcut MCP first. If the MCP isn't connected, ask the user to paste the relevant story details rather than guessing.
+- Branch names should include the story ID: `feat/sc-42-short-slug`. Shortcut's "copy git branch" feature generates this format automatically.
+- PR titles should reference the story: `sc-42: <Conventional Commit summary>`.
+- Commit messages follow Conventional Commits; include the story ID in the description when applicable: `fix(auth): handle expired tokens [sc-42]`.


### PR DESCRIPTION
## Summary
- Three new `memory-templates/trackers/` variants — `linear.md`, `gitlab.md`, `shortcut.md` — rounding out the matrix started in v0.4.0.
- `bootstrap.sh` accepts the new tracker types via `--tracker` and lists them in the interactive prompt.
- New `--linear-team KEY` flag (analogous to `--jira-project`). Implies `--tracker linear`. Required in non-interactive mode when tracker is Linear.
- GitLab variant uses `{{REPO_SLUG}}` (already auto-filled by bootstrap) and documents GitLab-specific conventions: `!NN` for merge requests, `glab` CLI, self-hosted host flexibility.
- Linear and Shortcut variants document their respective MCP usage patterns.

## Motivation
Previous v0.4.0 shipped github/jira/other. Work repos use GitLab (Puppet modules etc. that don't live on GitHub); other teams use Linear or Shortcut. Having proper tracker variants means Claude sessions understand the terminology for each tracker from day one — no manual filling of the `other.md` placeholder.

## Design notes
- **Linear needs a team key.** Analogous to JIRA's project key. Same pattern: dedicated flag (`--linear-team`), interactive prompt when tracker is selected, error in non-interactive mode if missing.
- **GitLab doesn't need a key.** Issues are `#NN` scoped to the repo (same as GitHub); `{{REPO_SLUG}}` covers the rest.
- **Shortcut doesn't need a key either.** Story numbers are workspace-global; the workspace slug is fixed per account and lives in the Shortcut MCP config, not in our memory.
- **No breaking changes.** Existing `--tracker github` / `--tracker jira` invocations unchanged.

## Test plan
- [x] `bash -n bootstrap.sh` — syntax OK.
- [x] `--tracker linear --linear-team ENG /tmp/wf` — `reference_issue_tracker.md` seeded from linear variant with `ENG` substituted.
- [x] `--tracker gitlab /tmp/wf` (with git remote origin) — `reference_issue_tracker.md` seeded from gitlab variant with `{{REPO_SLUG}}` substituted from git remote.
- [ ] Interactive mode: pick `linear` at the tracker prompt → prompted for team key, file seeded.
- [ ] Interactive mode: pick `shortcut` → file seeded without any key prompt.
- [ ] Non-interactive `--tracker linear` without `--linear-team` → errors cleanly.

## CHANGELOG
v0.5.0 — minor bump (new tracker options + new flag, backward-compatible). Entry included in this PR.