### PR TITLE
feat(bootstrap): preview actual MEMORY.md index lines in --dry-run

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -80,6 +80,37 @@ See SETUP.md in the kit repo for the full walk-through.
 EOF
 }
 
+tracker_index_line() {
+  # args: tracker_type project_name [jira_key] [linear_key]
+  # emits the exact line that gets appended to MEMORY.md for this tracker.
+  local tracker="$1" project="$2" jira_key="${3:-}" linear_key="${4:-}"
+  printf -- '- [Issue tracker for %s](reference_issue_tracker.md) — ' "$project"
+  case "$tracker" in
+    github)   printf 'tickets live in GitHub Issues on this repo\n' ;;
+    jira)     printf 'tickets live in JIRA project `%s`\n' "$jira_key" ;;
+    linear)   printf 'issues live in Linear team `%s`\n' "$linear_key" ;;
+    gitlab)   printf 'tickets live in GitLab Issues on this repo\n' ;;
+    shortcut) printf 'stories live in Shortcut (sc-NNN refs)\n' ;;
+    other)    printf 'tickets live in an external system — fill in the placeholders\n' ;;
+  esac
+}
+
+ci_index_line() {
+  # args: ci_tool project_name
+  # emits the exact line that gets appended to MEMORY.md for this CI variant.
+  local ci="$1" project="$2"
+  printf -- '- [CI / automation for %s](reference_ci.md) — ' "$project"
+  case "$ci" in
+    github-actions) printf 'CI runs on GitHub Actions (`gh run` CLI)\n' ;;
+    gitlab-ci)      printf 'CI runs on GitLab CI/CD (`glab ci` CLI)\n' ;;
+    jenkins)        printf 'CI runs on Jenkins (host + job names documented in CONTEXT.md)\n' ;;
+    circleci)       printf 'CI runs on CircleCI (`circleci` CLI)\n' ;;
+    atlantis)       printf 'Terraform automation via Atlantis (PR-comment driven)\n' ;;
+    ansible-cli)    printf 'automation via local `ansible-playbook` runs\n' ;;
+    other)          printf 'CI/automation tool — fill in the placeholders\n' ;;
+  esac
+}
+
 SKIP_MEMORY=0
 FORCE=0
 DRY_RUN=0
@@ -322,11 +353,13 @@ if [ "$DRY_RUN" -eq 1 ]; then
     echo "  + copy $KIT_ROOT/memory-templates/*.md"
     if [ -n "$TRACKER" ] && [ "$TRACKER" != "none" ]; then
       echo "  + copy memory-templates/trackers/$TRACKER.md → reference_issue_tracker.md"
-      echo "  + append index line to MEMORY.md"
+      echo "  + append to MEMORY.md:"
+      echo "      $(tracker_index_line "$TRACKER" "$PROJECT_NAME" "$JIRA_PROJECT_KEY" "$LINEAR_TEAM_KEY")"
     fi
     if [ -n "$CI_TOOL" ] && [ "$CI_TOOL" != "none" ]; then
       echo "  + copy memory-templates/ci/$CI_TOOL.md → reference_ci.md"
-      echo "  + append index line to MEMORY.md"
+      echo "  + append to MEMORY.md:"
+      echo "      $(ci_index_line "$CI_TOOL" "$PROJECT_NAME")"
     fi
     echo "  + substitute placeholders:"
     echo "      {{WORKING_FOLDER}}    → $WORKING_FOLDER"
@@ -401,17 +434,7 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
       exit 1
     fi
     cp "$TRACKER_SRC" "$MEMORY_DIR/reference_issue_tracker.md"
-    {
-      printf -- '- [Issue tracker for %s](reference_issue_tracker.md) — ' "$PROJECT_NAME"
-      case "$TRACKER" in
-        github)   printf 'tickets live in GitHub Issues on this repo\n' ;;
-        jira)     printf 'tickets live in JIRA project `%s`\n' "$JIRA_PROJECT_KEY" ;;
-        linear)   printf 'issues live in Linear team `%s`\n' "$LINEAR_TEAM_KEY" ;;
-        gitlab)   printf 'tickets live in GitLab Issues on this repo\n' ;;
-        shortcut) printf 'stories live in Shortcut (sc-NNN refs)\n' ;;
-        other)    printf 'tickets live in an external system — fill in the placeholders\n' ;;
-      esac
-    } >> "$MEMORY_DIR/MEMORY.md"
+    tracker_index_line "$TRACKER" "$PROJECT_NAME" "$JIRA_PROJECT_KEY" "$LINEAR_TEAM_KEY" >> "$MEMORY_DIR/MEMORY.md"
     echo "  ✓ Seeded tracker memory ($TRACKER) → reference_issue_tracker.md"
   fi
 
@@ -422,18 +445,7 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
       exit 1
     fi
     cp "$CI_SRC" "$MEMORY_DIR/reference_ci.md"
