### PR TITLE
docs: add widget-tracker memory-example snapshot

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,7 @@ This folder answers that. Each subfolder is a fictional project at a realistic m
 ## What's here
 
 - `widget-tracker/` — a made-up small Go CLI. Mid-Phase 1: Phase 0 shipped, Phase 1 partially complete. Demonstrates populated `CONTEXT.md`, a multi-phase `plan.md`, a `phase-1-checklist.md` with mixed ✅ / ⏳ / [ ] states, and a `SESSION-LOG.md` with a few chronological entries.
+- `widget-tracker/memory-example/` — a snapshot of what auto-memory looks like for the same project mid-Phase 1. Shows the four files that change per project (`MEMORY.md` index, `reference_ai_working_folder.md`, `reference_issue_tracker.md`, `project_current.md`) with placeholders resolved. The other memory files in `memory-templates/` (the `feedback_*.md` rules and `user_role.md`) ship as-is — no per-project edits needed — and aren't reproduced here.
 
 ## How to use
 

--- a/examples/widget-tracker/memory-example/MEMORY.md
+++ b/examples/widget-tracker/memory-example/MEMORY.md
@@ -1,14 +1,21 @@
 # Memory Index
 
-- [User role and background](user_role.md) — who you're collaborating with, how to calibrate explanations
+> **About this snapshot:** Only the four files that vary per project are reproduced in this directory (`MEMORY.md`, `reference_ai_working_folder.md`, `reference_issue_tracker.md`, `project_current.md`). The remaining entries below are referenced by file name in code spans — they ship as-is from `memory-templates/` with no per-project edits, so a real bootstrapped project's memory directory contains them unchanged. In a real `MEMORY.md` every entry is a clickable link.
+
+## Per-project (in this snapshot)
+
 - [AI working folder location](reference_ai_working_folder.md) — read CONTEXT.md + SESSION-LOG.md at session start
 - [Issue tracker — GitHub Issues](reference_issue_tracker.md) — tickets live on `exampleco/widget-tracker`
 - [Current project context](project_current.md) — what's being built, why, timeline
-- [Commit format](feedback_commit_format.md) — Conventional Commits, single line, signed off
-- [Merge strategy](feedback_merge_strategy.md) — always merge commits; never squash or rebase
-- [Push branches by default](feedback_push_branches.md) — `git push -u origin <branch>` after commit without asking
-- [PR test plans](feedback_pr_test_plans.md) — detailed numbered manual-test steps with expected logs
-- [Check off PR tests on pass](feedback_pr_check_off_on_pass.md) — edit PR body with evidence + ✅ after testing
-- [Watch CI in background](feedback_watch_ci_in_background.md) — spawn `gh run watch` in background after push
-- [Keep planning docs in sync](feedback_docs_in_sync.md) — update plan / checklist / implementation as work lands
-- [No AI co-author trailers](feedback_no_ai_coauthor.md) — commits attributed to the human committer only
+
+## Ships as-is from `memory-templates/`
+
+- `user_role.md` — who you're collaborating with, how to calibrate explanations
+- `feedback_commit_format.md` — Conventional Commits, single line, signed off
+- `feedback_merge_strategy.md` — always merge commits; never squash or rebase
+- `feedback_push_branches.md` — `git push -u origin <branch>` after commit without asking
+- `feedback_pr_test_plans.md` — detailed numbered manual-test steps with expected logs
+- `feedback_pr_check_off_on_pass.md` — edit PR body with evidence + ✅ after testing
+- `feedback_watch_ci_in_background.md` — spawn `gh run watch` in background after push
+- `feedback_docs_in_sync.md` — update plan / checklist / implementation as work lands
+- `feedback_no_ai_coauthor.md` — commits attributed to the human committer only

