### PR TITLE
docs: add SECURITY.md with disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,59 @@
+# Security policy
+
+`claude-project-kit` ships a shell script (`bootstrap.sh`) that runs on contributor and adopter machines, plus a set of templates and prompts that get copied into other projects. If you find a security concern in any of that surface, this doc is how to report it.
+
+---
+
+## What's in scope
+
+- **`bootstrap.sh`** — argument injection, path traversal in `<working-folder>` / `--project-name` handling, `sed` delimiter collisions, unsafe handling of values from `git remote get-url`, accidental clobbering of files outside the documented write paths.
+- **Memory placeholder substitution** — values that escape `{{PLACEHOLDER}}` boundaries during `sed` replacement and end up modifying unintended fields.
+- **Templates and prompts** — content in `templates/` or `memory-templates/` that, when seeded into a downstream project, instructs Claude to read or exfiltrate data outside the project's expected scope. (`SEED-PROMPT.md` already includes a prompt-injection guard for target-repo content; gaps in that guard are in scope.)
+- **CI workflows** — anything in `.github/workflows/` that could run untrusted code, leak secrets, or be triggered with elevated permissions from an unprivileged source.
+
+## What's NOT in scope
+
+- The kit's downstream projects. If you're using the kit and find a security issue in *your* project, that's between you and your project's policy — not this kit's.
+- Best-practice suggestions for hardening downstream usage (e.g. "you should pin commit SHAs"). Open a regular issue for those.
+- The kit's documentation phrasing or markdown rendering.
+
+---
+
+## How to report
+
+**Preferred — GitHub Security Advisories (private vulnerability reporting):**
+[Open a draft advisory](https://github.com/IamMrCupp/claude-project-kit/security/advisories/new). This keeps the report private until disclosure is coordinated. If the link returns "private vulnerability reporting is not enabled," fall back to email below — and mention it in your report so the maintainer can enable it.
+
+**Fallback — email:** `mrcupp@mrcupp.com`. Subject line `[claude-project-kit security]`. Include:
+- A description of the issue and which file(s) / version(s) it affects.
+- Reproduction steps. A minimal `bootstrap.sh` invocation that triggers the issue is ideal.
+- The impact you observed (file written outside the working folder, command executed unexpectedly, secret exposed, etc.).
+- Whether you'd like credit in the disclosure, and how.
+
+**Please do NOT:**
+- Open a public GitHub Issue describing the vulnerability before it's been triaged.
+- Post the report to Discussions, social media, or anywhere else public.
+- Open a PR with the fix attached — that publishes the issue. Send the report first; we'll coordinate the fix branch privately.
+
+---
+
+## What to expect
+
+This is a hobby / personal project, not a vendor product. Realistic expectations:
+
+- **Acknowledgement:** within 7 days of the report.
+- **Triage:** within 14 days. If the issue is in scope and reproducible, we'll agree on a coordinated disclosure timeline (typically 30–90 days depending on severity and exploitability).
+- **Fix:** released as a `fix:` (patch bump) or `feat!:` (major bump if the fix is breaking) Conventional Commit. The CHANGELOG entry will reference the disclosure once coordinated.
+- **Credit:** named in the release notes if you want it; anonymous if you prefer.
+
+If a report turns out to be out of scope, you'll get a brief explanation and a pointer to the right place (regular issue, downstream-project policy, or "this is intended behavior").
+
+---
+
+## Other security posture
+
+For transparency, the repo currently has these GitHub features enabled:
+
+- **Dependabot security updates** — automated PRs for vulnerable dependencies.
+- **Secret scanning** + push protection — accidental commits of common secret patterns (API keys, tokens, etc.) are blocked at push time.
+- **Branch protection on `main`** — not currently configured. CI workflows (lychee link-check, bats) run advisory-only; merges aren't gated. Tracked as a maintainer follow-up; not a security-disclosure issue.


### PR DESCRIPTION
## Summary

- `SECURITY.md` (new, repo root) — security policy with: in/out-of-scope surface, two report channels (GitHub Security Advisories preferred, email `mrcupp@mrcupp.com` as fallback), expectations on acknowledgement / triage / fix timelines that match a hobby project, and a transparency snapshot of currently-enabled GitHub security features.

## Motivation

Closes #29. Hygiene checklist for a public repo that runs shell code on contributor + adopter machines. `bootstrap.sh` parses `git remote get-url` output, runs `sed` replacement on placeholder values, and creates / writes files based on user-provided paths — all surface where injection or path-traversal bugs are possible. A clear "how to report this privately" channel is the OSS-citizenship baseline.

## Design notes

- **Two channels, not one.** GitHub Security Advisories is the preferred path because it's private-by-default and keeps reporter + maintainer + history in one place. Email is the fallback because GHSA is repo-setting-gated (see flag below). The doc tells reporters what to do if the GHSA link is dead, so the policy is robust to the setting being toggled either way.
- **In-scope is concrete.** Names the actual surface (`bootstrap.sh` arg handling, `sed` delimiter collisions, prompt-injection in seeded templates). Generic "any vulnerability" language is useless to reporters; concrete examples calibrate what's worth reporting.
- **Expectations match the project's reality.** This isn't Anthropic — it's a hobby project. The 7-day acknowledgement / 14-day triage / 30–90-day fix windows are honest, not aspirational. Better to underpromise than to publish vendor-grade SLAs and miss them.
- **No PGP key.** Most hobby OSS reports don't use PGP and the email channel is fallback-only. Adding key infrastructure for a project at this scale is ceremony; if someone wants encryption they'll ask first.

## Repo setting flag

The `Open a draft advisory` link in the doc points at `/security/advisories/new` — that page only renders correctly if **private vulnerability reporting** is enabled in repo Settings. Currently it is **not** enabled (verified via `gh api .../private-vulnerability-reporting` → `{"enabled": false}`).

**One-click action for the maintainer:** Settings → Security → Private vulnerability reporting → Enable. Or via API: `gh api -X PUT repos/IamMrCupp/claude-project-kit/private-vulnerability-reporting`. Doing this either before or right after merge makes the documented preferred channel work; until then, reporters fall through to the email path (which the doc handles cleanly).

## Test plan

- [x] `git diff origin/main` shows one new file, `SECURITY.md`, at repo root. No other files touched.
- [ ] CI: `markdown link check` workflow passes — links to `/security/advisories/new`, `mailto:mrcupp@mrcupp.com`, and the kit's own paths resolve.
- [ ] Visual render check on GitHub: `SECURITY.md` is auto-detected by GitHub and shows up in the repo's Security tab.
- [ ] After merge, decide whether to enable private vulnerability reporting (one-click in Settings) so the documented preferred channel actually works.

## CHANGELOG

`docs:` patch bump (e.g. v0.10.0 → v0.10.1).