### PR TITLE
docs: add ko-fi and buymeacoffee funding links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+ko_fi: iammrcupp
+buy_me_a_coffee: iammrcupp

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Treat this kit as a living template. If a pattern or rule proves useful on a rea
 
 The conventions and tooling notes are written assuming **Git + GitHub + GitHub Actions**. They translate cleanly to GitLab (MRs, `glab ci`, pipelines), Jenkins, Azure DevOps, etc. — adapt the specifics, keep the principles.
 
+## Support
+
+If this kit saved you time and you'd like to throw a coffee my way:
+
+- [ko-fi.com/iammrcupp](https://ko-fi.com/iammrcupp)
+- [buymeacoffee.com/iammrcupp](https://buymeacoffee.com/iammrcupp)
+
+No pressure — the kit's MIT-licensed and will stay that way regardless.
+
 ## License
 
 MIT — see [LICENSE](LICENSE). Use it, fork it, strip out what doesn't fit your context.


### PR DESCRIPTION
## Summary
- `.github/FUNDING.yml` — GitHub's native sponsor-button config with `ko_fi` and `buy_me_a_coffee` keys. Produces a "Sponsor" button in the repo header; zero README surface area.
- `README.md` — new `## Support` section (above License) with plain markdown links to both platforms. Reaches readers who browse the README standalone rather than the repo page.

Both surfaces exist so reader-type doesn't miss it. Tone is low-key — "if it saved you time, coffee appreciated, no pressure, MIT regardless."

## Test plan
- [ ] GitHub renders the "Sponsor" button in the repo header after merge (needs a minute after merge).
- [ ] README renders the Support section with both links clickable.
- [ ] release-please treats this as a `docs:` commit (no CHANGELOG section in the next release, since `docs` is visible in CHANGELOG but doesn't trigger a version bump).