--- a/examples/widget-tracker/memory-example/MEMORY.md
+++ b/examples/widget-tracker/memory-example/MEMORY.md
@@ -1,0 +1,14 @@
+# Memory Index
+
+- [User role and background](user_role.md) — who you're collaborating with, how to calibrate explanations
+- [AI working folder location](reference_ai_working_folder.md) — read CONTEXT.md + SESSION-LOG.md at session start
+- [Issue tracker — GitHub Issues](reference_issue_tracker.md) — tickets live on `exampleco/widget-tracker`
+- [Current project context](project_current.md) — what's being built, why, timeline
+- [Commit format](feedback_commit_format.md) — Conventional Commits, single line, signed off
+- [Merge strategy](feedback_merge_strategy.md) — always merge commits; never squash or rebase
+- [Push branches by default](feedback_push_branches.md) — `git push -u origin <branch>` after commit without asking
+- [PR test plans](feedback_pr_test_plans.md) — detailed numbered manual-test steps with expected logs
+- [Check off PR tests on pass](feedback_pr_check_off_on_pass.md) — edit PR body with evidence + ✅ after testing
+- [Watch CI in background](feedback_watch_ci_in_background.md) — spawn `gh run watch` in background after push
+- [Keep planning docs in sync](feedback_docs_in_sync.md) — update plan / checklist / implementation as work lands
+- [No AI co-author trailers](feedback_no_ai_coauthor.md) — commits attributed to the human committer only

--- a/examples/widget-tracker/memory-example/project_current.md
+++ b/examples/widget-tracker/memory-example/project_current.md
@@ -1,0 +1,27 @@
+---
+name: Current project context — widget-tracker
+description: What this project is, why it exists, timeline, stakeholders, and constraints that aren't obvious from the code.
+type: project
+---
+
+**Project:** widget-tracker
+**Repo:** `exampleco/widget-tracker`
+
+A single-binary Go CLI for tracking inventory of physical widgets across multiple storage locations. SQLite-backed, fully local, no server, no GUI. Built for a small ops team that lost data twice in six months to concurrent edits on a shared spreadsheet and explicitly doesn't want a cloud service. Each operator runs a local instance; CSV import/export is the sync mechanism between operators. Phase 1 (core CRUD + SQLite backend) targeted for end of April 2026 so the team can start using it before the Q3 inventory cycle.
+
+**Why:** spreadsheet-based tracking has been losing data and triggering manual reconciliation work. The team has decided they don't want a cloud service (reliability concerns, no IT budget). A local CLI with deterministic single-writer behavior wins.
+
+**How to apply:**
+- When suggesting scope changes or trade-offs, lean toward what serves the local-first, single-operator goal — not abstract scaling or "what if we had a server" concerns that don't apply.
+- Flag anything that would push the end-of-April Phase 1 milestone or reduce the core CRUD value proposition.
+- If the goal changes (e.g. team decides they do want a server after all), update this memory — stale project memories cause bad suggestions.
+
+**Known constraints:**
+- Must compile with the pure-Go SQLite driver (no CGO). Operators run on locked-down macOS and Linux laptops where toolchain installs are friction.
+- No runtime network dependencies — fully offline tool.
+- Must support macOS arm64 + x86_64 and Linux x86_64 from day one. Linux arm64 is P1, Windows-via-WSL is P2.
+
+**Stakeholders / audience:**
+- Primary users: ~5 operators on the exampleco ops team.
+- Code review: project owner + one rotating reviewer from the platform team.
+- If it breaks: ops falls back to the old spreadsheet flow until a fix lands.

--- a/examples/widget-tracker/memory-example/reference_ai_working_folder.md
+++ b/examples/widget-tracker/memory-example/reference_ai_working_folder.md
@@ -1,0 +1,21 @@
+---
+name: AI working folder for widget-tracker
+description: Private AI context folder (separate from the public repo) with canonical CONTEXT.md, SESSION-LOG.md, and planning docs.
+type: reference
+---
+
+At the start of every session for this project, read these two files first — they are the canonical source of truth, manually maintained across sessions:
+
+- `/Users/dev/Documents/Claude/Projects/widget-tracker/CONTEXT.md` — project overview, working rules, current phase status
+- `/Users/dev/Documents/Claude/Projects/widget-tracker/SESSION-LOG.md` — chronological history of sessions and decisions
+
+Also in that folder:
+- `plan.md`, `implementation.md`, `research.md` — planning docs
+- `phase-N-checklist.md` — per-phase checklists with branch/commit info
+- `acceptance-test-results.md` — manual test log for the current phase
+
+This folder is deliberately OUTSIDE the repo. The repo (`/Users/dev/Code/widget-tracker`) is public — AI working files must never be committed there.
+
+**Why:** having a persistent working folder lets any Claude session pick up where the previous one left off. Ephemeral sandbox filesystems don't survive session changes.
+
+**How to apply:** When starting work on widget-tracker, read CONTEXT.md and SESSION-LOG.md before touching code. Trust them over this memory — they're updated at session end; this memory just points to them.