-    {
-      printf -- '- [CI / automation for %s](reference_ci.md) — ' "$PROJECT_NAME"
-      case "$CI_TOOL" in
-        github-actions) printf 'CI runs on GitHub Actions (`gh run` CLI)\n' ;;
-        gitlab-ci)      printf 'CI runs on GitLab CI/CD (`glab ci` CLI)\n' ;;
-        jenkins)        printf 'CI runs on Jenkins (host + job names documented in CONTEXT.md)\n' ;;
-        circleci)       printf 'CI runs on CircleCI (`circleci` CLI)\n' ;;
-        atlantis)       printf 'Terraform automation via Atlantis (PR-comment driven)\n' ;;
-        ansible-cli)    printf 'automation via local `ansible-playbook` runs\n' ;;
-        other)          printf 'CI/automation tool — fill in the placeholders\n' ;;
-      esac
-    } >> "$MEMORY_DIR/MEMORY.md"
+    ci_index_line "$CI_TOOL" "$PROJECT_NAME" >> "$MEMORY_DIR/MEMORY.md"
     echo "  ✓ Seeded CI memory ($CI_TOOL) → reference_ci.md"
   fi
 

--- a/tests/bootstrap_dry_run.bats
+++ b/tests/bootstrap_dry_run.bats
@@ -65,6 +65,31 @@ teardown() { bootstrap_teardown; }
   [[ "$output" == *"real run would fail (never overwrites memory)"* ]]
 }
 
+@test "--dry-run with --tracker shows the actual MEMORY.md index line" {
+  run "$BOOTSTRAP" --dry-run --tracker github "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"append to MEMORY.md:"* ]]
+  [[ "$output" == *"[Issue tracker for"* ]]
+  [[ "$output" == *"reference_issue_tracker.md"* ]]
+  [[ "$output" == *"GitHub Issues on this repo"* ]]
+}
+
+@test "--dry-run with --tracker jira shows index line with project key" {
+  run "$BOOTSTRAP" --dry-run --tracker jira --jira-project INFRA "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"JIRA project"* ]]
+  [[ "$output" == *"\`INFRA\`"* ]]
+}
+
+@test "--dry-run with --ci shows the actual MEMORY.md index line" {
+  run "$BOOTSTRAP" --dry-run --ci atlantis "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"append to MEMORY.md:"* ]]
+  [[ "$output" == *"[CI / automation for"* ]]
+  [[ "$output" == *"reference_ci.md"* ]]
+  [[ "$output" == *"Atlantis"* ]]
+}
+
 @test "--dry-run with --skip-memory reports memory skipped" {
   run "$BOOTSTRAP" --dry-run --skip-memory "$TEST_WF"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

- `bootstrap.sh` — extracts the tracker / CI MEMORY.md index-line composition into two helper functions (`tracker_index_line`, `ci_index_line`). `--dry-run` now invokes those helpers and shows the literal line that the real run will append, instead of the previous opaque `+ append index line to MEMORY.md`.
- `bootstrap.sh` — real-run path also calls the new helpers (replaces the inline `printf … } >> MEMORY.md` blocks). Single source of truth for the line content; dry-run and real-run can't drift.
- `tests/bootstrap_dry_run.bats` — three new tests verifying the previewed line content for tracker (github), tracker-with-key (jira/INFRA), and CI (atlantis).

## Motivation

Closes Phase 3 item C.1. Pre-this-PR `--dry-run` was advertised as a complete preview ("see exactly what bootstrap would produce") but elided the MEMORY.md index lines, which contain real composition logic — project-name interpolation, tracker-specific phrasing, JIRA / Linear key inclusion. Users running dry-run before a real invocation had to either re-run for real and inspect MEMORY.md, or read `bootstrap.sh` to predict the output. Both miss the point of dry-run.

## Design notes

- **Helpers are bash 3 compatible.** `local` keyword + `printf -- '...'` form (the leading `--` prevents printf from interpreting the `- ` in `- [Issue tracker…]` as a flag) + `${3:-}` defaults for safe handling under `set -u`. No bashisms beyond what the kit already requires.
- **DRY refactor + new feature in one commit.** The helper extraction is what enables the dry-run feature — committing them together (rather than refactor-then-feature) keeps the change motivated. Bats coverage is its own commit so the test plan is reviewable separately.
- **Output format chosen for parseability.** Dry-run prints `+ append to MEMORY.md:` followed by the line indented 6 spaces — same shape as the existing placeholder substitution table. Reads as "here's the literal" without ambiguity.
- **Tests assert content, not exact whitespace.** `[[ "$output" == *"GitHub Issues on this repo"* ]]` matches the substring regardless of indentation, so cosmetic format tweaks won't break tests. Tests for `[Issue tracker for"`/`[CI / automation for"` confirm the markdown link prefix is present.

## Test plan

- [x] `bash -n bootstrap.sh` — syntax OK.
- [x] Local dry-run with `--tracker jira --jira-project INFRA --ci atlantis` produces the expected literal lines (verified `- [Issue tracker for wf-c1-test](reference_issue_tracker.md) — tickets live in JIRA project \`INFRA\`` and the matching CI line).
- [x] `bats tests/` — 64/64 pass locally (61 existing + 3 new). Existing tests `tracker seeding appends a line to MEMORY.md index` and `--tracker jira seeds and substitutes {{JIRA_PROJECT_KEY}}` still pass — verifies the real-run refactor didn't change behavior.
- [ ] CI: `bats` workflow runs green on this PR (touches `bootstrap.sh` + `tests/`, so it should trigger).

## CHANGELOG

`feat(bootstrap):` → minor bump. The two commits land as separate entries:
- `feat(bootstrap): preview actual MEMORY.md index lines in --dry-run` (Features section)
- `test(bootstrap): verify --dry-run previews actual index lines` (Tests section)