### PR TITLE
test: add bats test suite for bootstrap.sh + fix tilde-expansion bug

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -1,0 +1,33 @@
+name: Bats
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - 'bootstrap.sh'
+      - 'memory-templates/**'
+      - 'templates/**'
+      - 'tests/**'
+      - '.github/workflows/bats.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+
+      - name: Configure git (required by bootstrap.sh + tests)
+        run: |
+          git config --global user.email "bats@example.invalid"
+          git config --global user.name "Bats Test Runner"
+          git config --global init.defaultBranch main
+
+      - name: Run bats suite
+        run: bats tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ See [Upgrading an existing project](SETUP.md#upgrading-an-existing-project) for 
 
 ---
 
+## 2026-04-24 — Bats test suite for `bootstrap.sh`
+
+**Tag:** [v0.8.0](https://github.com/IamMrCupp/claude-project-kit/releases/tag/v0.8.0)
+
+### Added
+- `tests/` — [Bats](https://bats-core.readthedocs.io/) test suite with 61 tests across five files: arg parsing, template + memory seeding, tracker variants, CI variants, `--dry-run` behavior. ([#19](https://github.com/IamMrCupp/claude-project-kit/pull/19))
+- `tests/helpers.bash` — sandboxed-setup helpers that override `HOME` and `cwd` per test so auto-memory writes stay isolated. ([#19](https://github.com/IamMrCupp/claude-project-kit/pull/19))
+- `tests/README.md` — how to run tests locally, what's covered, how to add new tests. ([#19](https://github.com/IamMrCupp/claude-project-kit/pull/19))
+- `.github/workflows/bats.yml` — CI workflow runs the suite on PRs that touch `bootstrap.sh`, `memory-templates/`, `templates/`, or `tests/`. ([#19](https://github.com/IamMrCupp/claude-project-kit/pull/19))
+
+### Fixed
+- `bootstrap.sh` — tilde expansion in the `~/path` working-folder argument was broken: bash's tilde expansion in parameter-expansion word context caused `${WORKING_FOLDER#~/}` to try stripping the expanded `$HOME/` prefix (which doesn't match `~/foo`), leaving the literal `~/` in the path. Fix: quote the pattern — `${WORKING_FOLDER#"~/"}`. Caught by the new test suite. ([#19](https://github.com/IamMrCupp/claude-project-kit/pull/19))
+
+### For existing adopters
+- No runtime changes apart from the tilde fix (which only improves broken behavior — no scripts should have relied on the buggy output).
+- Contributors to the kit itself: run `brew install bats-core` (macOS) or `apt install bats` (Debian/Ubuntu), then `bats tests/` from the kit root.
+
+---
+
 ## 2026-04-24 — CI/automation reference memory
 
 **Tag:** [v0.7.0](https://github.com/IamMrCupp/claude-project-kit/releases/tag/v0.7.0)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -211,7 +211,7 @@ fi
 
 case "$WORKING_FOLDER" in
   "~") WORKING_FOLDER="$HOME" ;;
-  "~/"*) WORKING_FOLDER="$HOME/${WORKING_FOLDER#~/}" ;;
+  "~/"*) WORKING_FOLDER="$HOME/${WORKING_FOLDER#"~/"}" ;;
 esac
 
 case "$WORKING_FOLDER" in

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,70 @@
+# Tests
+
+[Bats](https://bats-core.readthedocs.io/) test suite for `bootstrap.sh`.
+
+## Running locally
+
+Install bats:
+```bash
+# macOS
+brew install bats-core
+
+# Debian/Ubuntu
+sudo apt-get install bats
+
+# Or vendored — see https://bats-core.readthedocs.io/en/stable/installation.html
+```
+
+Run the full suite from the kit root:
+```bash
+bats tests/
+```
+
+Run a single file:
+```bash
+bats tests/bootstrap_args.bats
+```
+
+Run a single test by name (substring match):
+```bash
+bats tests/ -f "tilde"
+```
+
+## Test layout
+
+| File | Covers |
+|---|---|
+| `bootstrap_args.bats` | flag parsing, `--help`, unknown flags, missing values, validation (tracker/CI enums, absolute-path requirement, non-TTY missing-arg) |
+| `bootstrap_memory.bats` | template copy, `phase-N → phase-0` rename, memory seeding, `--skip-memory`, placeholder substitution (`{{PROJECT_NAME}}`, `{{WORKING_FOLDER}}`, `{{REPO_PATH}}`, `{{REPO_SLUG}}`), `--force`, existing-memory safety, tilde expansion |
+| `bootstrap_tracker.bats` | every `--tracker` variant (github/jira/linear/gitlab/shortcut/other/none), `{{JIRA_PROJECT_KEY}}` + `{{LINEAR_TEAM_KEY}}` substitution, `MEMORY.md` index append |
+| `bootstrap_ci.bats` | every `--ci` variant (github-actions/gitlab-ci/jenkins/circleci/atlantis/ansible-cli/other/none), `MEMORY.md` index append, combined `--tracker` + `--ci` |
+| `bootstrap_dry_run.bats` | `--dry-run` plan printout, no-side-effect guarantees, non-empty-folder warnings, `--skip-memory` interaction |
+
+## What's NOT tested
+
+- **Interactive mode** (the `read -p` prompts). Bats runs non-interactively (`[ -t 0 ]` is false), so interactive-mode paths aren't exercised. Manual-test interactive mode when touching those branches. The non-interactive mode error path (missing arg in non-TTY → exit 2) IS tested.
+- **Visual / UX details** of printed output beyond specific substrings the tests assert on.
+
+## Test isolation
+
+Each test runs in a sandboxed temp directory:
+- `HOME` is overridden to a per-test tempdir, so `~/.claude/projects/...` writes don't touch real auto-memory.
+- A fresh `git init` repo is created per test as the target.
+- `teardown()` deletes the temp dir.
+
+See `tests/helpers.bash` for the setup/teardown mechanics.
+
+## Adding a test
+
+1. Pick the file that matches the code path you're touching (or add a new `bootstrap_<topic>.bats`).
+2. Structure:
+   ```bash
+   @test "one-line description of what's asserted" {
+     run "$BOOTSTRAP" <args>
+     [ "$status" -eq 0 ]
+     [[ "$output" == *"expected substring"* ]]
+     [ -f "$TEST_WF/expected-file" ]
+   }
+   ```
+3. Run `bats tests/<file>.bats` to verify.
+4. Commit — CI will run the full suite on PR.

--- a/tests/bootstrap_args.bats
+++ b/tests/bootstrap_args.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# Arg parsing, help text, and CLI validation.
+
+load 'helpers'
+
+setup() { bootstrap_setup; }
+teardown() { bootstrap_teardown; }
+
+@test "--help exits 0 and prints usage" {
+  run "$BOOTSTRAP" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+  [[ "$output" == *"--tracker"* ]]
+  [[ "$output" == *"--ci"* ]]
+  [[ "$output" == *"--dry-run"* ]]
+}
+
+@test "-h exits 0 and prints usage" {
+  run "$BOOTSTRAP" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "unknown flag errors with exit 2" {
+  run "$BOOTSTRAP" --does-not-exist "$TEST_WF"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown option"* ]]
+}
+
+@test "extra positional arg errors with exit 2" {
+  run "$BOOTSTRAP" "$TEST_WF" "$TEST_WF.extra"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unexpected extra argument"* ]]
+}
+
+@test "missing <working-folder> in non-TTY errors with exit 2" {
+  # bats drives the script non-interactively, so no arg should error
+  # rather than prompting.
+  run "$BOOTSTRAP"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"missing <working-folder>"* ]]
+}
+
+@test "--project-name without value errors" {
+  run "$BOOTSTRAP" --project-name
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--project-name requires a value"* ]]
+}
+
+@test "--tracker without value errors" {
+  run "$BOOTSTRAP" --tracker
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--tracker requires a value"* ]]
+}
+
+@test "--jira-project without value errors" {
+  run "$BOOTSTRAP" --jira-project
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--jira-project requires a value"* ]]
+}
+
+@test "--linear-team without value errors" {
+  run "$BOOTSTRAP" --linear-team
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--linear-team requires a value"* ]]
+}
+
+@test "--ci without value errors" {
+  run "$BOOTSTRAP" --ci
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--ci requires a value"* ]]
+}
+
+@test "invalid --tracker value errors" {
+  run "$BOOTSTRAP" --tracker bogus "$TEST_WF"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--tracker must be one of"* ]]
+}
+
+@test "invalid --ci value errors" {
+  run "$BOOTSTRAP" --ci bogus "$TEST_WF"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--ci must be one of"* ]]
+}
+
+@test "relative working-folder path errors" {
+  run "$BOOTSTRAP" relative/path
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"must be an absolute path"* ]]
+}
+
+@test "--tracker jira without --jira-project in non-TTY errors" {
+  run "$BOOTSTRAP" --tracker jira "$TEST_WF"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"requires --jira-project"* ]]
+}
+
+@test "--tracker linear without --linear-team in non-TTY errors" {
+  run "$BOOTSTRAP" --tracker linear "$TEST_WF"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"requires --linear-team"* ]]
+}
+
+@test "--jira-project alone infers --tracker jira" {
+  run "$BOOTSTRAP" --jira-project INFRA "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Issue tracker:  jira (project: INFRA)"* ]]
+}
+
+@test "--linear-team alone infers --tracker linear" {
+  run "$BOOTSTRAP" --linear-team ENG "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Issue tracker:  linear (team: ENG)"* ]]
+}

