### PR TITLE
feat: add end-of-session prompt and bootstrap --dry-run flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ See [Upgrading an existing project](SETUP.md#upgrading-an-existing-project) for 
 
 ---
 
+## 2026-04-23 — End-of-session prompt and `--dry-run`
+
+**Tag:** [v0.6.0](https://github.com/IamMrCupp/claude-project-kit/releases/tag/v0.6.0)
+
+### Added
+- `PROMPTS.md` — new **Prompt 3: Wrapping up a session**. Scaffolds the end-of-session hygiene from SETUP.md §7: drafts a `SESSION-LOG.md` entry, suggests `CONTEXT.md` status-line updates, flags checklist items missing PR numbers, and surfaces memory candidates — all in draft form, waiting on confirmation before writing. ([#17](https://github.com/IamMrCupp/claude-project-kit/pull/17))
+- `bootstrap.sh --dry-run` — preview every action (paths, placeholder substitutions, tracker memory copy, MEMORY.md index append) and exit without writing anything. Safe to re-run. ([#17](https://github.com/IamMrCupp/claude-project-kit/pull/17))
+- `SETUP.md §7` — pointer to Prompt 3 for users who want a scaffolded wrap-up rather than doing the checklist by hand. ([#17](https://github.com/IamMrCupp/claude-project-kit/pull/17))
+
+### For existing adopters
+- No breaking changes. `--dry-run` is opt-in; existing invocations behave identically.
+- To use Prompt 3, pull the updated `PROMPTS.md` from the kit — the prompt is self-contained and doesn't require any memory or template changes in your project.
+
+---
+
 ## 2026-04-23 — More tracker variants
 
 **Tag:** [v0.5.0](https://github.com/IamMrCupp/claude-project-kit/releases/tag/v0.5.0)

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -74,6 +74,44 @@ confused. Don't make changes yet — align on direction first.
 
 ---
 
+## 3. Wrapping up a session
+
+Use this at the end of a session to apply the end-of-session hygiene from [SETUP.md §7](SETUP.md). It takes stock of what actually happened and drafts the updates for your review — it does **not** edit the working folder autonomously.
+
+```
+We're wrapping up this session. Help me apply the end-of-session hygiene.
+Do NOT edit any files yet — draft everything, show me, and wait for my
+confirmation before writing anything.
+
+1. Draft a SESSION-LOG.md entry for today:
+   - Date (YYYY-MM-DD)
+   - 1-line focus
+   - Branches touched / PRs opened, merged, or still open (with numbers)
+   - Decisions, rule changes, or gotchas worth recording for next session
+   - Open threads ("what we'd pick up next time")
+
+2. Suggest whether CONTEXT.md's "Current Phase Status" line needs a bump,
+   based on what changed this session. If so, propose the new wording.
+
+3. Scan the current phase-<N>-checklist.md:
+   - Flag items that landed this session but aren't yet ticked
+   - Flag ticked items missing a branch or PR number
+
+4. Flag any preference or rule that came up more than once this session —
+   those are candidates for a new feedback_*.md memory file. Draft the
+   feedback entry if applicable.
+
+Show me each of these as a separate section. I'll confirm each before
+anything is written.
+```
+
+**Notes:**
+- If `reference_ai_working_folder.md` is set up in auto-memory, Claude already knows where the working folder lives. Otherwise prefix with: *"Working folder is `<path>`."*
+- The "draft first, don't write" guard is load-bearing — session-end updates are easy to get wrong (overzealous status bumps, hallucinated PR numbers), and reviewing is faster than undoing.
+- For a bare-minimum wrap-up (no checklist or memory review), the one-liner *"Draft a SESSION-LOG.md entry for today and show it to me"* is usually enough.
+
+---
+
 ## When to write a new prompt
 
 Add one here whenever you find yourself typing similar setup instructions into a fresh session for the third time. A good prompt is:

--- a/SETUP.md
+++ b/SETUP.md
@@ -57,6 +57,7 @@ Flags:
 - `--jira-project KEY` — JIRA project key (e.g. `INFRA`). Implies `--tracker jira` if `--tracker` isn't also passed.
 - `--linear-team KEY` — Linear team key (e.g. `ENG`). Implies `--tracker linear` if `--tracker` isn't also passed.
 - `--force` — proceed even if the working folder is already non-empty
+- `--dry-run` — print what would be created (paths, placeholder substitutions, tracker memory, MEMORY.md index line) and exit without writing anything. Safe to re-run.
 - `-h` / `--help` — show usage
 
 Prefer to see what's happening step-by-step? See [Manual alternative](#manual-alternative) at the bottom of this doc.
@@ -139,6 +140,8 @@ Every working session should end with:
 4. Auto-memory refreshed — if a rule came up twice, save it as feedback
 
 The habit that makes this work: the **last thing you do** before quitting is update these docs. It takes two minutes and rescues the next session from "where was I?"
+
+For a scaffolded version of this pass, paste **Prompt 3 ("Wrapping up a session")** from [PROMPTS.md](PROMPTS.md). It has Claude draft all four items and stop for your review before writing anything — easier than remembering each piece by hand.
 
 ---
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -53,6 +53,10 @@ Options:
                      and is non-empty. Does NOT override the auto-memory
                      safety check — existing memory files are never
                      overwritten.
+  --dry-run          Print what would be created (paths, placeholder
+                     substitutions, tracker memory, MEMORY.md index
+                     line) and exit without writing anything. Safe to
+                     run repeatedly to preview config before committing.
   -h, --help         Show this help and exit.
 
 Examples:
@@ -73,6 +77,7 @@ EOF
 
 SKIP_MEMORY=0
 FORCE=0
+DRY_RUN=0
 WORKING_FOLDER=""
 PROJECT_NAME=""
 TRACKER=""
@@ -83,6 +88,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --skip-memory) SKIP_MEMORY=1; shift ;;
     --force) FORCE=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
     --project-name)
       if [ $# -lt 2 ]; then
         echo "error: --project-name requires a value" >&2
@@ -267,6 +273,49 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
   fi
 fi
 echo
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "=== DRY RUN — no files will be written ==="
+  echo
+  echo "Would create working folder: $WORKING_FOLDER"
+  echo "  + copy $KIT_ROOT/templates/*.md"
+  echo "  + rename phase-N-checklist.md → phase-0-checklist.md"
+  if [ -e "$WORKING_FOLDER" ] && [ -n "$(ls -A "$WORKING_FOLDER" 2>/dev/null)" ] && [ "$FORCE" -eq 0 ]; then
+    echo "  ! working folder already non-empty — real run would fail without --force"
+  fi
+  echo
+  if [ "$SKIP_MEMORY" -eq 0 ]; then
+    echo "Would create memory folder: $MEMORY_DIR"
+    echo "  + copy $KIT_ROOT/memory-templates/*.md"
+    if [ -n "$TRACKER" ] && [ "$TRACKER" != "none" ]; then
+      echo "  + copy memory-templates/trackers/$TRACKER.md → reference_issue_tracker.md"
+      echo "  + append index line to MEMORY.md"
+    fi
+    echo "  + substitute placeholders:"
+    echo "      {{WORKING_FOLDER}}    → $WORKING_FOLDER"
+    echo "      {{REPO_PATH}}         → $REPO_ROOT"
+    echo "      {{PROJECT_NAME}}      → $PROJECT_NAME"
+    if [ -n "$REPO_SLUG" ]; then
+      echo "      {{REPO_SLUG}}         → $REPO_SLUG"
+    else
+      echo "      {{REPO_SLUG}}         → (not set — no git remote 'origin')"
+    fi
+    if [ -n "$JIRA_PROJECT_KEY" ]; then
+      echo "      {{JIRA_PROJECT_KEY}}  → $JIRA_PROJECT_KEY"
+    fi
+    if [ -n "$LINEAR_TEAM_KEY" ]; then
+      echo "      {{LINEAR_TEAM_KEY}}   → $LINEAR_TEAM_KEY"
+    fi
+    if [ -d "$MEMORY_DIR" ] && [ -n "$(ls -A "$MEMORY_DIR" 2>/dev/null)" ]; then
+      echo "  ! memory folder already non-empty — real run would fail (never overwrites memory)"
+    fi
+  else
+    echo "Memory seeding skipped (--skip-memory)."
+  fi
+  echo
+  echo "No changes made. Re-run without --dry-run to apply."
+  exit 0
+fi
 
 if [ "$INTERACTIVE" -eq 1 ]; then
   read -r -p "Proceed? [Y/n]: " INPUT


### PR DESCRIPTION
## Summary
- `PROMPTS.md` — new **Prompt 3: Wrapping up a session**. Scaffolds the end-of-session hygiene from `SETUP.md §7`: drafts a `SESSION-LOG.md` entry, suggests `CONTEXT.md` status-line updates, flags checklist items missing PR numbers, surfaces memory candidates — all in draft form, waiting on confirmation before writing.
- `bootstrap.sh --dry-run` — preview every action (paths, placeholder substitutions, tracker memory copy, MEMORY.md index append) and exit without writing anything. Safe to re-run; useful for verifying flag combos before committing.
- `SETUP.md §7` — pointer to Prompt 3. `SETUP.md §2` flag list gets `--dry-run`.

## Motivation
Two friction points from real session work:
1. **End-of-session hygiene** is easy to forget or do incompletely. Scaffolding it as a prompt makes it one paste away and enforces the "draft first, write after confirmation" discipline that keeps Claude from hallucinating PR numbers or overzealous status bumps.
2. **Flag-combo debugging** with bootstrap was trial-and-error. `--dry-run` lets you see exactly what `--tracker jira --jira-project INFRA --project-name foo` would produce without actually committing.

## Design notes
- **Prompt 3 is draft-only.** The first line of the prompt body is "Do NOT edit any files yet — draft everything, show me, and wait for my confirmation before writing anything." This matches how Prompt 1 treats the working folder as read-only on load.
- **`--dry-run` includes sanity warnings.** If the working folder is already non-empty (needs `--force`) or the memory folder has existing files (real run would fail), the dry-run calls that out so the user can fix before a real invocation.
- **`--dry-run` skips the `Proceed?` interactive prompt.** Dry-run is purely informational — no confirmation needed.

## Test plan
- [x] `bash -n bootstrap.sh` — syntax OK.
- [x] `--dry-run --tracker linear --linear-team ENG /tmp/wf` — prints full plan including `{{LINEAR_TEAM_KEY}}` substitution; no working folder or memory folder created post-run.
- [ ] `--dry-run` with a non-empty working folder — emits the "real run would fail without --force" warning.
- [ ] `--dry-run` with a non-empty memory folder — emits the "real run would fail (never overwrites memory)" warning.
- [ ] Paste Prompt 3 at end of a real session — Claude drafts all four sections and stops before writing.

## CHANGELOG
v0.6.0 — minor bump (new prompt + new flag, backward-compatible). Entry included in this PR.