### PR TITLE
feat(bootstrap): add CI/automation reference memory variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ See [Upgrading an existing project](SETUP.md#upgrading-an-existing-project) for 
 
 ---
 
+## 2026-04-24 — CI/automation reference memory
+
+**Tag:** [v0.7.0](https://github.com/IamMrCupp/claude-project-kit/releases/tag/v0.7.0)
+
+### Added
+- `memory-templates/ci/` — seven reference-memory variants describing how Claude should interact with each CI/automation platform: `github-actions.md`, `gitlab-ci.md`, `jenkins.md`, `circleci.md`, `atlantis.md`, `ansible-cli.md`, `other.md`. Each documents the CLI of record, log-fetching patterns, and conventions specific to that tool (e.g. Atlantis's PR-comment model, Ansible's local operator discipline). ([#18](https://github.com/IamMrCupp/claude-project-kit/pull/18))
+- `bootstrap.sh --ci TYPE` — new flag. Seeds `reference_ci.md` into the project's auto-memory from the selected variant and appends an index line to `MEMORY.md`. ([#18](https://github.com/IamMrCupp/claude-project-kit/pull/18))
+- Interactive mode now prompts for CI/automation tool after the tracker prompt (default `none`). ([#18](https://github.com/IamMrCupp/claude-project-kit/pull/18))
+- `bootstrap.sh --dry-run` output includes the CI reference copy in the plan. ([#18](https://github.com/IamMrCupp/claude-project-kit/pull/18))
+
+### Changed
+- This release replaces the originally-planned CI *workflow* starters (ship `test.yml` / `lint.yml` scaffolds). Workflow starters fit too narrow a slice of real CI landscapes (Jenkins, CircleCI, Atlantis, Ansible CLI, etc. all bypassed) and duplicated thin scaffolds adopters already know how to write. Reference-memory variants scale across all of them and teach Claude *how to interact with* the chosen tool instead. ([#18](https://github.com/IamMrCupp/claude-project-kit/pull/18))
+
+### For existing adopters
+- No breaking changes. Non-interactive invocations without `--ci` behave identically — no CI reference file is seeded.
+- To add CI awareness to an already-bootstrapped project, copy `memory-templates/ci/<TYPE>.md` from the kit into your project's auto-memory folder as `reference_ci.md` and add a line referencing it in your `MEMORY.md`.
+
+---
+
 ## 2026-04-23 — End-of-session prompt and `--dry-run`
 
 **Tag:** [v0.6.0](https://github.com/IamMrCupp/claude-project-kit/releases/tag/v0.6.0)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ The working folder is project-specific knowledge ("what are we building, how far
     ├── feedback_*.md        ← rules & preferences (commits, PRs, CI, etc.)
     ├── project_*.md         ← project context
     ├── reference_*.md       ← external pointers (working folder, etc.)
-    └── trackers/            ← per-tracker reference memory (github / jira / linear / gitlab / shortcut / other)
+    ├── trackers/            ← per-tracker reference memory (github / jira / linear / gitlab / shortcut / other)
+    └── ci/                  ← per-CI reference memory (github-actions / gitlab-ci / jenkins / circleci / atlantis / ansible-cli / other)
 ```
 
 ## How to use (new or existing project)
@@ -66,8 +67,8 @@ Works the same for greenfield repos and ones you're adopting it on mid-stream �
 1. Read [SETUP.md](SETUP.md) — it walks you through the full bootstrap in ~10 minutes.
 2. Pick a private working folder location (e.g. `~/Documents/Claude/Projects/<Project Name>/`).
 3. From your target repo root, run `bootstrap.sh` — either of:
-   - **Interactive (hand-held):** `bootstrap.sh` with no arguments prompts for working-folder path, project name, whether to seed auto-memory, and your issue tracker (GitHub Issues / JIRA / Linear / GitLab / Shortcut / other / none). For JIRA and Linear, it also prompts for the project or team key.
-   - **Non-interactive (scripted):** `bootstrap.sh <working-folder> [--tracker TYPE] [--jira-project KEY | --linear-team KEY]` — see `bootstrap.sh -h` for the full flag list.
+   - **Interactive (hand-held):** `bootstrap.sh` with no arguments prompts for working-folder path, project name, whether to seed auto-memory, your issue tracker (GitHub Issues / JIRA / Linear / GitLab / Shortcut / other / none), and your primary CI/automation tool (GitHub Actions / GitLab CI / Jenkins / CircleCI / Atlantis / Ansible CLI / other / none). For JIRA and Linear, it also prompts for the project or team key.
+   - **Non-interactive (scripted):** `bootstrap.sh <working-folder> [--tracker TYPE] [--jira-project KEY | --linear-team KEY] [--ci TYPE]` — see `bootstrap.sh -h` for the full flag list.
 4. Open Claude Code in the target repo and say *"Follow the instructions in `<working-folder>/SEED-PROMPT.md`."* Claude deep-reads your repo, fills the templates, flags anything it inferred or can't derive, and stops for your review.
 5. Answer Claude's questions, confirm the inferences, and start working. The normal per-session prompt lives in [PROMPTS.md](PROMPTS.md).
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -46,7 +46,7 @@ cd <project-repo>
 cd <project-repo>
 <framework-dir>/bootstrap.sh
 ```
-Bootstrap prompts for the working-folder path, project name, whether to seed auto-memory, and your issue tracker (`github` / `jira` / `linear` / `gitlab` / `shortcut` / `other` / `none`, default `github`). For `jira` and `linear`, it also prompts for the project/team key. It then shows a summary and asks to confirm before any file writes. Scripted invocations (piped/redirected stdin) without a path argument still error rather than hanging.
+Bootstrap prompts for the working-folder path, project name, whether to seed auto-memory, your issue tracker (`github` / `jira` / `linear` / `gitlab` / `shortcut` / `other` / `none`, default `github`), and your primary CI/automation tool (`github-actions` / `gitlab-ci` / `jenkins` / `circleci` / `atlantis` / `ansible-cli` / `other` / `none`, default `none`). For `jira` and `linear`, it also prompts for the project/team key. It then shows a summary and asks to confirm before any file writes. Scripted invocations (piped/redirected stdin) without a path argument still error rather than hanging.
 
 Both modes create the working folder, copy the templates, rename `phase-N-checklist.md` → `phase-0-checklist.md`, and seed the project's auto-memory at the Claude harness's expected path (`~/.claude/projects/<sanitized>/memory/`). When an issue tracker is selected, a `reference_issue_tracker.md` file is seeded into auto-memory with tracker-specific guidance.
 
@@ -56,6 +56,7 @@ Flags:
 - `--tracker TYPE` — issue tracker: `github`, `jira`, `linear`, `gitlab`, `shortcut`, `other`, or `none`. Skipped if omitted in non-interactive mode.
 - `--jira-project KEY` — JIRA project key (e.g. `INFRA`). Implies `--tracker jira` if `--tracker` isn't also passed.
 - `--linear-team KEY` — Linear team key (e.g. `ENG`). Implies `--tracker linear` if `--tracker` isn't also passed.
+- `--ci TYPE` — primary CI/automation tool: `github-actions`, `gitlab-ci`, `jenkins`, `circleci`, `atlantis`, `ansible-cli`, `other`, or `none`. Skipped if omitted in non-interactive mode.
 - `--force` — proceed even if the working folder is already non-empty
 - `--dry-run` — print what would be created (paths, placeholder substitutions, tracker memory, MEMORY.md index line) and exit without writing anything. Safe to re-run.
 - `-h` / `--help` — show usage

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -49,6 +49,11 @@ Options:
                      --tracker jira if --tracker isn't also passed.
   --linear-team KEY  Set the Linear team key (e.g. ENG). Implies
                      --tracker linear if --tracker isn't also passed.
+  --ci TYPE          Primary CI/automation tool: github-actions,
+                     gitlab-ci, jenkins, circleci, atlantis, ansible-cli,
+                     other, or none. Seeds a tool-specific reference_ci.md
+                     into the project's auto-memory. If omitted in non-
+                     interactive mode, CI-reference setup is skipped.
   --force            Proceed even if the working folder already exists
                      and is non-empty. Does NOT override the auto-memory
                      safety check — existing memory files are never
@@ -83,6 +88,7 @@ PROJECT_NAME=""
 TRACKER=""
 JIRA_PROJECT_KEY=""
 LINEAR_TEAM_KEY=""
+CI_TOOL=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -125,6 +131,15 @@ while [ $# -gt 0 ]; do
       LINEAR_TEAM_KEY="$2"
       shift 2
       ;;
+    --ci)
+      if [ $# -lt 2 ]; then
+        echo "error: --ci requires a value (github-actions|gitlab-ci|jenkins|circleci|atlantis|ansible-cli|other|none)" >&2
+        usage >&2
+        exit 2
+      fi
+      CI_TOOL="$2"
+      shift 2
+      ;;
     -h|--help) usage; exit 0 ;;
     --*) echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
     *)
@@ -160,6 +175,11 @@ if [ "$TRACKER" = "linear" ] && [ -z "$LINEAR_TEAM_KEY" ] && [ ! -t 0 ]; then
   echo "error: --tracker linear requires --linear-team <KEY> in non-interactive mode" >&2
   exit 2
 fi
+
+case "$CI_TOOL" in
+  ""|github-actions|gitlab-ci|jenkins|circleci|atlantis|ansible-cli|other|none) ;;
+  *) echo "error: --ci must be one of: github-actions, gitlab-ci, jenkins, circleci, atlantis, ansible-cli, other, none (got: $CI_TOOL)" >&2; exit 2 ;;
+esac
 
 INTERACTIVE=0
 if [ -z "$WORKING_FOLDER" ]; then
@@ -248,6 +268,16 @@ if [ "$INTERACTIVE" -eq 1 ]; then
       fi
     fi
   fi
+
+  if [ "$SKIP_MEMORY" -eq 0 ] && [ -z "$CI_TOOL" ]; then
+    read -r -p "Primary CI/automation tool? [github-actions/gitlab-ci/jenkins/circleci/atlantis/ansible-cli/other/none, default none]: " INPUT
+    CI_TOOL="$(printf '%s' "$INPUT" | tr '[:upper:]' '[:lower:]')"
+    CI_TOOL="${CI_TOOL:-none}"
+    case "$CI_TOOL" in
+      github-actions|gitlab-ci|jenkins|circleci|atlantis|ansible-cli|other|none) ;;
+      *) echo "error: invalid CI tool: $CI_TOOL" >&2; exit 2 ;;
+    esac
+  fi
 fi
 
 REPO_SLUG=""
@@ -271,6 +301,9 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
       *)      echo "Issue tracker:  $TRACKER" ;;
     esac
   fi
+  if [ -n "$CI_TOOL" ] && [ "$CI_TOOL" != "none" ]; then
+    echo "CI / automation: $CI_TOOL"
+  fi
 fi
 echo
 
@@ -289,6 +322,10 @@ if [ "$DRY_RUN" -eq 1 ]; then
     echo "  + copy $KIT_ROOT/memory-templates/*.md"
     if [ -n "$TRACKER" ] && [ "$TRACKER" != "none" ]; then
       echo "  + copy memory-templates/trackers/$TRACKER.md → reference_issue_tracker.md"
+      echo "  + append index line to MEMORY.md"
+    fi
+    if [ -n "$CI_TOOL" ] && [ "$CI_TOOL" != "none" ]; then
+      echo "  + copy memory-templates/ci/$CI_TOOL.md → reference_ci.md"
       echo "  + append index line to MEMORY.md"
     fi
     echo "  + substitute placeholders:"
@@ -378,6 +415,28 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
     echo "  ✓ Seeded tracker memory ($TRACKER) → reference_issue_tracker.md"
   fi
 
+  if [ -n "$CI_TOOL" ] && [ "$CI_TOOL" != "none" ]; then
+    CI_SRC="$KIT_ROOT/memory-templates/ci/$CI_TOOL.md"
+    if [ ! -f "$CI_SRC" ]; then
+      echo "error: CI template not found: $CI_SRC" >&2
+      exit 1
+    fi
+    cp "$CI_SRC" "$MEMORY_DIR/reference_ci.md"
+    {
+      printf -- '- [CI / automation for %s](reference_ci.md) — ' "$PROJECT_NAME"
+      case "$CI_TOOL" in
+        github-actions) printf 'CI runs on GitHub Actions (`gh run` CLI)\n' ;;
+        gitlab-ci)      printf 'CI runs on GitLab CI/CD (`glab ci` CLI)\n' ;;
+        jenkins)        printf 'CI runs on Jenkins (host + job names documented in CONTEXT.md)\n' ;;
+        circleci)       printf 'CI runs on CircleCI (`circleci` CLI)\n' ;;
+        atlantis)       printf 'Terraform automation via Atlantis (PR-comment driven)\n' ;;
+        ansible-cli)    printf 'automation via local `ansible-playbook` runs\n' ;;
+        other)          printf 'CI/automation tool — fill in the placeholders\n' ;;
+      esac
+    } >> "$MEMORY_DIR/MEMORY.md"
+    echo "  ✓ Seeded CI memory ($CI_TOOL) → reference_ci.md"
+  fi
+
   FILLED_FILES=0
   for f in "$MEMORY_DIR"/*.md; do
     tmp="$(mktemp)"
@@ -433,6 +492,10 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
   if [ "$TRACKER" = "other" ]; then
     echo "     Also fill in the {{placeholders}} in reference_issue_tracker.md"
     echo "     — the 'other' tracker template needs your specifics."
+  fi
+  if [ "$CI_TOOL" = "other" ]; then
+    echo "     Also fill in the {{placeholders}} in reference_ci.md"
+    echo "     — the 'other' CI template needs your specifics."
   fi
 else
   echo "  3. Memory was skipped (--skip-memory). See SETUP.md §Manual alternative"

--- a/memory-templates/ci/ansible-cli.md
+++ b/memory-templates/ci/ansible-cli.md
@@ -1,0 +1,22 @@
+---
+name: Automation for {{PROJECT_NAME}} — Ansible (CLI)
+description: This project uses Ansible via the local CLI (`ansible-playbook`) rather than CI-driven runs.
+type: reference
+---
+
+**{{PROJECT_NAME}}** uses **Ansible** via the local CLI for automation runs.
+
+- **Primary command:** `ansible-playbook <playbook>.yml` with inventory, limit, and tag flags as needed.
+- **Inventory:** typically `inventory/` or `hosts.yml` at repo root (check `ansible.cfg` for the default inventory path).
+- **Vault:** `ansible-vault` for encrypted secrets. Vault password typically supplied via `--ask-vault-pass`, `--vault-password-file`, or the `ANSIBLE_VAULT_PASSWORD_FILE` env var.
+- **Dry-run:** `--check` for dry-run, `--diff` for showing file diffs that would be applied. Combine them for maximum preview.
+- **Targeting:** `-l <host-pattern>` to limit to specific hosts; `-t <tag>` for specific tagged tasks.
+
+**Why:** CI-driven Ansible exists but this project runs it locally — the operator is the point of coordination. This means change control happens at the terminal, not in a PR dashboard. Safety hinges on discipline (use `--check`, review `--diff`, narrow scope with `-l` and `-t`).
+
+**How to apply:**
+- Before suggesting an `ansible-playbook` invocation that touches real hosts, propose the full command and show what `-l` / `-t` will constrain it to. Never shell out to a live playbook run without explicit user confirmation.
+- Default to `--check --diff` for the first preview of any change. Only then propose the actual run.
+- If the user asks "did it work," ask for the output of the previous run rather than guessing based on the playbook contents.
+- Vault secrets never appear in commit messages, SESSION-LOG, or this memory — they're operator-local.
+- Document any nonstandard inventory layout, role dependencies, or pre-run steps (e.g. `ansible-galaxy install`) in `CONTEXT.md`.

--- a/memory-templates/ci/atlantis.md
+++ b/memory-templates/ci/atlantis.md
@@ -1,0 +1,21 @@
+---
+name: Automation for {{PROJECT_NAME}} — Atlantis (Terraform)
+description: This project uses Atlantis for Terraform plan/apply on PRs. Interaction is via PR comments, not a traditional CI dashboard.
+type: reference
+---
+
+**{{PROJECT_NAME}}** uses **Atlantis** for Terraform automation.
+
+- **Interaction model:** PR-comment driven. `atlantis plan` comments produce plan output on the PR; `atlantis apply` applies after approval.
+- **Config:** `atlantis.yaml` at repo root (optional — Atlantis auto-discovers Terraform directories if absent).
+- **Workflow:** open PR → Atlantis auto-plans (or wait for `atlantis plan` comment) → reviewer approves the plan output → `atlantis apply` comment runs the apply → Atlantis auto-merges (if configured) or leaves the PR for human merge.
+- **Locking:** Atlantis locks a workspace during plan/apply; competing PRs wait. Long-running applies can block other work.
+
+**Why:** Atlantis bridges Terraform and PR review, so the PR IS the deploy interface. Treating it like normal CI (looking at a dashboard) misses the point — the plan output on the PR is the artifact.
+
+**How to apply:**
+- When reviewing a Terraform PR, the plan comment is load-bearing: read it carefully. `+/-/~` counts aren't enough; specific resource changes matter.
+- Never suggest `atlantis apply` without an approval already landed — Atlantis enforces this, but propose the right sequence.
+- If a PR's plan is stale (pushed new commits since), re-run `atlantis plan` to regenerate before any approval judgments.
+- Workspace locks are real — if a plan says "locked by PR #42," coordinate with that PR's owner instead of force-unlocking.
+- For multi-workspace repos, understand which workspaces are in scope for the PR before commenting; `atlantis.yaml`'s `projects:` block defines this.

--- a/memory-templates/ci/circleci.md
+++ b/memory-templates/ci/circleci.md
@@ -1,0 +1,21 @@
+---
+name: CI for {{PROJECT_NAME}} — CircleCI
+description: This project runs CI on CircleCI. Pipeline config is `.circleci/config.yml`; `circleci` is the CLI of record.
+type: reference
+---
+
+**{{PROJECT_NAME}}** runs CI on **CircleCI**.
+
+- **Pipeline config:** `.circleci/config.yml` at repo root.
+- **CLI:** `circleci` (`circleci local execute` runs a job locally; `circleci config validate` catches YAML errors; `circleci api` hits the REST endpoints for run/job inspection).
+- **Orbs:** reusable config packages — check the `orbs:` block in `config.yml` for what the project depends on.
+- **Contexts:** org-wide secret buckets (`circleci context list`). Jobs reference contexts via the `context:` key; understanding which context a job uses is often the first step when debugging auth failures.
+- **Workflows vs jobs:** a workflow orchestrates jobs; a pipeline triggers one or more workflows. CircleCI surfaces all three in the UI; disambiguate when reporting status.
+
+**Why:** CircleCI's config is terse and orb-heavy, so understanding what a job depends on often means chasing orb definitions. The CLI's `config validate` catches most YAML/schema issues before a push.
+
+**How to apply:**
+- Before pushing a `.circleci/config.yml` change, run `circleci config validate` — saves a roundtrip.
+- On failure, fetch the job step output via the CircleCI API; the UI is slower to load than the API.
+- If the project uses approval jobs (manual gates), note them in `CONTEXT.md` so Claude doesn't expect a fully green pipeline on first push.
+- Orb version pins matter — if a job starts failing with no config change, check whether an unpinned orb auto-updated.

--- a/memory-templates/ci/github-actions.md
+++ b/memory-templates/ci/github-actions.md
@@ -1,0 +1,20 @@
+---
+name: CI for {{PROJECT_NAME}} — GitHub Actions
+description: This project runs CI on GitHub Actions. Workflows live at `.github/workflows/`; `gh run` is the CLI of record.
+type: reference
+---
+
+**{{PROJECT_NAME}}** runs CI on **GitHub Actions**.
+
+- **Workflow files:** `.github/workflows/*.yml` in the repo.
+- **CLI:** `gh run` for inspection (`gh run list`, `gh run view <id>`, `gh run watch <id>`).
+- **Logs:** `gh run view <id> --log` for full output; `--log-failed` for just the failing steps.
+- **Secrets:** repo-level at *Settings → Secrets and variables → Actions*; org-level inherited for org-owned repos.
+
+**Why:** standardizing on `gh run` (rather than the web UI) keeps CI observation scriptable and surfaces enough detail inline that Claude doesn't have to ask the user to paste logs.
+
+**How to apply:**
+- After pushing a branch that should trigger CI, wait ~5s for the run to register, then fire `gh run watch` in the background so the completion pings the session. Don't poll.
+- On CI failure, fetch `gh run view <id> --log-failed` first — scope to the failing steps before reading the whole log.
+- Never re-run workflows blindly to "fix" a flake. Identify the root cause or flag the flake explicitly in the SESSION-LOG.
+- When opening a PR, rely on `gh pr checks` to see required checks at a glance.

--- a/memory-templates/ci/gitlab-ci.md
+++ b/memory-templates/ci/gitlab-ci.md
@@ -1,0 +1,21 @@
+---
+name: CI for {{PROJECT_NAME}} — GitLab CI
+description: This project runs CI on GitLab CI/CD. Pipeline config is `.gitlab-ci.yml`; `glab ci` is the CLI of record.
+type: reference
+---
+
+**{{PROJECT_NAME}}** runs CI on **GitLab CI/CD**.
+
+- **Pipeline config:** `.gitlab-ci.yml` at the repo root (includes may fan out to other files).
+- **CLI:** `glab ci` (`glab ci list`, `glab ci view <pipeline-id>`, `glab ci watch`). `glab ci trace` streams job logs.
+- **Jobs vs pipelines:** a pipeline is a collection of jobs; always disambiguate. A job ID is different from a pipeline ID — specify which you're fetching.
+- **Variables:** pipeline/job variables at *Settings → CI/CD → Variables*; group-level variables inherited.
+- **Runners:** shared vs group vs project runners; check `.gitlab-ci.yml` tags to know which runner pool a job targets.
+
+**Why:** GitLab's CI conflates "pipeline" and "job" in several UI spots, and the CLI is less familiar than `gh run`. Being explicit about which layer you're inspecting prevents confusion.
+
+**How to apply:**
+- After pushing, wait ~5s then fire `glab ci watch` in the background so the pipeline outcome pings the session.
+- On failure, identify the failing **job** (not pipeline) and fetch `glab ci trace <job-id>` for its log specifically.
+- MR pipelines are different from branch pipelines — confirm which the user is asking about before fetching.
+- Don't retry jobs to mask flakes; flag them in the SESSION-LOG.

--- a/memory-templates/ci/jenkins.md
+++ b/memory-templates/ci/jenkins.md
@@ -1,0 +1,20 @@
+---
+name: CI for {{PROJECT_NAME}} — Jenkins
+description: This project runs CI on Jenkins. Job config lives in the Jenkins UI or a `Jenkinsfile` in the repo.
+type: reference
+---
+
+**{{PROJECT_NAME}}** runs CI on **Jenkins**.
+
+- **Pipeline config:** `Jenkinsfile` at repo root (declarative or scripted). Some projects configure jobs entirely in the Jenkins UI — if so, document the job names in `CONTEXT.md`.
+- **Access:** Jenkins host URL should be noted in `CONTEXT.md` (not this memory file — hosts change per deployment).
+- **CLI:** `jenkins-cli.jar` can trigger builds and fetch logs, but availability depends on how the Jenkins instance is configured. Many orgs restrict CLI access; fall back to the web UI or Jenkins API.
+- **API:** `<JENKINS_URL>/job/<name>/lastBuild/consoleText` for recent log; `<JENKINS_URL>/job/<name>/<N>/api/json` for structured build metadata.
+
+**Why:** Jenkins deployments vary widely (on-prem, cloud, multi-master, plugin-heavy). The memory captures the *conventions* of this project's Jenkins setup so Claude doesn't guess. Adapt specifics to match your deployment.
+
+**How to apply:**
+- Before asking "did CI pass," check `CONTEXT.md` for the Jenkins host + job name for this repo. If missing, ask the user.
+- For log inspection, prefer the API's `consoleText` endpoint over scraping the HTML UI.
+- Jenkins builds are numbered per job (`#42`), not per pipeline. Always include the job name when referencing a build.
+- If the project uses GitHub PR integration (via the Jenkins GitHub plugin), the PR status check links to the Jenkins build — use that link, don't guess the job path.

--- a/memory-templates/ci/other.md
+++ b/memory-templates/ci/other.md
@@ -1,0 +1,19 @@
+---
+name: CI/automation for {{PROJECT_NAME}}
+description: This project uses a CI or automation tool that isn't covered by the kit's named variants — fill in the details below.
+type: reference
+---
+
+**{{PROJECT_NAME}}** uses: **{{describe the CI/automation tool — e.g. Buildkite, Drone, TeamCity, Spinnaker, custom runners}}**
+
+- **Config location:** {{e.g. `.buildkite/pipeline.yml`, `.drone.yml`, `teamcity/` in VCS root}}
+- **Access:** {{URL / host / org info — or "see CONTEXT.md" if it's documented there}}
+- **CLI or API:** {{command used to inspect runs / trigger builds, e.g. `buildkite-agent`, `drone build`}}
+- **Secret/credential store:** {{where secrets live; how they're injected into jobs}}
+
+**Why:** the project uses a CI or automation system that isn't GitHub Actions, GitLab CI, Jenkins, CircleCI, Atlantis, or local Ansible. Without this reference, Claude has no way to know the naming or lookup conventions.
+
+**How to apply:**
+- Fill in the placeholders above before relying on this memory.
+- Add a `How to apply:` section with the patterns you actually use: how you watch runs, how you fetch failing logs, how you reference a build (`#NNN` vs `build-NNN` vs URL), and whether the user expects Claude to kick off runs or just interpret their output.
+- If a dedicated MCP server exists for this CI/automation tool, note it here — Claude will use it for lookups when connected.


### PR DESCRIPTION
## Summary
- `memory-templates/ci/` — seven reference-memory variants: `github-actions.md`, `gitlab-ci.md`, `jenkins.md`, `circleci.md`, `atlantis.md`, `ansible-cli.md`, `other.md`.
- `bootstrap.sh --ci TYPE` — new flag mirroring the `--tracker` pattern. Interactive mode prompts for CI/automation tool after the tracker prompt (default `none`).
- When a CI tool is selected, bootstrap copies the variant into auto-memory as `reference_ci.md`, appends an index line to `MEMORY.md`, and includes the copy in `--dry-run` output.
- README file tree + "How to use" block updated; SETUP.md §2 flag list updated.
- CHANGELOG v0.7.0 entry.

## Motivation
Originally this slot was going to ship GitHub Actions + GitLab CI *workflow* starters. Pulled that direction after thinking about the real landscape: Jenkins, CircleCI, Atlantis, local ansible-playbook — plus the reality that `test.yml` scaffolds don't save much over a blank file. Instead, this PR ships **reference memory** variants: Claude sessions learn *how to interact with* the project's chosen CI/automation tool (CLI of record, log-fetching patterns, tool-specific conventions like Atlantis's PR-comment model or Ansible's local-operator discipline). Same pattern as the tracker variants from v0.4.0/v0.5.0.

## Design notes
- **Variable naming:** `CI_TOOL` (not `CI`) to avoid shadowing the ubiquitous `CI=true` env var set by most CI systems.
- **Scope is both CI and "CI-adjacent automation."** Atlantis is PR-bot infrastructure; Ansible CLI is local automation with no CI dashboard at all. Both benefit from the same memorized conventions, so they live alongside pure CI systems in `memory-templates/ci/`. The directory name is slightly loose; the content isn't.
- **Variants document CLI + conventions, not YAML scaffolds.** Each ships `{{PROJECT_NAME}}` placeholders (auto-filled by bootstrap) and `How to apply:` rules for Claude sessions — watch patterns, log-fetch commands, anti-patterns to flag.
- **No breaking changes.** `--ci` is optional; existing invocations behave identically.

## Test plan
- [x] `bash -n bootstrap.sh` — syntax OK.
- [x] `--tracker gitlab --ci atlantis /tmp/wf` (combined) — both reference files seeded, MEMORY.md has both index lines, placeholders substituted.
- [ ] `--ci jenkins /tmp/wf` — `reference_ci.md` seeded from `jenkins.md`.
- [ ] `--ci other /tmp/wf` — next-steps message reminds user to fill the `{{placeholders}}`.
- [ ] Interactive mode: pick `circleci` at the CI prompt → file seeded.
- [ ] `--dry-run --ci ansible-cli /tmp/wf` — plan output includes the CI copy line; no files written.

## CHANGELOG
v0.7.0 — minor bump (new flag + new memory variants, backward-compatible). Entry included.