--- a/tests/bootstrap_ci.bats
+++ b/tests/bootstrap_ci.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# CI/automation variant selection and memory seeding.
+
+load 'helpers'
+
+setup() { bootstrap_setup; }
+teardown() { bootstrap_teardown; }
+
+@test "--ci github-actions seeds reference_ci.md from gha variant" {
+  run "$BOOTSTRAP" --ci github-actions "$TEST_WF"
+  [ "$status" -eq 0 ]
+  local mem
+  mem="$(memory_dir)"
+  [ -f "$mem/reference_ci.md" ]
+  grep -q "GitHub Actions" "$mem/reference_ci.md"
+  grep -q "gh run" "$mem/reference_ci.md"
+}
+
+@test "--ci gitlab-ci seeds gitlab-ci variant" {
+  run "$BOOTSTRAP" --ci gitlab-ci "$TEST_WF"
+  [ "$status" -eq 0 ]
+  local mem
+  mem="$(memory_dir)"
+  [ -f "$mem/reference_ci.md" ]
+  grep -q "GitLab CI" "$mem/reference_ci.md"
+  grep -q "glab ci" "$mem/reference_ci.md"
+}
+
+@test "--ci jenkins seeds jenkins variant" {
+  run "$BOOTSTRAP" --ci jenkins "$TEST_WF"
+  [ "$status" -eq 0 ]
+  local mem
+  mem="$(memory_dir)"
+  [ -f "$mem/reference_ci.md" ]
+  grep -q "Jenkins" "$mem/reference_ci.md"
+  grep -q "Jenkinsfile" "$mem/reference_ci.md"
+}
+
+@test "--ci circleci seeds circleci variant" {
+  run "$BOOTSTRAP" --ci circleci "$TEST_WF"
+  [ "$status" -eq 0 ]
+  local mem
+  mem="$(memory_dir)"
+  [ -f "$mem/reference_ci.md" ]
+  grep -q "CircleCI" "$mem/reference_ci.md"
+  grep -q "circleci" "$mem/reference_ci.md"
+}
+
+@test "--ci atlantis seeds atlantis variant" {
+  run "$BOOTSTRAP" --ci atlantis "$TEST_WF"
+  [ "$status" -eq 0 ]
+  local mem
+  mem="$(memory_dir)"
+  [ -f "$mem/reference_ci.md" ]
+  grep -q "Atlantis" "$mem/reference_ci.md"
+  grep -q "atlantis plan" "$mem/reference_ci.md"
+}
+
+@test "--ci ansible-cli seeds ansible-cli variant" {
+  run "$BOOTSTRAP" --ci ansible-cli "$TEST_WF"
+  [ "$status" -eq 0 ]
+  local mem
+  mem="$(memory_dir)"
+  [ -f "$mem/reference_ci.md" ]
+  grep -q "Ansible" "$mem/reference_ci.md"
+  grep -q "ansible-playbook" "$mem/reference_ci.md"
+}
+
+@test "--ci other seeds placeholder-full variant" {
+  run "$BOOTSTRAP" --ci other "$TEST_WF"
+  [ "$status" -eq 0 ]
+  local mem
+  mem="$(memory_dir)"
+  [ -f "$mem/reference_ci.md" ]
+  grep -q '{{describe the CI' "$mem/reference_ci.md"
+  [[ "$output" == *"Also fill in the {{placeholders}} in reference_ci.md"* ]]
+}
+
+@test "--ci none does not seed reference_ci.md" {
+  run "$BOOTSTRAP" --ci none "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [ ! -f "$(memory_dir)/reference_ci.md" ]
+}
+
+@test "no --ci flag does not seed reference_ci.md" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [ ! -f "$(memory_dir)/reference_ci.md" ]
+}
+
+@test "CI seeding appends a line to MEMORY.md index" {
+  run "$BOOTSTRAP" --ci jenkins "$TEST_WF"
+  [ "$status" -eq 0 ]
+  grep -q "reference_ci.md" "$(memory_dir)/MEMORY.md"
+}
+
+@test "combined --tracker + --ci seeds both reference files" {
+  run "$BOOTSTRAP" --tracker jira --jira-project INFRA --ci atlantis "$TEST_WF"
+  [ "$status" -eq 0 ]
+  local mem
+  mem="$(memory_dir)"
+  [ -f "$mem/reference_issue_tracker.md" ]
+  [ -f "$mem/reference_ci.md" ]
+  grep -q "reference_issue_tracker.md" "$mem/MEMORY.md"
+  grep -q "reference_ci.md" "$mem/MEMORY.md"
+}

