### PR TITLE
docs: flag --tracker other / --ci other follow-up in SETUP

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -61,6 +61,8 @@ Flags:
 - `--dry-run` — print what would be created (paths, placeholder substitutions, tracker memory, MEMORY.md index line) and exit without writing anything. Safe to re-run.
 - `-h` / `--help` — show usage
 
+**On `--tracker other` and `--ci other`:** these are escape hatches for tools the kit doesn't have a named variant for. Picking either seeds a placeholder-rich memory file (`reference_issue_tracker.md` for trackers, `reference_ci.md` for CI) with `{{tracker URL pattern}}`, `{{ticket reference format}}`, `{{CI config location}}`, etc. that need manual fill-in before the memory is useful. The bootstrap end-of-run output flags this; if you're scanning flags to plan an invocation, plan for the follow-up edit.
+
 Prefer to see what's happening step-by-step? See [Manual alternative](#manual-alternative) at the bottom of this doc.
 
 ---


### PR DESCRIPTION
## Summary

- `SETUP.md` §2 — adds a short callout explaining that `--tracker other` and `--ci other` seed placeholder-rich memory files that need manual fill-in before they're useful.

## Motivation

Closes Phase 3 item B.6. `bootstrap.sh` already prints this warning at end-of-run (see lines 492–500), but a user scanning `SETUP.md` to plan an invocation has no signal — the flag list at line 56/59 lists `other` as just another value alongside `github` / `jira` / etc. The new callout lives directly under the flag list so scanning readers see it before they pick a value.

## Design notes

- **Single short paragraph, not a tutorial.** The actual fill-in instructions live in the seeded memory files themselves (`memory-templates/trackers/other.md`, `memory-templates/ci/other.md`) — both already have a `**How to apply:**` section walking through what to fill. No need to duplicate that in SETUP.md.
- **No new section heading.** The callout sits inside §2 (Run bootstrap) since that's where the flag decision happens. A separate "Manual fill-in" section would over-weight what's a 30-second follow-up edit.
- **Doesn't touch `bootstrap.sh`.** The runtime warning is already there and works correctly.

## Test plan

- [x] `git diff origin/main` shows a 2-line addition in SETUP.md §2 immediately before the "Manual alternative" pointer.
- [ ] CI: `markdown link check` workflow passes — no new links introduced; existing relative paths unchanged.
- [ ] Visual render check: the new paragraph reads cleanly as a follow-up note on the flag list.

## CHANGELOG

`docs:` patch bump.