### PR TITLE
docs: contributor onboarding (CONTRIBUTING + PR/issue templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Something doesn't work as documented
+title: '[bug] '
+labels: bug
+---
+
+## What happened
+
+<!-- One paragraph: what command / step you ran, and what went wrong. -->
+
+## Reproduction
+
+<!-- Numbered, copy-pasteable steps. -->
+
+1.
+2.
+3.
+
+## Expected
+
+<!-- What should have happened. -->
+
+## Actual
+
+<!-- What did happen — paste output, error, or screenshot. -->
+
+## Environment
+
+- OS:
+- Shell (bash/zsh/other):
+- Bash version (`bash --version | head -1`):
+- Kit version (git rev or tag):

--- a/.github/ISSUE_TEMPLATE/ci_variant_request.md
+++ b/.github/ISSUE_TEMPLATE/ci_variant_request.md
@@ -1,0 +1,30 @@
+---
+name: CI variant request
+about: Request a new --ci <name> variant
+title: '[ci] add <name> variant'
+labels: 'enhancement, ci-variant'
+---
+
+## CI platform
+
+<!-- e.g. Buildkite, Drone, TeamCity -->
+
+## How is it configured?
+
+<!-- File path(s) Claude should look for in a target repo. e.g. ".buildkite/pipeline.yml", ".drone.yml" -->
+
+## Where do logs / runs live?
+
+<!-- URL pattern, dashboard, or CLI command for retrieving run output. -->
+
+## Useful CLI for the platform?
+
+<!-- If there's a `bk`, `drone`, `tc`, etc. binary, name it. The memory variant can point users at it. -->
+
+## Reference variant
+
+<!-- Which existing variant most closely mirrors the shape of this one? github-actions / gitlab-ci / jenkins / circleci / atlantis / ansible-cli -->
+
+## Willing to PR it?
+
+<!-- Yes/No. If yes: see CONTRIBUTING.md "New CI variant" — same shape as tracker. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Open-ended idea or improvement
+title: '[feature] '
+labels: enhancement
+---
+
+## Problem
+
+<!-- What's the friction or gap? Concrete scenario beats abstract pitch. -->
+
+## Proposal
+
+<!-- What you'd like to see. Sketch, not full spec. -->
+
+## Alternatives considered
+
+<!-- What you tried or thought about, and why it didn't fit. Optional. -->
+
+## Additional context
+
+<!-- Links, screenshots, prior art. -->

--- a/.github/ISSUE_TEMPLATE/tracker_variant_request.md
+++ b/.github/ISSUE_TEMPLATE/tracker_variant_request.md
@@ -1,0 +1,32 @@
+---
+name: Tracker variant request
+about: Request a new --tracker <name> variant
+title: '[tracker] add <name> variant'
+labels: 'enhancement, tracker-variant'
+---
+
+## Tracker name
+
+<!-- e.g. Asana, Trello, Pivotal Tracker -->
+
+## URL pattern
+
+<!-- How are individual issues/tickets URLed? e.g. https://app.asana.com/0/<project_id>/<task_id> -->
+
+## Identifier format
+
+<!-- How do users typically reference an issue in a commit message? e.g. "PROJ-123", "#42" -->
+
+## Bootstrap flag(s) needed
+
+<!--
+Beyond `--tracker <name>`, are there project-key / team-key / workspace-id style fields the user must provide at bootstrap? Existing examples: --jira-project KEY, --linear-team TEAM.
+-->
+
+## Reference variant
+
+<!-- Which existing variant most closely mirrors the shape of this one? github / jira / linear / gitlab / shortcut -->
+
+## Willing to PR it?
+
+<!-- Yes/No. If yes: see CONTRIBUTING.md "New tracker variant" — it's a 4-step recipe. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## Summary
+
+<!-- 1–3 bullets. What changed? Reference affected files. -->
+
+-
+
+## Motivation
+
+<!-- Why this change? What signal prompted it (bug, request, friction)? Concrete > abstract. -->
+
+## Design notes
+
+<!-- Non-obvious decisions: tradeoffs considered, alternatives rejected, anything a reviewer might second-guess. Optional for trivial changes. -->
+
+## Test plan
+
+<!--
+Numbered, copy-pasteable steps with expected outcomes. Tick boxes after passing.
+
+For pure-docs PRs: "No runtime change; verification is CI alone." is fine.
+For runtime changes: include actual commands + expected output.
+-->
+
+- [ ]
+- [ ]
+
+## CHANGELOG
+
+<!--
+Confirm the commit type drives the version bump you intend:
+- feat            → minor bump
+- fix             → patch bump
+- feat! / BREAKING CHANGE → major bump
+- docs/refactor/test/ci/perf → patch + CHANGELOG entry
+- chore/build     → no release, hidden from CHANGELOG
+
+See CONTRIBUTING.md for the full mapping.
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,123 @@
+# Contributing to claude-project-kit
+
+A reusable scaffold for Claude-assisted projects. Contributions welcome — especially new tracker / CI variants and adopter feedback.
+
+This guide tells you how to make changes that match the kit's conventions. If something here conflicts with [`CONVENTIONS.md`](CONVENTIONS.md), `CONVENTIONS.md` wins.
+
+---
+
+## Quick start
+
+1. Fork the repo and clone your fork.
+2. Make changes on a topic branch — see [Branch naming](#branch-naming).
+3. Run the tests — see [Running tests](#running-tests).
+4. Open a PR from your branch to `main`. The PR template prompts for the sections that matter.
+
+---
+
+## Common contribution shapes
+
+### New tracker variant
+
+Add support for an issue tracker beyond the current set (GitHub, Jira, Linear, GitLab, Shortcut).
+
+1. Add `memory-templates/trackers/<tracker>.md` — mirror the format of an existing variant. Use `{{TRACKER_*_KEY}}`-style placeholders for fields the user provides at bootstrap time.
+2. Add a case branch in `bootstrap.sh` for `--tracker <tracker>` (search `case "$TRACKER" in`).
+3. Append the right line to the new project's `MEMORY.md` index inside that case branch.
+4. Add a Bats test in `tests/bootstrap_tracker.bats` covering the new variant + any new flag.
+
+### New CI variant
+
+Same shape as tracker, but in `memory-templates/ci/` and `tests/bootstrap_ci.bats`.
+
+### Documentation, examples, prompts
+
+Edit the relevant `.md` file. The `link-check.yml` workflow runs `lychee --offline` on docs PRs — broken relative links will fail CI.
+
+---
+
+## Branch naming
+
+`<type>/<slug>` where `<type>` matches the Conventional Commit type you'll use: `feat`, `fix`, `docs`, `ci`, `test`, `chore`, `refactor`, `perf`, `build`. Examples: `feat/asana-tracker`, `fix/dry-run-tilde-bug`, `docs/contributor-onboarding`.
+
+---
+
+## Conventional Commits
+
+Single-line, signed-off commits. No HEREDOC bodies. No AI co-author trailers.
+
+```bash
+git commit -s -m "feat(trackers): add asana variant"
+```
+
+`type(scope): description` — `type` drives the `release-please` version bump:
+
+| Commit type | Bump | CHANGELOG | Notes |
+|---|---|---|---|
+| `feat` | minor | yes | new feature |
+| `fix` | patch | yes | bug fix |
+| `feat!` / `BREAKING CHANGE:` | major | yes | breaking change |
+| `docs` | patch | yes | user-facing documentation (intentional — see below) |
+| `refactor`, `test`, `ci`, `perf` | patch | yes | listed in CHANGELOG |
+| `chore` | none | hidden | no release |
+| `build` | none | hidden | no release |
+
+The full mapping is in [release-please-config.json](release-please-config.json).
+
+### Why `docs:` triggers a release
+
+Out of the box, `release-please` does NOT bump on `docs:` commits. We've intentionally set `docs:` to `"hidden": false` in `release-please-config.json` so documentation that ships to users gets a CHANGELOG entry and a release tag. The kit IS its docs — there's no other artifact to ship.
+
+If you want a change that does NOT trigger a release (e.g. internal cleanup, test scaffolding edits, config tweaks that don't ship to adopters), use `chore:`. It's hidden from CHANGELOG and won't bump the version.
+
+---
+
+## Running tests
+
+The kit uses [Bats](https://bats-core.readthedocs.io/) for `bootstrap.sh` coverage.
+
+```bash
+# Install
+brew install bats-core           # macOS
+sudo apt-get install bats        # Debian/Ubuntu
+
+# Run from repo root
+bats tests/
+```
+
+CI runs the Bats suite on PRs that touch `bootstrap.sh`, `memory-templates/`, `templates/`, or `tests/`. The `lychee --offline` link-check workflow runs on PRs that touch any `*.md` file. See [tests/README.md](tests/README.md) for the layout, single-test invocation, and the gap around interactive-mode coverage.
+
+---
+
+## PRs
+
+The repo has a [pull request template](.github/pull_request_template.md). The sections (Summary, Motivation, Design notes, Test plan, CHANGELOG) match what every prior PR has used.
+
+- **Test plan is required** for runtime-affecting changes (anything that touches `bootstrap.sh`, the bats suite, or CI workflows). Numbered, copy-pasteable steps with expected outcomes. Tick the boxes after passing — `gh pr edit` to update the body.
+- **Pure-docs PRs:** "no runtime change; verification is CI alone" is fine.
+- **Merge strategy: merge commits only.** No squash, no rebase-merge — `release-please` consumes the granular Conventional Commits to generate the CHANGELOG.
+
+---
+
+## Issue templates
+
+Use the closest-fit template:
+
+- **Bug report** — something doesn't work as documented
+- **Feature request** — open-ended idea
+- **Tracker variant request** — request a new `--tracker <name>` variant
+- **CI variant request** — request a new `--ci <name>` variant
+
+The variant-request templates ask for the same shape we'd need to scaffold the variant ourselves. If you can fill them in, the PR is largely mechanical.
+
+---
+
+## A note for adopters who copy `.github/FUNDING.yml`
+
+GitHub's Sponsor button does NOT render from `FUNDING.yml` alone — the repo also needs **Settings → General → Features → Sponsorships** enabled. This isn't documented prominently in GitHub's funding-file docs; we hit it on this repo and want to save you the same investigation.
+
+---
+
+## Questions
+
+Open an issue with the closest-fit template (often "Feature request") and add the `question` label if there's no actionable change requested.


### PR DESCRIPTION
## Summary

- `CONTRIBUTING.md` — first contributor guide for the kit. Covers branch naming, Conventional Commits + release-please commit-type → version-bump mapping, how to add a tracker / CI variant, how to run the Bats suite, PR shape, and an adopter note about the FUNDING.yml + Sponsorships toggle gotcha.
- `.github/pull_request_template.md` — formalizes the Summary / Motivation / Design notes / Test plan / CHANGELOG rhythm every prior PR has used by hand.
- `.github/ISSUE_TEMPLATE/*.md` — four templates: bug report, feature request, tracker variant request, CI variant request. The two variant-request templates encode the shape of the contribution so a filled-in issue is most of the way to a PR.

## Motivation

Closes Phase 3 items B.1, B.2, B.3 (and folds in resolutions for B.7 and B.8):

- The kit now has enough moving parts (bootstrap variants, bats suite, release-please, multiple memory-templates) that an outside contributor can't find their way without a map. CONTRIBUTING.md is that map.
- PR template formalizes a shape we've been writing by hand on every PR all along.
- Issue templates channel common requests into the right format without a maintainer asking the same follow-up questions.
- **B.7 carry-forward:** the `.github/FUNDING.yml` Sponsorships-toggle gotcha is captured in CONTRIBUTING.md so adopters who copy our funding setup don't repeat the investigation.
- **B.8 carry-forward:** the rationale for `docs:` triggering a release (intentional `"hidden": false` in `release-please-config.json` because the kit IS its docs) is documented in CONTRIBUTING.md, with `chore:` named as the escape hatch for changes that should NOT trigger a release.

## Design notes

- **Three granular `docs:` commits**, one per artifact, under one merge commit. Matches the kit's "merge commits only, granular Conventional Commits underneath" pattern that release-please consumes.
- **`docs:` commit type** (vs. `chore:`): release-please will bump patch and ship a CHANGELOG entry. Intentional — adopters benefit from knowing CONTRIBUTING.md exists.
- **Issue template files use `.md` (not `.yml`).** Markdown templates are more readable in the GitHub UI than YAML form templates and don't constrain freeform fields. Match the kit's "docs-first" posture.
- **No `config.yml` to disable blank issues.** Templates are guides, not gates — leaving the blank-issue option preserves the escape hatch for things that don't fit any template.
- **PR template is HTML-comment-driven** (no required-field plugin, no YAML form). Same rationale as issue templates: lower friction, easier to skim, doesn't break the merge-commit-only workflow.

## Test plan

- [x] `git log origin/main..HEAD` shows three signed-off, single-line, `docs:`-typed commits with no co-author trailers.
- [ ] CI: `link-check` workflow passes (lychee `--offline` validates the relative links in CONTRIBUTING.md — references to `CONVENTIONS.md`, `release-please-config.json`, `tests/README.md`, `.github/pull_request_template.md`).
- [ ] Visual render check: CONTRIBUTING.md table renders correctly on GitHub. Sponsor-button adopter note reads cleanly.
- [ ] Visual render check: PR template HTML comments render as guidance, not visible text.
- [ ] Visual render check: opening "New issue" on the repo lists all four templates with their `about:` descriptions.

## CHANGELOG

`docs:` commits → release-please will produce a patch bump (v0.9.1 → v0.9.2) with a "Documentation" section listing all three commits. Intentional per the rationale documented in CONTRIBUTING.md itself.