--- a/tests/bootstrap_dry_run.bats
+++ b/tests/bootstrap_dry_run.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# --dry-run behavior: plan printout, no filesystem writes.
+
+load 'helpers'
+
+setup() { bootstrap_setup; }
+teardown() { bootstrap_teardown; }
+
+@test "--dry-run exits 0 and prints DRY RUN banner" {
+  run "$BOOTSTRAP" --dry-run "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY RUN"* ]]
+  [[ "$output" == *"No changes made"* ]]
+}
+
+@test "--dry-run creates no working folder" {
+  run "$BOOTSTRAP" --dry-run "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [ ! -d "$TEST_WF" ]
+}
+
+@test "--dry-run creates no memory folder" {
+  run "$BOOTSTRAP" --dry-run "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [ ! -d "$(memory_dir)" ]
+}
+
+@test "--dry-run lists planned placeholder substitutions" {
+  run "$BOOTSTRAP" --dry-run "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"{{WORKING_FOLDER}}"* ]]
+  [[ "$output" == *"{{PROJECT_NAME}}"* ]]
+  [[ "$output" == *"{{REPO_PATH}}"* ]]
+  [[ "$output" == *"{{REPO_SLUG}}"* ]]
+}
+
+@test "--dry-run with --tracker jira mentions key substitution" {
+  run "$BOOTSTRAP" --dry-run --tracker jira --jira-project INFRA "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"{{JIRA_PROJECT_KEY}}"* ]]
+  [[ "$output" == *"INFRA"* ]]
+  [[ "$output" == *"trackers/jira.md"* ]]
+}
+
+@test "--dry-run with --ci mentions the CI variant copy" {
+  run "$BOOTSTRAP" --dry-run --ci atlantis "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ci/atlantis.md"* ]]
+  [[ "$output" == *"reference_ci.md"* ]]
+}
+
+@test "--dry-run flags non-empty working folder as needing --force" {
+  mkdir -p "$TEST_WF"
+  touch "$TEST_WF/existing"
+  run "$BOOTSTRAP" --dry-run "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"real run would fail without --force"* ]]
+}
+
+@test "--dry-run flags non-empty memory folder as blocking real run" {
+  mkdir -p "$(memory_dir)"
+  echo "keep" > "$(memory_dir)/existing.md"
+  run "$BOOTSTRAP" --dry-run "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"real run would fail (never overwrites memory)"* ]]
+}
+
+@test "--dry-run with --skip-memory reports memory skipped" {
+  run "$BOOTSTRAP" --dry-run --skip-memory "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Memory seeding skipped"* ]]
+  # should NOT list memory placeholders
+  [[ "$output" != *"{{WORKING_FOLDER}}    → "* ]]
+}

