### PR TITLE
feat: add .claude/ starter agents and slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ The working folder is project-specific knowledge ("what are we building, how far
 │   ├── implementation.md
 │   ├── phase-N-checklist.md
 │   ├── acceptance-test-results.md
-│   └── research.md
+│   ├── research.md
+│   └── .claude/             ← starter agents + slash commands (staged in WF)
+│       ├── agents/          ← code-reviewer, session-summarizer
+│       ├── commands/        ← /close-phase, /session-end
+│       └── README.md        ← how to copy into your target repo
 ├── examples/                ← filled-in reference — read, don't copy
 │   └── widget-tracker/      ← fictional Go CLI, mid-Phase-1 snapshot
 └── memory-templates/        ← starter auto-memory for a new project

--- a/SETUP.md
+++ b/SETUP.md
@@ -157,7 +157,10 @@ If you can't run `bootstrap.sh` (no Bash available, restricted environment, or y
 mkdir -p "<working-folder>"
 cp <framework-dir>/templates/*.md "<working-folder>/"
 mv "<working-folder>/phase-N-checklist.md" "<working-folder>/phase-0-checklist.md"
+[ -d "<framework-dir>/templates/.claude" ] && cp -R "<framework-dir>/templates/.claude" "<working-folder>/"
 ```
+
+The `.claude/` directory holds starter agents and slash commands that match the kit's session-end / phase-close conventions. They're staged in the working folder; copy into your target repo's `.claude/` if you want them active. See [`templates/.claude/README.md`](templates/.claude/README.md) for the four starters and how to activate them.
 
 ### Seed auto-memory
 The harness expects memory at `~/.claude/projects/<sanitized-path>/memory/`. Sanitization rule: absolute repo path with `/` replaced by `-`, prefixed with `-`. Example: `/Users/you/Code/acme/foo` → `-Users-you-Code-acme-foo`.
@@ -197,9 +200,13 @@ For a fully filled-in reference, see [`examples/widget-tracker/CONTEXT.md`](exam
    ```bash
    cp <kit-dir>/memory-templates/<NEW_FILE>.md ~/.claude/projects/<sanitized-path>/memory/
    ```
-4. **Changed prose in kit-level files** (e.g. `CONVENTIONS.md`, `SETUP.md`, `README.md`) — re-read them. Your local copies of working-folder templates and memory files are yours; they don't auto-upgrade.
-5. **New `bootstrap.sh` flags or behavior** — apply only to *new* projects you bootstrap going forward. Already-bootstrapped projects keep their current state.
-6. **Don't re-run `bootstrap.sh`** on a populated working folder — it errors by design. If you really need to re-seed, clear the auto-memory dir manually and pass `--force` to the working folder, but you'll lose local customizations.
+4. **New files in `templates/.claude/`** — copy into your working folder's `.claude/` (then re-copy into your target repo if you've activated those starters):
+   ```bash
+   cp -R <kit-dir>/templates/.claude/<NEW_FILE> <working-folder>/.claude/
+   ```
+5. **Changed prose in kit-level files** (e.g. `CONVENTIONS.md`, `SETUP.md`, `README.md`) — re-read them. Your local copies of working-folder templates and memory files are yours; they don't auto-upgrade.
+6. **New `bootstrap.sh` flags or behavior** — apply only to *new* projects you bootstrap going forward. Already-bootstrapped projects keep their current state.
+7. **Don't re-run `bootstrap.sh`** on a populated working folder — it errors by design. If you really need to re-seed, clear the auto-memory dir manually and pass `--force` to the working folder, but you'll lose local customizations.
 
 If a future change is *not* backwards-compatible (rare for a docs-only kit — only likely if a template structure fundamentally changes), the CHANGELOG entry will call that out explicitly.
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -344,6 +344,9 @@ if [ "$DRY_RUN" -eq 1 ]; then
   echo "Would create working folder: $WORKING_FOLDER"
   echo "  + copy $KIT_ROOT/templates/*.md"
   echo "  + rename phase-N-checklist.md → phase-0-checklist.md"
+  if [ -d "$KIT_ROOT/templates/.claude" ]; then
+    echo "  + copy templates/.claude/ → $WORKING_FOLDER/.claude/ (starter agents + commands)"
+  fi
   if [ -e "$WORKING_FOLDER" ] && [ -n "$(ls -A "$WORKING_FOLDER" 2>/dev/null)" ] && [ "$FORCE" -eq 0 ]; then
     echo "  ! working folder already non-empty — real run would fail without --force"
   fi
@@ -421,6 +424,11 @@ cp "$KIT_ROOT/templates/"*.md "$WORKING_FOLDER/"
 mv "$WORKING_FOLDER/phase-N-checklist.md" "$WORKING_FOLDER/phase-0-checklist.md"
 echo "  ✓ Copied template files to $WORKING_FOLDER"
 echo "  ✓ Renamed phase-N-checklist.md → phase-0-checklist.md"
+
+if [ -d "$KIT_ROOT/templates/.claude" ]; then
+  cp -R "$KIT_ROOT/templates/.claude" "$WORKING_FOLDER/"
+  echo "  ✓ Copied .claude/ starters (agents + commands) to $WORKING_FOLDER/.claude/"
+fi
 
 if [ "$SKIP_MEMORY" -eq 0 ]; then
   mkdir -p "$MEMORY_DIR"

--- a/templates/.claude/README.md
+++ b/templates/.claude/README.md
@@ -1,0 +1,31 @@
+# `.claude/` starters
+
+Two agents and two slash commands that follow the kit's session-end + phase-close conventions. Staged here in your working folder; copy into your target repo's `.claude/` if you want them.
+
+## What's here
+
+### Agents (`.claude/agents/`)
+
+- **`code-reviewer.md`** — reviews diffs, branches, or files for security / correctness / performance / style. Universal; works on any project.
+- **`session-summarizer.md`** — drafts SESSION-LOG entries, CONTEXT.md status bumps, checklist scans, and memory candidates from the current session's activity. Specific to projects using the kit's working-folder pattern.
+
+### Slash commands (`.claude/commands/`)
+
+- **`/close-phase`** — runs the phase-close writeback (checklist tick, `plan.md` status, `CONTEXT.md`, `SESSION-LOG.md`, optional acceptance-results archive). Takes a phase number or infers from `CONTEXT.md`.
+- **`/session-end`** — Prompt 3 from `PROMPTS.md` packaged as a slash command. Drafts the end-of-session updates, waits for confirmation before writing.
+
+## How to activate them
+
+These are **staged in your working folder, not in your target repo.** The kit doesn't modify the target repo — that's the kit's invariant. To activate the agents and commands, copy the directory into your target repo:
+
+```bash
+cp -r <working-folder>/.claude/ <your-repo>/.claude/
+```
+
+Then commit the target's `.claude/` (or `.gitignore` it) to taste — the kit doesn't have an opinion. Both agents and slash commands work the same way whether they're committed or not.
+
+## Customizing
+
+These are starters. Edit them, swap models in the frontmatter, restrict the tool allowlist, write new ones. The kit's role is to seed the pattern, not own the content.
+
+To add a new agent: create `<working-folder>/.claude/agents/<name>.md` with frontmatter (`name`, `description`; optional `tools`, `model`). To add a new slash command: `<working-folder>/.claude/commands/<name>.md` with optional frontmatter (`description`, `argument-hint`, `allowed-tools`, `model`). Then re-copy into the target repo.

--- a/templates/.claude/agents/code-reviewer.md
+++ b/templates/.claude/agents/code-reviewer.md
@@ -1,0 +1,33 @@
+---
+name: code-reviewer
+description: Review code changes (diffs, PR branches, or individual files) for security issues, correctness gaps, performance concerns, and style drift. Use proactively after non-trivial changes, before merge, or when the user asks for a second-opinion review.
+tools: Read, Grep, Glob, Bash
+---
+
+You are a code reviewer focused on giving actionable feedback before merge.
+
+## What to look for
+
+- **Security:** injection points (SQL, command, prompt), unsafe deserialization, secrets committed to code, path traversal, missing input validation at trust boundaries (user input, third-party APIs, file paths from arguments).
+- **Correctness:** off-by-one errors, null/undefined handling, race conditions, error paths that swallow failures silently, missing edge cases (empty input, max-size input, unicode, concurrent access).
+- **Performance:** N+1 queries, unbounded loops, memory leaks, accidentally-quadratic algorithms, repeated work that could be cached or batched.
+- **Style drift:** code that doesn't match the conventions in the rest of the file, in `CONVENTIONS.md` if present, or in nearby modules.
+
+## How to work
+
+1. **Identify the scope.** A diff (`git diff origin/main`), a branch (`git log --oneline origin/main..HEAD`), a single file (the path the user gave), or the working tree (`git status`). Ask if unclear.
+2. **Read each changed file fully** — context outside the diff often hides the bug. Don't review only the changed lines.
+3. **Cross-reference.** If a function changed, find its callers. If a public API changed, grep for usage sites.
+4. **Run lightweight verification only if asked** (e.g. `bats tests/`, `npm test`). Otherwise stick to static review — running tests is the human's call.
+
+## Hand back
+
+Group findings by severity:
+
+- **Block:** must-fix before merge (security holes, correctness bugs, breaking behavior changes).
+- **Discuss:** worth a conversation but not necessarily a blocker (alternative designs, performance tradeoffs, naming concerns).
+- **Nit:** style / clarity suggestions, take or leave.
+
+For each finding, cite the file and line (`path/to/file.ext:42`) and explain **why** it's an issue, not just **what** it is. Bare findings without rationale are noise.
+
+If nothing material comes up, say so explicitly. A clean review is a valid outcome — don't manufacture findings.

--- a/templates/.claude/agents/session-summarizer.md
+++ b/templates/.claude/agents/session-summarizer.md
@@ -1,0 +1,44 @@
+---
+name: session-summarizer
+description: Draft the end-of-session SESSION-LOG entry, suggest CONTEXT.md status updates, and flag missed checklist ticks for projects following the claude-project-kit pattern. Use at the end of a working session before pushing or closing.
+tools: Read, Bash, Glob
+---
+
+You are a session-end scribe for a project that uses the `claude-project-kit` pattern (working folder with `CONTEXT.md`, `SESSION-LOG.md`, `plan.md`, `phase-N-checklist.md`).
+
+## Goal
+
+Hand the user back drafts they can review and then commit. **Do not edit any files yourself.** Drafts only.
+
+## What to produce
+
+1. **`SESSION-LOG.md` entry** to append:
+   - Date (YYYY-MM-DD)
+   - One-line focus
+   - Branches touched / PRs opened, merged, or still open (with numbers)
+   - Key decisions or rule changes worth recording
+   - Non-obvious findings for next session
+   - Open threads / next steps
+
+2. **`CONTEXT.md` status-line update** (if applicable). Propose new wording for the "Current Phase Status" line if this session moved the phase forward. If nothing changed, say so.
+
+3. **Checklist scan** of the current `phase-<N>-checklist.md`:
+   - Items that landed this session but aren't yet ticked
+   - Ticked items missing branch / PR numbers
+
+4. **Memory candidates.** Any rule, preference, or correction that came up more than once is a candidate for a `feedback_*.md` memory file. Draft the entry if applicable, including the **Why:** and **How to apply:** lines.
+
+## How to gather context
+
+- `git log --oneline --since="<approximate session start>"` — this session's commits.
+- `gh pr list --state all --limit 10` — PR activity (open, merged, closed).
+- `gh issue list --state all --limit 10` — issue activity if the repo uses Issues.
+- Read the last entry in `SESSION-LOG.md` to know where the previous session left off.
+- Read the current `phase-<N>-checklist.md` to find items that should be ticked.
+- Read `CONTEXT.md` for the current phase status line.
+
+## Hand back
+
+Show each section as a separate, clearly-labeled block. The user will confirm or correct each one before anything is written. Do not write files; do not invoke `git commit` or `gh pr edit` — draft only.
+
+If the working folder path isn't obvious, check the `reference_ai_working_folder.md` in auto-memory or ask the user before guessing.

--- a/templates/.claude/commands/close-phase.md
+++ b/templates/.claude/commands/close-phase.md
@@ -1,0 +1,30 @@
+---
+description: Close a project phase — tick the checklist, update plan.md status, archive acceptance results, append a SESSION-LOG entry. Drafts everything; waits for confirmation before writing.
+argument-hint: [phase-number]
+---
+
+Close phase $ARGUMENTS of this project. If no phase number was given, read `CONTEXT.md` and infer the current phase.
+
+## Files to load
+
+- `<working-folder>/CONTEXT.md` — current phase status
+- `<working-folder>/plan.md` — phase breakdown
+- `<working-folder>/phase-$ARGUMENTS-checklist.md` (or current `phase-N-checklist.md`)
+- `<working-folder>/SESSION-LOG.md` — last entry for context
+- `<working-folder>/acceptance-test-results.md` if it exists
+
+The working-folder path comes from `reference_ai_working_folder.md` in auto-memory. If that's not set, ask the user before guessing.
+
+## What to do
+
+1. **Tick remaining unchecked items** in the phase checklist. For each, find the matching merged PR (`gh pr list --state merged`) and add the PR number + merge date. If no PR exists for an item, flag it for human review rather than ticking blindly.
+2. **Update plan.md "Status" line** at the top to reflect phase closure (e.g. `Phase N complete ✅ (YYYY-MM-DD)`).
+3. **Update CONTEXT.md "Current Phase Status"** block — mark the closing phase complete, set the next phase posture (often "Deferred — no active work").
+4. **Archive acceptance results** if `acceptance-test-results.md` exists and is non-empty: rename to `acceptance-test-results-phase-$ARGUMENTS.md` and update the CONTEXT.md Reference section to point at the archive.
+5. **Draft a SESSION-LOG entry** for this session covering: focus, PRs landed, key decisions, non-obvious findings, open threads.
+
+## Hand back
+
+Show each change as a diff (or as the proposed file content if it's a new file). Wait for the user's confirmation per change before writing.
+
+Do not invoke `git commit` or push. The user commits the working-folder updates separately when they're ready.

--- a/templates/.claude/commands/session-end.md
+++ b/templates/.claude/commands/session-end.md
@@ -1,0 +1,28 @@
+---
+description: End-of-session wrap-up — draft SESSION-LOG entry, suggest CONTEXT.md status updates, flag unticked checklist items, draft any new memory entries. Same flow as Prompt 3 in PROMPTS.md, packaged as a slash command.
+---
+
+We're wrapping up this session. Help me apply the end-of-session hygiene.
+Do NOT edit any files yet — draft everything, show me, and wait for my
+confirmation before writing anything.
+
+1. Draft a SESSION-LOG.md entry for today:
+   - Date (YYYY-MM-DD)
+   - 1-line focus
+   - Branches touched / PRs opened, merged, or still open (with numbers)
+   - Decisions, rule changes, or gotchas worth recording for next session
+   - Open threads ("what we'd pick up next time")
+
+2. Suggest whether CONTEXT.md's "Current Phase Status" line needs a bump,
+   based on what changed this session. If so, propose the new wording.
+
+3. Scan the current phase-<N>-checklist.md:
+   - Flag items that landed this session but aren't yet ticked
+   - Flag ticked items missing a branch or PR number
+
+4. Flag any preference or rule that came up more than once this session —
+   those are candidates for a new feedback_*.md memory file. Draft the
+   feedback entry if applicable.
+
+Show me each of these as a separate section. I'll confirm each before
+anything is written.

--- a/tests/bootstrap_memory.bats
+++ b/tests/bootstrap_memory.bats
@@ -26,6 +26,20 @@ teardown() { bootstrap_teardown; }
   [ ! -f "$TEST_WF/phase-N-checklist.md" ]
 }
 
+@test "templates/.claude/ starters are copied to working folder" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_WF/.claude" ]
+  [ -d "$TEST_WF/.claude/agents" ]
+  [ -d "$TEST_WF/.claude/commands" ]
+  [ -f "$TEST_WF/.claude/agents/code-reviewer.md" ]
+  [ -f "$TEST_WF/.claude/agents/session-summarizer.md" ]
+  [ -f "$TEST_WF/.claude/commands/close-phase.md" ]
+  [ -f "$TEST_WF/.claude/commands/session-end.md" ]
+  [ -f "$TEST_WF/.claude/README.md" ]
+  [[ "$output" == *".claude/ starters"* ]]
+}
+
 @test "basic run seeds memory folder with all starter files" {
   run "$BOOTSTRAP" "$TEST_WF"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

- `templates/.claude/` (new directory under `templates/`) — staging area for starter Claude Code agents and slash commands. Five files:
  - `agents/code-reviewer.md` — universal diff/branch/file reviewer (security, correctness, performance, style)
  - `agents/session-summarizer.md` — drafts SESSION-LOG entries, CONTEXT.md status bumps, checklist scans, memory candidates
  - `commands/close-phase.md` — `/close-phase [phase-number]` runs the phase-close writeback
  - `commands/session-end.md` — `/session-end` packages Prompt 3 from `PROMPTS.md` as a slash command
  - `README.md` — explains the staging pattern and how to activate the starters in a target repo
- `bootstrap.sh` — copies `templates/.claude/` into the working folder (`cp -R`) when present. Dry-run preview mentions the copy.
- `tests/bootstrap_memory.bats` — new test asserting the `.claude/` directory and all five starter files land in the working folder; bats suite goes 64 → 65.
- `README.md` + `SETUP.md` — file-tree listing extended; Manual-alternative bootstrap commands include the `.claude/` copy; Upgrading-an-existing-project section gets a step for new files in `templates/.claude/`.

## Motivation

Closes #37. Claude Code's agents + slash-command mechanism is powerful but undiscovered by most users. Shipping starters that follow the kit's session-end / phase-close conventions raises the floor — adopters get working examples on day one, edit to taste, and add their own from there.

## Design notes

- **Placement: working folder, not target repo.** The kit's invariant is "never modify the target repo." Bootstrap copies `templates/.claude/` into the working folder's `.claude/`; the user copies that to their target repo's `.claude/` if they want the starters active. `templates/.claude/README.md` explains the activation step.
- **Scope: 2 agents + 2 commands**, not a kitchen sink. Each one matches an existing kit convention (`code-reviewer` is universal; `session-summarizer` + `/close-phase` + `/session-end` align with the kit's working-folder + checklist + SESSION-LOG patterns). Adopters extend; the kit doesn't try to own the long tail.
- **`/session-end` duplicates Prompt 3 verbatim** rather than referencing `PROMPTS.md`. Reason: the slash command's content has to be self-contained — Claude doesn't know about `PROMPTS.md` from a different repo. Two copies is fine; the kit's docs explain that the slash command and the prompt are interchangeable convenience-wrappers around the same flow.
- **`cp -R`, not `cp -r`.** macOS BSD `cp` and GNU `cp` both accept `-R`; `-r` is GNU-specific. Matches the kit's "Bash 3+ portable" stance.
- **Conditional copy** — `if [ -d "$KIT_ROOT/templates/.claude" ]` — so the kit can land this PR without breaking older clones that haven't pulled yet (they'd just skip the copy silently). Belt-and-suspenders; not strictly needed once this is in `main`, but cheap.
- **No `.claude/` interactive-test coverage.** The copy is non-interactive; bats covers it. The expect suite stays focused on the `read -p` prompts in interactive mode.

## Test plan

- [x] `bash -n bootstrap.sh` — syntax OK.
- [x] `bats tests/` — 65/65 pass locally (was 64; +1 for `.claude/` copy assertion).
- [x] `tests/interactive/run.sh` — 5/5 pass (no regression).
- [x] Manual real-run: `bootstrap.sh --skip-memory /tmp/wf-37-test` produces `/tmp/wf-37-test/.claude/{agents,commands,README.md}` with the five starter files.
- [x] Manual dry-run: `bootstrap.sh --dry-run /tmp/wf-37-dry` includes `+ copy templates/.claude/ → /tmp/wf-37-dry/.claude/ (starter agents + commands)` in the plan.
- [ ] CI: `Bats` workflow runs both bats + expect suites green on this PR.
- [ ] CI: `markdown link check` workflow passes — relative links in the new `templates/.claude/README.md` (and the README/SETUP additions) all resolve.

## CHANGELOG

Four commits, four entries:
- `feat(templates): add .claude/ starter agents and commands` — Features (minor bump)
- `feat(bootstrap): copy templates/.claude/ to working folder` — Features (minor bump, but already implied by the templates feat)
- `test(bootstrap): verify .claude/ copy` — Tests
- `docs: document templates/.claude/ in README and SETUP` — Documentation

`feat:` → minor bump (e.g. v0.10.1 → v0.11.0). New user-facing capability.