### PR TITLE
feat(prompts): add Prompt 4 for resuming mid-PR

### DIFF
--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -26,7 +26,7 @@ landed most recently, and any open threads. Then wait for my next instruction.
 **Notes:**
 - Replace `<working-folder>` with the actual path (e.g. `~/Documents/Claude/Projects/my-project/`)
 - **Once you've set up `memory-templates/reference_ai_working_folder.md` for the project**, the memory tells Claude where to look automatically — you can shorten the prompt to *"Load context and give me a 3-bullet summary of where we are."*
-- If you're resuming mid-PR, add a line: *"I also had a branch `<branch-name>` open — check its state before suggesting next steps."*
+- If you're resuming mid-PR, use [Prompt 4](#4-resuming-mid-pr) instead of this one — it loads the same context but adds a structured branch + PR + CI assessment.
 
 ---
 
@@ -109,6 +109,52 @@ anything is written.
 - If `reference_ai_working_folder.md` is set up in auto-memory, Claude already knows where the working folder lives. Otherwise prefix with: *"Working folder is `<path>`."*
 - The "draft first, don't write" guard is load-bearing — session-end updates are easy to get wrong (overzealous status bumps, hallucinated PR numbers), and reviewing is faster than undoing.
 - For a bare-minimum wrap-up (no checklist or memory review), the one-liner *"Draft a SESSION-LOG.md entry for today and show it to me"* is usually enough.
+
+---
+
+## 4. Resuming mid-PR
+
+Use this when a previous session ended with a branch in flight and you want to pick it up cleanly. Combines the working-folder context load (like Prompt 1) with a structured branch / PR / CI assessment so Claude has the full picture before proposing next steps.
+
+```
+I had a branch open from a previous session. Help me resume.
+
+## Before we work — load context
+
+1. Read `<working-folder>/CONTEXT.md`, `<working-folder>/SESSION-LOG.md`, and the
+   current phase checklist — same as Prompt 1.
+2. Note the most recent SESSION-LOG entry's "Open threads" / "Next steps"
+   section if there is one — that's likely what this branch is about.
+
+## Then assess the branch
+
+Run these and report:
+
+1. `git status` — anything uncommitted? Position relative to `origin/<branch>`?
+2. `git log --oneline origin/main..HEAD` — what commits are on this branch?
+3. `gh pr list --head <branch> --json number,state,title,body,statusCheckRollup`
+   — is there an open PR?
+4. If a PR exists, extract the test plan from the body. Note which checkboxes
+   are ticked, which aren't.
+5. Latest CI run for this branch — conclusion, and any failed check names.
+
+## Hand back
+
+A 5-bullet read:
+- What this branch is for (your inference + SESSION-LOG cross-reference)
+- What's been done (commits, ticked test-plan items)
+- What's left (untested test-plan items, unaddressed review comments,
+  CI failures)
+- The likely next concrete step
+- Any conflicts with `origin/main` since the branch was pushed
+
+Don't start coding — wait for me to confirm direction.
+```
+
+**Notes:**
+- Assumes the branch is already checked out. If you don't remember which branch, prefix with: *"My open branches: `git branch --no-merged origin/main`. Pick the right one with me first."*
+- For a branch that was never pushed, skip steps 3–5 — no PR or CI exists yet.
+- If `reference_ai_working_folder.md` is in auto-memory, the "load context" section can shrink to *"Load context (per memory)."*
 
 ---
 


### PR DESCRIPTION
## Summary

- `PROMPTS.md` — adds **Prompt 4: Resuming mid-PR**. Combines the working-folder context load (like Prompt 1) with a structured assessment of branch state (`git status`, `git log`), open-PR state (`gh pr list --head`), test-plan checkbox status, and CI conclusion. Hands back a 5-bullet read of where the branch is and what's the likely next concrete step. Stops before coding.
- `PROMPTS.md` Prompt 1 notes — replaces the inline "if you're resuming mid-PR, add a line…" hint with a cross-link to the new Prompt 4. Avoids duplicating the recipe in two places.

## Motivation

Closes Phase 3 item B.5. Resuming work after a multi-day pause is a real friction point — you have to remember which branch was open, what state it was in, what CI said, what review comments were open. Prior solution: paste Prompt 1 plus an ad-hoc one-liner about the branch. This works but doesn't structure what Claude should *check* before proposing next steps. Result: half-baked status reports that miss CI failures or untested test-plan items.

Prompt 4 makes the assessment explicit. Same shape as the other prompts (specific files / commands to read, hand-back format, "don't start coding" guard).

## Design notes

- **Steps 1–2 mirror Prompt 1** (load CONTEXT + SESSION-LOG + checklist) but with a specific instruction to look for the most recent SESSION-LOG entry's "Open threads" / "Next steps" section — that's almost always why the branch was opened.
- **Steps 3–5 (PR + test-plan + CI assessment) are the new value-add** over Prompt 1. The `gh pr list --head <branch> --json …` form is robust to having no PR (returns empty array, doesn't error).
- **5-bullet hand-back format** matches Prompt 1's hand-back. Familiar shape; the "next concrete step" bullet is what makes this useful for resuming work specifically.
- **"Don't start coding — wait for me to confirm direction"** guard at the end matches Prompts 1 and 3. Same load-bearing rationale: easier to redirect a draft than to undo writes.
- **Skip-clauses for non-pushed branches** (Notes section) prevent confused output when the branch has never seen a remote — steps 3–5 just don't apply.
- **Branch named `feat/prompt-resuming-mid-pr`** to match the `feat:` commit type (new feature = minor bump). The CONTRIBUTING.md convention I just landed says branch type should match commit type.

## Test plan

- [x] `git diff origin/main` shows two PROMPTS.md changes: (a) Prompt 1 notes line cross-link, (b) new "## 4. Resuming mid-PR" section before "## When to write a new prompt".
- [ ] CI: `markdown link check` workflow passes — internal anchor `#4-resuming-mid-pr` resolves; no broken relative links.
- [ ] Visual render check: GitHub renders Prompt 4 cleanly — fenced code block intact, anchor link from Prompt 1 notes jumps correctly.
- [ ] Cold dogfood (deferred to a real-life resumption scenario): paste Prompt 4 at the start of a session resuming a real branch, confirm Claude follows steps 1–5 in order and produces the 5-bullet hand-back without starting to code.

## CHANGELOG

`feat(prompts):` → minor bump (e.g. v0.9.x → v0.10.0). Adopters get a new prompt; existing prompts unchanged.