--- a/tests/bootstrap_memory.bats
+++ b/tests/bootstrap_memory.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+# Working-folder + memory seeding + placeholder substitution.
+
+load 'helpers'
+
+setup() { bootstrap_setup; }
+teardown() { bootstrap_teardown; }
+
+@test "basic run creates working folder with templates" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_WF" ]
+  [ -f "$TEST_WF/CONTEXT.md" ]
+  [ -f "$TEST_WF/SESSION-LOG.md" ]
+  [ -f "$TEST_WF/plan.md" ]
+  [ -f "$TEST_WF/implementation.md" ]
+  [ -f "$TEST_WF/SEED-PROMPT.md" ]
+  [ -f "$TEST_WF/research.md" ]
+  [ -f "$TEST_WF/acceptance-test-results.md" ]
+}
+
+@test "phase-N-checklist.md is renamed to phase-0-checklist.md" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_WF/phase-0-checklist.md" ]
+  [ ! -f "$TEST_WF/phase-N-checklist.md" ]
+}
+
+@test "basic run seeds memory folder with all starter files" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+  local mem
+  mem="$(memory_dir)"
+  [ -d "$mem" ]
+  [ -f "$mem/MEMORY.md" ]
+  [ -f "$mem/user_role.md" ]
+  [ -f "$mem/reference_ai_working_folder.md" ]
+  [ -f "$mem/project_current.md" ]
+}
+
+@test "--skip-memory does not create memory folder" {
+  run "$BOOTSTRAP" --skip-memory "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_WF" ]
+  [ ! -d "$(memory_dir)" ]
+}
+
+@test "placeholder substitution fills {{PROJECT_NAME}}" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+  # default project name = basename of working folder
+  grep -q "$(basename "$TEST_WF")" "$(memory_dir)/reference_ai_working_folder.md"
+  ! grep -q '{{PROJECT_NAME}}' "$(memory_dir)/reference_ai_working_folder.md"
+}
+
+@test "placeholder substitution fills {{WORKING_FOLDER}}" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+  grep -q "$TEST_WF" "$(memory_dir)/reference_ai_working_folder.md"
+  ! grep -q '{{WORKING_FOLDER}}' "$(memory_dir)/reference_ai_working_folder.md"
+}
+
+@test "placeholder substitution fills {{REPO_PATH}}" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+  grep -q "$TEST_REPO" "$(memory_dir)/reference_ai_working_folder.md"
+  ! grep -q '{{REPO_PATH}}' "$(memory_dir)/reference_ai_working_folder.md"
+}
+
+@test "placeholder substitution fills {{REPO_SLUG}} when git remote exists" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+  grep -q "example/test-repo" "$(memory_dir)/project_current.md"
+  ! grep -q '{{REPO_SLUG}}' "$(memory_dir)/project_current.md"
+}
+
+@test "{{REPO_SLUG}} left as placeholder when no git remote" {
+  setup_repo_without_remote
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+  grep -q '{{REPO_SLUG}}' "$(memory_dir)/project_current.md"
+  [[ "$output" == *"no git remote 'origin' found"* ]]
+}
+
+@test "--project-name overrides the auto-derived name" {
+  run "$BOOTSTRAP" --project-name "my-custom-name" "$TEST_WF"
+  [ "$status" -eq 0 ]
+  grep -q "my-custom-name" "$(memory_dir)/reference_ai_working_folder.md"
+}
+
+@test "non-empty working folder errors without --force" {
+  mkdir -p "$TEST_WF"
+  touch "$TEST_WF/existing-file"
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"is not empty"* ]]
+}
+
+@test "--force proceeds past non-empty working folder" {
+  mkdir -p "$TEST_WF"
+  touch "$TEST_WF/existing-file"
+  run "$BOOTSTRAP" --force "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_WF/existing-file" ]
+  [ -f "$TEST_WF/CONTEXT.md" ]
+}
+
+@test "existing non-empty memory folder errors (never overwrites)" {
+  mkdir -p "$(memory_dir)"
+  echo "pre-existing" > "$(memory_dir)/keep.md"
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"already contains files"* ]]
+  [ -f "$(memory_dir)/keep.md" ]
+}
+
+@test "tilde in working-folder expands to HOME" {
+  run "$BOOTSTRAP" "~/test-wf"
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_HOME/test-wf" ]
+  [ -f "$TEST_HOME/test-wf/CONTEXT.md" ]
+}

