### PR TITLE
test: interactive-mode coverage with expect-based suite

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install bats
-        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Install bats + expect
+        run: sudo apt-get update && sudo apt-get install -y bats expect
 
       - name: Configure git (required by bootstrap.sh + tests)
         run: |
@@ -29,5 +29,8 @@ jobs:
           git config --global user.name "Bats Test Runner"
           git config --global init.defaultBranch main
 
-      - name: Run bats suite
+      - name: Run bats suite (non-interactive)
         run: bats tests/
+
+      - name: Run expect suite (interactive)
+        run: tests/interactive/run.sh

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,34 +1,48 @@
 # Tests
 
-[Bats](https://bats-core.readthedocs.io/) test suite for `bootstrap.sh`.
+Two suites cover `bootstrap.sh`:
+
+- **Bats** — non-interactive paths (flags, memory seeding, tracker / CI variants, dry-run).
+- **Expect** — interactive-mode paths (`read -p` prompts) that bats can't drive.
 
 ## Running locally
 
-Install bats:
+### Bats suite
+
+Install [bats](https://bats-core.readthedocs.io/):
 ```bash
 # macOS
 brew install bats-core
 
 # Debian/Ubuntu
 sudo apt-get install bats
-
-# Or vendored — see https://bats-core.readthedocs.io/en/stable/installation.html
 ```
 
-Run the full suite from the kit root:
+Run from the kit root:
 ```bash
-bats tests/
+bats tests/                          # full suite
+bats tests/bootstrap_args.bats       # one file
+bats tests/ -f "tilde"               # by name (substring match)
 ```
 
-Run a single file:
+### Expect suite (interactive mode)
+
+Install `expect`:
 ```bash
-bats tests/bootstrap_args.bats
+# macOS
+brew install expect
+
+# Debian/Ubuntu
+sudo apt-get install -y expect
 ```
 
-Run a single test by name (substring match):
+Run from the kit root:
 ```bash
-bats tests/ -f "tilde"
+tests/interactive/run.sh                          # all interactive tests
+tests/interactive/run.sh 02-tracker-jira.exp      # one file
 ```
+
+Each test runs in its own sandbox (`HOME` override + fresh fake repo), same isolation pattern as the bats helpers.
 
 ## Test layout
 
@@ -39,22 +53,29 @@ bats tests/ -f "tilde"
 | `bootstrap_tracker.bats` | every `--tracker` variant (github/jira/linear/gitlab/shortcut/other/none), `{{JIRA_PROJECT_KEY}}` + `{{LINEAR_TEAM_KEY}}` substitution, `MEMORY.md` index append |
 | `bootstrap_ci.bats` | every `--ci` variant (github-actions/gitlab-ci/jenkins/circleci/atlantis/ansible-cli/other/none), `MEMORY.md` index append, combined `--tracker` + `--ci` |
 | `bootstrap_dry_run.bats` | `--dry-run` plan printout, no-side-effect guarantees, non-empty-folder warnings, `--skip-memory` interaction |
+| `interactive/01-default-flow.exp` | accept defaults end-to-end, default github tracker memory seeded |
+| `interactive/02-tracker-jira.exp` | jira tracker + JIRA project key prompt |
+| `interactive/03-tracker-linear.exp` | linear tracker + Linear team key prompt |
+| `interactive/04-ci-variant.exp` | CI prompt; `atlantis` variant memory seeded |
+| `interactive/05-proceed-decline.exp` | answer `n` at the final Proceed prompt; abort path; no working folder created |
 
 ## What's NOT tested
 
-- **Interactive mode** (the `read -p` prompts). Bats runs non-interactively (`[ -t 0 ]` is false), so interactive-mode paths aren't exercised. Manual-test interactive mode when touching those branches. The non-interactive mode error path (missing arg in non-TTY → exit 2) IS tested.
 - **Visual / UX details** of printed output beyond specific substrings the tests assert on.
+- **Every combination** of tracker × CI in interactive mode — the bats suite covers the full Cartesian product non-interactively. The expect suite samples each interactive prompt branch once.
 
 ## Test isolation
 
-Each test runs in a sandboxed temp directory:
+Both suites use the same per-test sandbox pattern:
 - `HOME` is overridden to a per-test tempdir, so `~/.claude/projects/...` writes don't touch real auto-memory.
-- A fresh `git init` repo is created per test as the target.
-- `teardown()` deletes the temp dir.
+- A fresh `git init` repo is created per test as the target, with a stub `origin` remote.
+- The tempdir is deleted on teardown.
 
-See `tests/helpers.bash` for the setup/teardown mechanics.
+For bats, see `tests/helpers.bash`. For expect, see `tests/interactive/run.sh` (sandbox lives in the bash runner) and `tests/interactive/helpers.exp` (sourced by every `.exp`; sets timeout + failure handler).
 
 ## Adding a test
+
+### Non-interactive (bats)
 
 1. Pick the file that matches the code path you're touching (or add a new `bootstrap_<topic>.bats`).
 2. Structure:
@@ -67,4 +88,25 @@ See `tests/helpers.bash` for the setup/teardown mechanics.
    }
    ```
 3. Run `bats tests/<file>.bats` to verify.
-4. Commit — CI will run the full suite on PR.
+
+### Interactive (expect)
+
+1. Add a numbered file under `tests/interactive/` (e.g. `06-skip-memory.exp`). The numeric prefix sets run order.
+2. Structure (see existing `*.exp` files for full template):
+   ```tcl
+   #!/usr/bin/env expect
+   source [file dirname [info script]]/helpers.exp
+
+   spawn $::kit_root/bootstrap.sh
+   expect "Path";  send -- "$::test_wf\r"
+   expect "Project name";  send -- "\r"
+   # ... drive remaining prompts ...
+   expect "Proceed";  send -- "\r"
+   expect "Copied template files"
+   expect eof
+   catch wait result
+   exit [lindex $result 3]
+   ```
+3. Run `tests/interactive/run.sh 06-skip-memory.exp` to verify.
+
+CI runs both suites on PRs that touch `bootstrap.sh`, `memory-templates/`, `templates/`, or `tests/`.

--- a/tests/interactive/01-default-flow.exp
+++ b/tests/interactive/01-default-flow.exp
@@ -1,0 +1,34 @@
+#!/usr/bin/env expect
+# Accept defaults all the way through (custom path; defaults for everything
+# else). Verifies: tracker default = github, CI default = none, proceed = yes,
+# memory + tracker memory both seeded.
+
+source [file dirname [info script]]/helpers.exp
+
+spawn $::kit_root/bootstrap.sh
+
+expect "Path"
+send -- "$::test_wf\r"
+
+expect "Project name"
+send -- "\r"
+
+expect "Seed auto-memory"
+send -- "\r"
+
+expect "Issue tracker"
+send -- "\r"
+
+expect "CI/automation"
+send -- "\r"
+
+expect "Proceed"
+send -- "\r"
+
+expect "Copied template files"
+expect "Copied memory files"
+expect "Seeded tracker memory (github)"
+expect eof
+
+catch wait result
+exit [lindex $result 3]

--- a/tests/interactive/02-tracker-jira.exp
+++ b/tests/interactive/02-tracker-jira.exp
@@ -1,0 +1,33 @@
+#!/usr/bin/env expect
+# Pick jira tracker; provide JIRA project key INFRA. CI = default (none).
+
+source [file dirname [info script]]/helpers.exp
+
+spawn $::kit_root/bootstrap.sh
+
+expect "Path"
+send -- "$::test_wf\r"
+
+expect "Project name"
+send -- "\r"
+
+expect "Seed auto-memory"
+send -- "\r"
+
+expect "Issue tracker"
+send -- "jira\r"
+
+expect "JIRA project key"
+send -- "INFRA\r"
+
+expect "CI/automation"
+send -- "\r"
+
+expect "Proceed"
+send -- "\r"
+
+expect "Seeded tracker memory (jira)"
+expect eof
+
+catch wait result
+exit [lindex $result 3]

--- a/tests/interactive/03-tracker-linear.exp
+++ b/tests/interactive/03-tracker-linear.exp
@@ -1,0 +1,33 @@
+#!/usr/bin/env expect
+# Pick linear tracker; provide Linear team key ENG. CI = default (none).
+
+source [file dirname [info script]]/helpers.exp
+
+spawn $::kit_root/bootstrap.sh
+
+expect "Path"
+send -- "$::test_wf\r"
+
+expect "Project name"
+send -- "\r"
+
+expect "Seed auto-memory"
+send -- "\r"
+
+expect "Issue tracker"
+send -- "linear\r"
+
+expect "Linear team key"
+send -- "ENG\r"
+
+expect "CI/automation"
+send -- "\r"
+
+expect "Proceed"
+send -- "\r"
+
+expect "Seeded tracker memory (linear)"
+expect eof
+
+catch wait result
+exit [lindex $result 3]

--- a/tests/interactive/04-ci-variant.exp
+++ b/tests/interactive/04-ci-variant.exp
@@ -1,0 +1,32 @@
+#!/usr/bin/env expect
+# Default github tracker; pick atlantis CI variant. Verifies the CI prompt +
+# CI memory seeding path, plus the post-run "Also fill in" reminder doesn't
+# fire (atlantis is a named variant, not 'other').
+
+source [file dirname [info script]]/helpers.exp
+
+spawn $::kit_root/bootstrap.sh
+
+expect "Path"
+send -- "$::test_wf\r"
+
+expect "Project name"
+send -- "\r"
+
+expect "Seed auto-memory"
+send -- "\r"
+
+expect "Issue tracker"
+send -- "\r"
+
+expect "CI/automation"
+send -- "atlantis\r"
+
+expect "Proceed"
+send -- "\r"
+
+expect "Seeded CI memory (atlantis)"
+expect eof
+
+catch wait result
+exit [lindex $result 3]

--- a/tests/interactive/05-proceed-decline.exp
+++ b/tests/interactive/05-proceed-decline.exp
@@ -1,0 +1,46 @@
+#!/usr/bin/env expect
+# Walk through the prompts; answer "n" at the final Proceed prompt. Verifies
+# the abort path: "Aborted." prints, exit code is 0, no working folder is
+# created.
+
+source [file dirname [info script]]/helpers.exp
+
+spawn $::kit_root/bootstrap.sh
+
+expect "Path"
+send -- "$::test_wf\r"
+
+expect "Project name"
+send -- "\r"
+
+expect "Seed auto-memory"
+send -- "\r"
+
+expect "Issue tracker"
+send -- "\r"
+
+expect "CI/automation"
+send -- "\r"
+
+expect "Proceed"
+send -- "n\r"
+
+expect "Aborted"
+expect eof
+
+catch wait result
+set status [lindex $result 3]
+
+# Bootstrap should exit 0 on user-requested abort.
+if {$status != 0} {
+    puts stderr "expected exit 0 from user abort, got $status"
+    exit 1
+}
+
+# And no working folder should have been created.
+if {[file isdirectory $::test_wf]} {
+    puts stderr "FAIL: working folder $::test_wf exists after user-aborted run"
+    exit 1
+}
+
+exit 0

--- a/tests/interactive/helpers.exp
+++ b/tests/interactive/helpers.exp
@@ -1,0 +1,33 @@
+# Common setup for tests/interactive/*.exp — sourced at the top of each test.
+#
+# The runner (run.sh) sets these env vars per test:
+#   KIT_ROOT   — absolute path to the kit checkout
+#   TEST_REPO  — fake target repo (git init + origin remote already done)
+#   TEST_TMP   — sandbox temp root
+#   HOME       — sandboxed HOME (so memory writes stay inside TEST_TMP)
+#
+# Each test script should:
+#   1. Source this file.
+#   2. spawn $::kit_root/bootstrap.sh
+#   3. Drive the interactive prompts with expect/send.
+#   4. End with: expect eof; catch wait result; exit [lindex $result 3]
+
+set timeout 10
+
+# Default failure handler — fires on any expect that doesn't match its
+# patterns within $timeout. Prints what we DID see for debuggability.
+expect_after {
+    timeout {
+        puts stderr "TIMEOUT — last 1000 chars of output:"
+        puts stderr [string range $expect_out(buffer) end-1000 end]
+        exit 1
+    }
+}
+
+set ::kit_root  $env(KIT_ROOT)
+set ::test_repo $env(TEST_REPO)
+set ::test_tmp  $env(TEST_TMP)
+set ::test_wf   "$::test_tmp/wf"
+
+# Tests start with cwd = the fake repo.
+cd $::test_repo

--- a/tests/interactive/run.sh
+++ b/tests/interactive/run.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Runner for tests/interactive/*.exp — drives bootstrap.sh interactive mode.
+#
+# Each .exp file gets a fresh sandbox: temp dir, sandboxed $HOME, fake target
+# repo with a git remote. Mirrors the per-test isolation in tests/helpers.bash.
+#
+# Usage:
+#   tests/interactive/run.sh           # run all *.exp tests
+#   tests/interactive/run.sh foo.exp   # run a single file (path or basename)
+
+set -uo pipefail
+
+KIT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if ! command -v expect >/dev/null 2>&1; then
+  echo "error: 'expect' is required to run interactive tests" >&2
+  echo "       macOS: brew install expect" >&2
+  echo "       Debian/Ubuntu: sudo apt-get install -y expect" >&2
+  exit 2
+fi
+
+if [ "$#" -gt 0 ]; then
+  TARGETS=()
+  for arg in "$@"; do
+    if [ -f "$arg" ]; then
+      TARGETS+=("$arg")
+    elif [ -f "$SCRIPT_DIR/$arg" ]; then
+      TARGETS+=("$SCRIPT_DIR/$arg")
+    else
+      echo "error: cannot find test file: $arg" >&2
+      exit 2
+    fi
+  done
+else
+  TARGETS=("$SCRIPT_DIR"/[0-9]*.exp)
+fi
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+for exp in "${TARGETS[@]}"; do
+  [ -f "$exp" ] || continue
+  name="$(basename "$exp" .exp)"
+
+  TEST_TMP="$(mktemp -d)"
+  TEST_HOME="$TEST_TMP/home"
+  TEST_REPO="$TEST_TMP/repo"
+  mkdir -p "$TEST_HOME" "$TEST_REPO"
+  git -C "$TEST_REPO" init -q
+  git -C "$TEST_REPO" remote add origin "https://github.com/example/test-repo.git"
+
+  if HOME="$TEST_HOME" \
+     KIT_ROOT="$KIT_ROOT" \
+     TEST_REPO="$TEST_REPO" \
+     TEST_TMP="$TEST_TMP" \
+     expect "$exp" >/tmp/exp-out.$$ 2>&1; then
+    PASS=$((PASS + 1))
+    echo "  ok  $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("$name")
+    echo "  FAIL $name"
+    sed 's/^/      /' /tmp/exp-out.$$
+  fi
+
+  rm -f /tmp/exp-out.$$
+  rm -rf "$TEST_TMP"
+done
+
+echo
+echo "Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failed: %s\n' "${FAILED_TESTS[@]}"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- `tests/interactive/` (new directory) — five expect scripts driving the interactive `read -p` prompts in `bootstrap.sh`. Covers: default-flow accept-all, jira tracker + project key, linear tracker + team key, CI variant selection (atlantis), and the user-decline path at the final Proceed prompt.
- `tests/interactive/run.sh` — bash runner that sandboxes each `.exp` file the same way `tests/helpers.bash` sandboxes bats tests (per-test `HOME` override + fake target repo with stub `origin` remote). Reports pass/fail; non-zero exit on any failure.
- `tests/interactive/helpers.exp` — shared expect setup: 10s timeout, `expect_after` failure handler that prints the buffer on timeout, and the env-var → tcl-var bindings that individual tests use.
- `tests/README.md` — documents the new suite alongside bats: install instructions for `expect` (macOS + Debian/Ubuntu), how to run all / one test, the test layout table extended with the five new entries, and a "How to add an interactive test" recipe with a tcl template.
- `.github/workflows/bats.yml` — installs `expect` alongside `bats` and runs the interactive suite as a second step. Same workflow, two steps. Pre-existing path filters already cover this directory.

## Motivation

Closes #35. Interactive mode in `bootstrap.sh` is the only code path the bats suite couldn't cover — `[ -t 0 ]` is false under bats, so the `read -p` branches never executed. Manual smoke procedures were the previous fallback. They're not reliable: humans skip them, rationalize "it probably still works," and lie to the test plan when tired. Automation is the only way to keep coverage honest.

## Design notes

- **Decision: option A from C.3 (expect runner) over option B (manual smoke script) or C (accept the gap).** Option A is the only one that can't be skipped. The `expect` dependency is cheap — preinstalled on macOS, one-line `apt-get install` in CI.
- **Per-test sandbox in the bash runner, not in tcl.** The shell-side setup (mktemp, git init, stub remote) is much shorter in bash than in tcl. Each `.exp` script just sources `helpers.exp` (env-var bindings + timeout handler) and drives the prompts. Mirrors how `tests/helpers.bash` is structured for bats.
- **Numeric prefixes on test files** (`01-…`, `02-…`, etc.) for predictable run order. Future tests should pick the next number; no semantic meaning beyond ordering.
- **Pattern matching uses substrings, not full-prompt matches.** Bootstrap's prompts include `[default]` brackets that conflict with expect's glob character-class semantics. Matching `"Path"` instead of `"Path \\\["` keeps the tests simple and resilient to small prompt-text edits.
- **Five tests is a baseline, not an exhaustive matrix.** Each one exercises a distinct interactive branch: default-accept, tracker-with-key, tracker-without-key, CI variant, abort. The full Cartesian product of tracker × CI is already covered non-interactively by the bats suite — the interactive layer just needs to confirm each prompt branch fires correctly.
- **Failure mode = informative.** When an expect script times out (its most common failure), `expect_after` dumps the last 1000 chars of bootstrap's output to stderr. Lets you see what bootstrap printed, which makes "the prompt text changed" failures self-diagnosing.

## Test plan

- [x] `bats tests/` — 64/64 pass (no regressions; existing suite unchanged).
- [x] `tests/interactive/run.sh` — 5/5 pass locally (`expect` 5.45.4 on macOS via `/usr/bin/expect`).
- [x] `tests/interactive/run.sh 02-tracker-jira.exp` — single-file invocation works.
- [ ] CI: `Bats` workflow runs both `bats tests/` and `tests/interactive/run.sh` green on this PR. The `expect` install step adds ~5s to total runtime.
- [ ] Manually verify on a fresh clone (post-merge) that someone with neither `bats` nor `expect` installed gets the documented install instructions when running each suite.

## CHANGELOG

Three commits, three CHANGELOG entries:
- `test(interactive): add expect-based interactive-mode test suite` — Tests section
- `docs(tests): document expect suite in tests/README.md` — Documentation section
- `ci: run expect interactive suite alongside bats` — CI section

`test:`, `docs:`, and `ci:` commits → release-please patch bump (e.g. v0.10.1 → v0.10.2 once the SECURITY.md release lands first).