--- a/examples/widget-tracker/memory-example/reference_issue_tracker.md
+++ b/examples/widget-tracker/memory-example/reference_issue_tracker.md
@@ -1,0 +1,17 @@
+---
+name: Issue tracker for widget-tracker
+description: Tickets for this project are tracked via GitHub Issues on exampleco/widget-tracker.
+type: reference
+---
+
+Tickets for **widget-tracker** live in GitHub Issues on `exampleco/widget-tracker`.
+
+- **Ticket URLs:** `https://github.com/exampleco/widget-tracker/issues/<number>`
+- **Reference format:** `#123` in-repo, `exampleco/widget-tracker#123` for cross-repo references.
+
+**Why:** the repo is the single source of truth for work tracking; commits, PRs, and issues all cross-link natively.
+
+**How to apply:**
+- When the user mentions a ticket (e.g. `#42`), fetch it via `gh issue view 42` before reasoning about it — never guess contents.
+- When opening a PR that resolves an issue, include `Closes #42` in the PR body so GitHub auto-closes on merge.
+- When a commit references an issue, follow the Conventional Commits description with the reference (e.g. `fix(auth): handle expired tokens (#42)`).


### PR DESCRIPTION
## Summary

- `examples/widget-tracker/memory-example/` (new directory, 4 files) — snapshot of what auto-memory looks like mid-Phase 1 for the existing fictional `widget-tracker` example. Includes the four files that vary per project: `MEMORY.md` index, `reference_ai_working_folder.md`, `reference_issue_tracker.md`, `project_current.md`. Placeholders are resolved (`{{PROJECT_NAME}}`, `{{REPO_PATH}}`, `{{REPO_SLUG}}`, `{{WORKING_FOLDER}}`, `{{public/private}}`).
- `examples/README.md` — bullet added under "What's here" pointing at the new subdirectory and explicitly noting the as-is files (`feedback_*.md`, `user_role.md`) aren't reproduced because they ship without per-project edits.

## Motivation

Closes Phase 3 item B.4. Adopters running `bootstrap.sh` see auto-memory get seeded into `~/.claude/projects/<sanitized>/memory/` but have no concrete reference for "did this seed correctly?". The kit's `templates/` directory shows the shape; the existing `widget-tracker/` example shows a populated working folder; this PR fills the third leg — a populated auto-memory.

## Design notes

- **Four files, not all of them.** Snapshot only includes the files that change per project. The kit's `memory-templates/` directory has 14 files; ten of them (`feedback_*.md`, `user_role.md`, `MEMORY.md` itself) are project-agnostic and either ship with no placeholders or are user-personal. Reproducing them in the example would be visual noise pretending to be signal.
- **Tracker variant: github.** Matches widget-tracker's `CONTEXT.md` (already references GitHub Actions + GitHub hosting). If we add Jira/Linear/etc. tracker examples later, those go in their own example projects, not as variants of widget-tracker.
- **`{{public/private}}` resolved to `public`.** The fictional widget-tracker repo is described as public in its `CONTEXT.md`, so the snapshot follows.
- **Two granular commits** (`docs:` add files, `docs:` link from README). Matches the kit's "one logical change per commit" pattern. The README link without the files would be a broken reference, but commits are not independently merged — they ride together under one merge commit.

## Test plan

- [x] `git log origin/main..HEAD` shows two signed-off, single-line, `docs:`-typed commits with no co-author trailers.
- [ ] CI: `markdown link check` workflow passes (lychee `--offline` validates relative references in `examples/README.md` to the new subdirectory).
- [ ] Visual render check on GitHub: `examples/widget-tracker/memory-example/` directory listing shows the four files with their YAML frontmatter previewed correctly.
- [ ] Visual render check: `examples/README.md` "What's here" reads cleanly, the new bullet is parseable, parenthetical about as-is files isn't confusing.
- [ ] Spot-check `project_current.md` against `examples/widget-tracker/CONTEXT.md` — facts about widget-tracker (Go CLI, SQLite, ops team, end-of-April Phase 1 milestone) consistent across both.

## CHANGELOG

`docs:` commits → release-please patch bump with two "Documentation" entries.