--- a/tests/bootstrap_tracker.bats
+++ b/tests/bootstrap_tracker.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# Issue-tracker variant selection and memory seeding.
+
+load 'helpers'
+
+setup() { bootstrap_setup; }
+teardown() { bootstrap_teardown; }
+
+@test "--tracker github seeds reference_issue_tracker.md from github variant" {
+  run "$BOOTSTRAP" --tracker github "$TEST_WF"
+  [ "$status" -eq 0 ]
+  local mem
+  mem="$(memory_dir)"
+  [ -f "$mem/reference_issue_tracker.md" ]
+  grep -q "GitHub Issues" "$mem/reference_issue_tracker.md"
+  grep -q "example/test-repo" "$mem/reference_issue_tracker.md"
+}
+
+@test "--tracker jira seeds and substitutes {{JIRA_PROJECT_KEY}}" {
+  run "$BOOTSTRAP" --tracker jira --jira-project INFRA "$TEST_WF"
+  [ "$status" -eq 0 ]
+  local mem
+  mem="$(memory_dir)"
+  [ -f "$mem/reference_issue_tracker.md" ]
+  grep -q "JIRA project \`INFRA\`" "$mem/reference_issue_tracker.md"
+  ! grep -q '{{JIRA_PROJECT_KEY}}' "$mem/reference_issue_tracker.md"
+}
+
+@test "--tracker linear seeds and substitutes {{LINEAR_TEAM_KEY}}" {
+  run "$BOOTSTRAP" --tracker linear --linear-team ENG "$TEST_WF"
+  [ "$status" -eq 0 ]
+  local mem
+  mem="$(memory_dir)"
+  [ -f "$mem/reference_issue_tracker.md" ]
+  grep -q "Linear team \`ENG\`" "$mem/reference_issue_tracker.md"
+  ! grep -q '{{LINEAR_TEAM_KEY}}' "$mem/reference_issue_tracker.md"
+}
+
+@test "--tracker gitlab seeds gitlab variant with repo slug" {
+  run "$BOOTSTRAP" --tracker gitlab "$TEST_WF"
+  [ "$status" -eq 0 ]
+  local mem
+  mem="$(memory_dir)"
+  [ -f "$mem/reference_issue_tracker.md" ]
+  grep -q "GitLab Issues" "$mem/reference_issue_tracker.md"
+  grep -q "example/test-repo" "$mem/reference_issue_tracker.md"
+}
+
+@test "--tracker shortcut seeds shortcut variant" {
+  run "$BOOTSTRAP" --tracker shortcut "$TEST_WF"
+  [ "$status" -eq 0 ]
+  local mem
+  mem="$(memory_dir)"
+  [ -f "$mem/reference_issue_tracker.md" ]
+  grep -q "Shortcut" "$mem/reference_issue_tracker.md"
+  grep -q "sc-" "$mem/reference_issue_tracker.md"
+}
+
+@test "--tracker other seeds placeholder-full variant" {
+  run "$BOOTSTRAP" --tracker other "$TEST_WF"
+  [ "$status" -eq 0 ]
+  local mem
+  mem="$(memory_dir)"
+  [ -f "$mem/reference_issue_tracker.md" ]
+  # "other" variant has intentional {{placeholder}} markers for manual fill
+  grep -q '{{describe the tracker' "$mem/reference_issue_tracker.md"
+  [[ "$output" == *"Also fill in the {{placeholders}} in reference_issue_tracker.md"* ]]
+}
+
+@test "--tracker none does not seed reference_issue_tracker.md" {
+  run "$BOOTSTRAP" --tracker none "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [ ! -f "$(memory_dir)/reference_issue_tracker.md" ]
+}
+
+@test "no --tracker flag does not seed reference_issue_tracker.md" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [ ! -f "$(memory_dir)/reference_issue_tracker.md" ]
+}
+
+@test "tracker seeding appends a line to MEMORY.md index" {
+  run "$BOOTSTRAP" --tracker github "$TEST_WF"
+  [ "$status" -eq 0 ]
+  grep -q "reference_issue_tracker.md" "$(memory_dir)/MEMORY.md"
+}
+
+@test "tracker not seeded — no MEMORY.md index line for it" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+  ! grep -q "reference_issue_tracker.md" "$(memory_dir)/MEMORY.md"
+}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -1,0 +1,44 @@
+# Common setup/teardown and helper functions for bootstrap.sh bats tests.
+#
+# Each test file `load 'helpers'` and then calls `bootstrap_setup` /
+# `bootstrap_teardown` in its own `setup` / `teardown` hooks.
+
+KIT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+BOOTSTRAP="$KIT_ROOT/bootstrap.sh"
+
+# Create an isolated sandbox per test:
+#   TEST_TMP    — temp root (deleted in teardown)
+#   TEST_HOME   — sandboxed $HOME so ~/.claude/projects/... writes don't escape
+#   TEST_REPO   — a fake target repo with `git init` and an origin remote
+#   TEST_WF     — the working-folder path that bootstrap should create
+#
+# After this runs, `cd` is the test repo.
+bootstrap_setup() {
+  TEST_TMP="$(mktemp -d)"
+  TEST_HOME="$TEST_TMP/home"
+  TEST_REPO="$TEST_TMP/repo"
+  TEST_WF="$TEST_TMP/wf"
+  mkdir -p "$TEST_HOME" "$TEST_REPO"
+  git -C "$TEST_REPO" init -q
+  git -C "$TEST_REPO" remote add origin "https://github.com/example/test-repo.git"
+  export HOME="$TEST_HOME"
+  cd "$TEST_REPO"
+}
+
+bootstrap_teardown() {
+  [ -n "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"
+}
+
+# Echo the auto-memory path bootstrap will derive for the current TEST_REPO.
+memory_dir() {
+  local sanitized
+  sanitized="$(echo "$TEST_REPO" | sed 's|/|-|g')"
+  echo "$TEST_HOME/.claude/projects/${sanitized}/memory"
+}
+
+# Create a new fake repo WITHOUT a git remote — useful for testing REPO_SLUG
+# graceful-fallback behavior.
+setup_repo_without_remote() {
+  rm -rf "$TEST_REPO/.git"
+  git -C "$TEST_REPO" init -q
+}


### PR DESCRIPTION
## Summary
- `tests/` — Bats test suite with **61 tests** across five files covering arg parsing, template/memory seeding, tracker variants, CI variants, and `--dry-run` behavior.
- `tests/helpers.bash` — sandboxed per-test setup: overrides `HOME` + `cwd` so auto-memory writes don't touch the real `~/.claude/projects/`.
- `tests/README.md` — run instructions, coverage matrix, how to add tests.
- `.github/workflows/bats.yml` — CI runs the suite on PRs that touch `bootstrap.sh`, `memory-templates/`, `templates/`, or `tests/`.
- **Bug fix:** `bootstrap.sh` tilde expansion was broken for `~/path` arguments — bash's tilde-expansion in parameter-expansion word context caused `${WORKING_FOLDER#~/}` to try stripping `$HOME/` (not `~/`), leaving the literal `~/` in the result. Caught by the new test suite; fix is `${WORKING_FOLDER#"~/"}`.

## Motivation
`bootstrap.sh` has grown to ~290 lines covering interactive mode, tracker variants, CI variants, placeholder substitution, and `--dry-run`. No automated tests existed — regressions would only surface in manual smoke testing. This PR lands a suite that covers every non-interactive code path.

The value materialized immediately: writing the tilde-expansion test uncovered a real bug (see `bootstrap.sh` fix).

## Coverage snapshot

| File | Count | Focus |
|---|---|---|
| `bootstrap_args.bats` | 17 | flag parsing, `--help`, unknowns, validation, inferences (`--jira-project` implies `--tracker jira`) |
| `bootstrap_memory.bats` | 14 | template copy, rename, memory seeding, `--skip-memory`, placeholder substitution, `--force`, existing-memory safety, tilde |
| `bootstrap_tracker.bats` | 10 | every `--tracker` variant, `{{JIRA_PROJECT_KEY}}` + `{{LINEAR_TEAM_KEY}}` substitution, MEMORY.md append |
| `bootstrap_ci.bats` | 11 | every `--ci` variant, MEMORY.md append, combined tracker + CI |
| `bootstrap_dry_run.bats` | 9 | plan printout, no-writes guarantee, non-empty-folder warnings, `--skip-memory` interaction |
| **Total** | **61** | |

## What's not tested

- **Interactive mode** (read prompts). Bats runs non-interactively so `[ -t 0 ]` is false; interactive paths aren't exercised. The non-interactive fallback (missing-arg-in-non-TTY → exit 2) IS tested. Manual-test interactive mode when touching those branches — noted in `tests/README.md`.

## Test plan
- [x] `bats tests/` — all 61 pass locally on macOS (bats 1.13.0 via homebrew).
- [x] Tilde-expansion bug reproduced pre-fix, resolved post-fix.
- [x] GitHub Actions `bats.yml` workflow runs green on this PR (should trigger on push).

## CHANGELOG
v0.8.0 — minor bump. Despite being test + bug-fix, the bats CI workflow is a visible surface area change worth a minor bump. Entry included.