### PR TITLE
docs: add Features section to README, FEATURES.md reference, and polish bootstrap.sh -h

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,185 @@
+# Features
+
+A feature-by-feature reference. For setup steps, see [SETUP.md](SETUP.md). For the high-level pitch, see [README.md](README.md).
+
+## Contents
+
+- [Bootstrap](#bootstrap)
+- [Issue tracker awareness](#issue-tracker-awareness)
+- [CI awareness](#ci-awareness)
+- [Auto-memory seeding](#auto-memory-seeding)
+- [Phase-based planning docs](#phase-based-planning-docs)
+- [SEED-PROMPT auto-fill](#seed-prompt-auto-fill)
+- [Starter agents](#starter-agents)
+- [Starter slash commands](#starter-slash-commands)
+- [Worked example](#worked-example)
+- [Conventions baseline](#conventions-baseline)
+- [Manual mode](#manual-mode)
+- [What the kit does NOT do](#what-the-kit-does-not-do)
+
+---
+
+## Bootstrap
+
+### Idempotent, write-once
+
+`bootstrap.sh` is conservative on purpose — it refuses to clobber a populated working folder or auto-memory directory. Re-running on the same target prints what's already there and exits clean.
+
+- `--dry-run` — preview every path that would be created, every placeholder substitution, the tracker memory file, and the `MEMORY.md` index line. Writes nothing. Safe to run repeatedly.
+- `--force` — override the working-folder check (auto-memory is **still** protected; existing memory files are never overwritten).
+- `--skip-memory` — seed the working folder only, leave `~/.claude/projects/<sanitized-path>/memory/` alone.
+
+```bash
+bootstrap.sh ~/Documents/Claude/Projects/foo --dry-run
+```
+
+### Interactive vs. scripted modes
+
+Run with no path argument and a TTY → **interactive**. Bootstrap prompts for working folder, project name, memory seeding, tracker, and CI, then shows a summary and asks to confirm before any file writes.
+
+Run with a path argument → **non-interactive**. Flags drive everything; bootstrap errors fast on bad input rather than hanging. Piped or redirected stdin without a path argument also errors (no silent hang).
+
+```bash
+# Interactive
+bootstrap.sh
+
+# Scripted
+bootstrap.sh ~/Documents/Claude/Projects/foo \
+  --tracker jira --jira-project INFRA \
+  --ci github-actions
+```
+
+### `--project-name`
+
+Override the auto-derived project name used to fill `{{PROJECT_NAME}}` in seeded memory files. By default bootstrap uses the basename of `<working-folder>`; pass this when the basename doesn't match the human-friendly name you want.
+
+```bash
+bootstrap.sh ~/Documents/Claude/Projects/foo --project-name "Foo Service"
+```
+
+---
+
+## Issue tracker awareness
+
+`--tracker {github,jira,linear,gitlab,shortcut,other,none}` seeds a tracker-specific `reference_issue_tracker.md` into auto-memory. Each variant ships the conventions Claude needs to reference tickets correctly: URL pattern, ticket-reference format in commits / PRs, branch-naming convention, and the CLI tool of choice (`gh`, `jira`, `linear`, `glab`, etc.).
+
+| Tracker | Key flag | Notes |
+|---|---|---|
+| `github` | — | Default. Issues live on the same repo. |
+| `jira` | `--jira-project KEY` | Implies `--tracker jira`. JIRA MCP integration assumed if available. |
+| `linear` | `--linear-team KEY` | Implies `--tracker linear`. |
+| `gitlab` | — | Issues on the same project. |
+| `shortcut` | — | Story IDs in commits / PRs. |
+| `other` | — | Escape hatch — seeds a placeholder-rich file you fill in by hand. |
+| `none` | — | Skips tracker memory entirely. |
+
+In non-interactive mode, omitting `--tracker` is the same as `--tracker none` — bootstrap won't guess.
+
+---
+
+## CI awareness
+
+`--ci {github-actions,gitlab-ci,jenkins,circleci,atlantis,ansible-cli,other,none}` seeds a CI-specific `reference_ci.md` into auto-memory: where the pipeline config lives, how to query status from CLI, what a passing build looks like, and the kit's "CI in the background" convention.
+
+`atlantis` and `ansible-cli` cover the Terraform / infra-automation cases that don't fit a standard CI shape. `other` and `none` work the same as for trackers.
+
+```bash
+bootstrap.sh ~/Documents/Claude/Projects/foo --ci atlantis
+```
+
+---
+
+## Auto-memory seeding
+
+Bootstrap copies `memory-templates/` into the harness-expected path (`~/.claude/projects/<sanitized-path>/memory/`) and substitutes placeholders from the current repo:
+
+- `{{PROJECT_NAME}}` — derived or `--project-name`
+- `{{WORKING_FOLDER}}` — the path you provided
+- `{{REPO_PATH}}` — absolute path to the target repo
+- `{{REPO_SLUG}}` — derived from `git remote get-url origin` if available
+
+Anything that can't be derived stays as `{{PLACEHOLDER}}` so it's grep-able. The end-of-run output flags any unsubstituted placeholders so you know what to fill in.
+
+The memory files are **starters**, not commandments. Prune what doesn't apply, add your own, keep `MEMORY.md` (the index) in sync. The harness loads `MEMORY.md` into context every session, so it stays small (under ~150 lines is a reasonable target).
+
+---
+
+## Phase-based planning docs
+
+The working-folder template includes a planning structure that scales from weekend project to multi-quarter work:
+
+- **`plan.md`** — phases at a high level. One section per phase, with goals and exit criteria.
+- **`phase-N-checklist.md`** — current phase's task list. Tick boxes, branch + PR per item.
+- **`implementation.md`** — running design / decision log for the active phase.
+- **`acceptance-test-results.md`** — end-of-phase verification record.
+- **`research.md`** — exploratory notes, references, dead ends.
+
+Bootstrap renames the phase-N template to `phase-0-checklist.md` so you can start filling it immediately. Subsequent phases follow the `phase-1-checklist.md`, `phase-2-checklist.md` pattern — the `/close-phase` slash command handles the writeback when one wraps.
+
+You don't have to use all of these. Bare minimum for a small project: `CONTEXT.md` + `SESSION-LOG.md`. Add the rest when scope warrants.
+
+---
+
+## SEED-PROMPT auto-fill
+
+Bootstrap drops `SEED-PROMPT.md` into the working folder. After bootstrap, open Claude Code in the target repo and say:
+
+> Follow the instructions in `<working-folder>/SEED-PROMPT.md`.
+
+Claude reads your README, package manifests, CI config, source layout, and recent git activity, then fills `CONTEXT.md` for you. Inferred fields are tagged `[CLAUDE-INFERRED: reasoning]`; fields it can't derive are tagged `[HUMAN-CONFIRM: question]`. It drafts an initial `research.md`, then **stops**, summarizes, and asks ≤5 targeted questions before going further.
+
+Saves ~30 minutes of manual fill-in on a real project, and the inference markers make the human review pass fast (grep, confirm, move on).
+
+---
+
+## Starter agents
+
+Two agents stage in `<working-folder>/.claude/agents/`. The kit doesn't modify your target repo — to activate, copy the directory in:
+
+```bash
+cp -r <working-folder>/.claude/ <your-repo>/.claude/
+```
+
+- **`code-reviewer`** — reviews diffs, branches, or files for security / correctness / performance / style. Project-agnostic; works anywhere.
+- **`session-summarizer`** — drafts SESSION-LOG entries, CONTEXT.md status bumps, checklist scans, and memory candidates from the current session's activity. Specific to projects using the kit's working-folder pattern.
+
+These are **starters**. Edit the frontmatter (model, tool allowlist), customize the prompts, write your own. The kit seeds the pattern, not the content. See [`templates/.claude/README.md`](templates/.claude/README.md) for the activation flow and how to add new ones.
+
+---
+
+## Starter slash commands
+
+Two slash commands stage in `<working-folder>/.claude/commands/`. Same activation pattern — copy `.claude/` into your target repo.
+
+- **`/close-phase`** — runs the phase-close writeback (checklist tick, `plan.md` status bump, `CONTEXT.md` update, optional acceptance-results archive). Takes a phase number or infers from `CONTEXT.md`.
+- **`/session-end`** — packages Prompt 3 from `PROMPTS.md` as a slash command. Drafts the four end-of-session updates (SESSION-LOG entry, CONTEXT bump, checklist scan, memory candidates) and waits for confirmation before writing.
+
+---
+
+## Worked example
+
+`examples/widget-tracker/` is a fictional Go CLI mid-Phase-1, with `CONTEXT.md`, `plan.md`, `phase-0-checklist.md`, `phase-1-checklist.md`, `SESSION-LOG.md`, and `implementation.md` filled in plausibly. Use it as a reference when you're not sure what a finished template should look like — read it, don't copy it.
+
+---
+
+## Conventions baseline
+
+`CONVENTIONS.md` captures defaults that have held up across projects: Conventional Commits, single-line commit messages, merge-commit PR strategy, detailed PR test plans, CI-in-background. Read once, keep what fits, drop what doesn't. For work projects, vet against employer policy first.
+
+The kit's own development follows these conventions, so the repo is a worked example of the conventions in action.
+
+---
+
+## Manual mode
+
+Every step has a manual alternative — see [SETUP.md §Manual alternative](SETUP.md#manual-alternative). Useful when Bash isn't available, you're in a restricted environment, or you just want to see what bootstrap would do without running it.
+
+---
+
+## What the kit does NOT do
+
+- **Doesn't modify your target repo.** Templates land in the working folder; memory lands in the harness path. Your repo stays clean.
+- **Doesn't make network calls.** No telemetry, no auto-update check, no remote dependencies at runtime.
+- **Doesn't manage your tracker / CI.** It seeds memory so Claude knows the conventions; it doesn't create JIRA projects, push GitHub Actions workflows, or open issues for you.
+- **Doesn't replace `CLAUDE.md`.** They're complementary — the kit handles cross-session state and preferences; `CLAUDE.md` handles in-repo guidance Claude reads automatically.
+- **Doesn't auto-upgrade installed projects.** When the kit ships new templates, existing adopters apply changes manually with the diff in [CHANGELOG.md](CHANGELOG.md). Bootstrap is write-once by design.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,78 @@
 # Claude Project Framework
 
+[![Release](https://img.shields.io/github/v/release/IamMrCupp/claude-project-kit?display_name=tag&sort=semver)](https://github.com/IamMrCupp/claude-project-kit/releases)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Tested on macOS / Linux](https://img.shields.io/badge/tested%20on-macOS%20%7C%20Linux-lightgrey)](#requirements)
+
 A reusable scaffold for starting new projects with Claude. Battle-tested on real projects and generalized so it works for personal code, open-source, or work projects.
 
 > **Heads up — Claude state for a bootstrapped project lives in three places, none of them your repo:**
-> 1. **Kit checkout** (wherever you cloned this repo) — templates, `bootstrap.sh`, docs.
-> 2. **Working folder** (you pick the path — [SETUP.md §1](SETUP.md#1-pick-a-working-folder-location) lists options) — per-project context.
-> 3. **Auto-memory** at `~/.claude/projects/<sanitized-path>/memory/` (fixed by the Claude harness) — per-project preferences.
 >
-> The kit never modifies your repo. All three locations above are private and local.
+> ```
+>   ┌────────────────────┐    templates copied   ┌──────────────────────┐
+>   │   Kit checkout     │ ───────────────────▶  │   Working folder     │
+>   │  (this repo)       │                       │  (per-project state) │
+>   │  templates/        │                       │  CONTEXT.md          │
+>   │  bootstrap.sh      │                       │  SESSION-LOG.md      │
+>   │  docs              │                       │  plan.md, …          │
+>   └────────────────────┘                       └──────────────────────┘
+>            │                                              ▲
+>            │ memory seeded                                │ Claude reads
+>            ▼                                              │ each session
+>   ┌────────────────────────────────────────────────────────────┐
+>   │                       Auto-memory                          │
+>   │   ~/.claude/projects/<sanitized-path>/memory/              │
+>   │   (per-project preferences, persistent across sessions)    │
+>   └────────────────────────────────────────────────────────────┘
+> ```
+>
+> The kit never modifies your repo. All three locations are private and local.
+
+## Contents
+
+- [Quickstart](#quickstart)
+- [Features](#features)
+- [What this is / isn't](#what-this-is--isnt)
+- [Why this works](#why-this-works)
+- [The idea, in one paragraph](#the-idea-in-one-paragraph)
+- [How to use](#how-to-use-new-or-existing-project)
+- [The lifecycle](#the-lifecycle)
+- [What's in here](#whats-in-here)
+- [Requirements](#requirements)
+- [Related docs](#related-docs)
+- [Support](#support)
+- [License](#license)
+
+## Quickstart
+
+```bash
+git clone https://github.com/IamMrCupp/claude-project-kit ~/Code/claude-project-kit
+cd <your-repo>                                   # the project you want to bootstrap
+~/Code/claude-project-kit/bootstrap.sh           # interactive — asks you everything
+```
+
+That kicks off interactive mode: it asks for the working-folder path, project name, issue tracker, and CI tool, then seeds everything in one pass. Full walkthrough in [SETUP.md](SETUP.md). Full flag list: `bootstrap.sh -h`.
+
+## Features
+
+- **Idempotent bootstrap** — write-once by default, with `--dry-run` (preview), `--force` (override the empty-folder check), and `--skip-memory` (working folder only).
+- **Issue tracker awareness** — `--tracker {github,jira,linear,gitlab,shortcut,other,none}` seeds tracker-specific memory. JIRA and Linear take a project / team key.
+- **CI awareness** — `--ci {github-actions,gitlab-ci,jenkins,circleci,atlantis,ansible-cli,other,none}` seeds CI-specific memory.
+- **Auto-memory seeding** — starter memory files for role, conventions, project context, and external references, with placeholder substitution from your repo (`{{PROJECT_NAME}}`, `{{REPO_SLUG}}`, etc.).
+- **Phase-based planning docs** — `plan.md` + per-phase checklist + `implementation.md` give Claude scoped, numbered tasks instead of a wall of intent.
+- **SEED-PROMPT auto-fill** — point Claude at one file and it deep-reads your repo, fills `CONTEXT.md`, drafts `research.md`, flags inferences, and stops for your review.
+- **Starter agents** — `code-reviewer` (universal) and `session-summarizer` (kit-aware), staged in the working folder; copy into your repo to activate.
+- **Starter slash commands** — `/close-phase` (phase-close writeback) and `/session-end` (end-of-session log + memory pass).
+- **Worked example** — `examples/widget-tracker/` is a fictional Go CLI mid-Phase-1 with all docs filled in plausibly.
+- **Conventions baseline** — Conventional Commits, merge-only PRs, test-plan format, etc. Read once, drop or keep per project.
+- **No surprises** — MIT licensed, no telemetry, no network calls, kit never modifies your target repo.
+
+See [FEATURES.md](FEATURES.md) for one-paragraph-per-feature detail with example invocations.
+
+## What this is / isn't
+
+- **Is:** a workflow scaffold layered on top of Claude Code — templates, memory starters, conventions, two starter agents, two starter slash commands.
+- **Isn't:** a Claude Code plugin, a replacement for `CLAUDE.md`, or a project tracker. It complements all three.
 
 ## Why this works
 
@@ -28,15 +93,47 @@ Every project gets **two parallel sets of files**:
 
 The working folder is project-specific knowledge ("what are we building, how far are we, what landed last week"). Auto-memory is cross-session behavior ("always use merge commits", "I prefer terse responses"). Neither is committed to the repo.
 
+## How to use (new or existing project)
+
+Works the same for greenfield repos and ones you're adopting it on mid-stream — the kit never modifies the target repo, it just creates an external working folder and seeds per-project auto-memory.
+
+1. Read [SETUP.md](SETUP.md) — it walks you through the full bootstrap in ~10 minutes.
+2. Pick a private working folder location (e.g. `~/Documents/Claude/Projects/<Project Name>/`).
+3. From your target repo root, run `bootstrap.sh` — either of:
+   - **Interactive (hand-held):** `bootstrap.sh` with no arguments prompts for working-folder path, project name, whether to seed auto-memory, your issue tracker (GitHub Issues / JIRA / Linear / GitLab / Shortcut / other / none), and your primary CI/automation tool (GitHub Actions / GitLab CI / Jenkins / CircleCI / Atlantis / Ansible CLI / other / none). For JIRA and Linear, it also prompts for the project or team key.
+   - **Non-interactive (scripted):** `bootstrap.sh <working-folder> [--tracker TYPE] [--jira-project KEY | --linear-team KEY] [--ci TYPE]` — see `bootstrap.sh -h` for the full flag list.
+4. Open Claude Code in the target repo and say *"Follow the instructions in `<working-folder>/SEED-PROMPT.md`."* Claude deep-reads your repo, fills the templates, flags anything it inferred or can't derive, and stops for your review.
+5. Answer Claude's questions, confirm the inferences, and start working. The normal per-session prompt lives in [PROMPTS.md](PROMPTS.md).
+
+## The lifecycle
+
+```
+  bootstrap → seed prompt → first session → iterate → session-end → upgrade
+   (once)      (once)        (once)         (loop)    (each end)   (per kit release)
+```
+
+- **Bootstrap** — once per project. Creates the working folder, seeds memory, drops `SEED-PROMPT.md`.
+- **Seed prompt** — once, immediately after. Claude fills the templates, flags inferences, stops for review.
+- **First session** — confirm inferences, start phase 0.
+- **Iterate** — branch → commit → PR → merge → tick the checklist.
+- **Session-end** — `SESSION-LOG.md` entry + `CONTEXT.md` status bump + checklist tick + memory pass. `/session-end` automates this.
+- **Upgrade** — when the kit ships new templates / memory / commands, see [SETUP.md §Upgrading](SETUP.md#upgrading-an-existing-project).
+
 ## What's in here
+
+<details>
+<summary>File tree</summary>
 
 ```
 .
 ├── README.md                ← you are here
 ├── SETUP.md                 ← step-by-step: starting a new project
+├── FEATURES.md              ← feature-by-feature reference
 ├── CONVENTIONS.md           ← generic working rules (commits, PRs, etc.)
 ├── PROMPTS.md               ← ready-to-paste session-opening prompts
 ├── CHANGELOG.md             ← what's landed; upgrade notes for existing adopters
+├── CONTRIBUTING.md          ← contributor onboarding
+├── SECURITY.md              ← reporting vulnerabilities
 ├── LICENSE
 ├── bootstrap.sh             ← one-command setup (see SETUP.md step 2)
 ├── templates/               ← copied into a new working folder
@@ -64,17 +161,26 @@ The working folder is project-specific knowledge ("what are we building, how far
     └── ci/                  ← per-CI reference memory (github-actions / gitlab-ci / jenkins / circleci / atlantis / ansible-cli / other)
 ```
 
-## How to use (new or existing project)
+</details>
 
-Works the same for greenfield repos and ones you're adopting it on mid-stream — the kit never modifies the target repo, it just creates an external working folder and seeds per-project auto-memory.
+## Requirements
 
-1. Read [SETUP.md](SETUP.md) — it walks you through the full bootstrap in ~10 minutes.
-2. Pick a private working folder location (e.g. `~/Documents/Claude/Projects/<Project Name>/`).
-3. From your target repo root, run `bootstrap.sh` — either of:
-   - **Interactive (hand-held):** `bootstrap.sh` with no arguments prompts for working-folder path, project name, whether to seed auto-memory, your issue tracker (GitHub Issues / JIRA / Linear / GitLab / Shortcut / other / none), and your primary CI/automation tool (GitHub Actions / GitLab CI / Jenkins / CircleCI / Atlantis / Ansible CLI / other / none). For JIRA and Linear, it also prompts for the project or team key.
-   - **Non-interactive (scripted):** `bootstrap.sh <working-folder> [--tracker TYPE] [--jira-project KEY | --linear-team KEY] [--ci TYPE]` — see `bootstrap.sh -h` for the full flag list.
-4. Open Claude Code in the target repo and say *"Follow the instructions in `<working-folder>/SEED-PROMPT.md`."* Claude deep-reads your repo, fills the templates, flags anything it inferred or can't derive, and stops for your review.
-5. Answer Claude's questions, confirm the inferences, and start working. The normal per-session prompt lives in [PROMPTS.md](PROMPTS.md).
+- **Bash 3.2+** — the macOS default works.
+- **git** — `git remote get-url origin` is used to derive `{{REPO_SLUG}}`. Bootstrap still runs without it; you'll fill that placeholder by hand.
+- **Claude Code CLI** — [install instructions](https://docs.claude.com/en/docs/claude-code).
+- **Tested on:** macOS and Linux. Should work on WSL2; not currently tested on native Windows.
+
+## Related docs
+
+| Doc | What it covers |
+|---|---|
+| [SETUP.md](SETUP.md) | Full bootstrap walkthrough (interactive + scripted), upgrade flow, manual alternative, troubleshooting |
+| [FEATURES.md](FEATURES.md) | Feature-by-feature reference with example invocations |
+| [PROMPTS.md](PROMPTS.md) | Session-opening / session-end prompt library |
+| [CONVENTIONS.md](CONVENTIONS.md) | Commit / PR / CI rules the kit assumes |
+| [CHANGELOG.md](CHANGELOG.md) | What's shipped, with **For existing adopters** notes per release |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Adding tracker / CI variants, running the Bats suite, PR shape |
+| [SECURITY.md](SECURITY.md) | Vulnerability reporting |
 
 ## When to update this framework
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -65,18 +65,28 @@ Options:
   -h, --help         Show this help and exit.
 
 Examples:
-  # Non-interactive
+  # Interactive (recommended for first-time use)
+  cd ~/Code/my-new-project
+  ~/Code/claude-project-kit/bootstrap.sh
+
+  # Non-interactive, minimal
   cd ~/Code/my-new-project
   ~/Code/claude-project-kit/bootstrap.sh ~/Documents/Claude/Projects/my-new-project
 
-  # Interactive
+  # Non-interactive, fully specified (typical real invocation)
   cd ~/Code/my-new-project
-  ~/Code/claude-project-kit/bootstrap.sh
+  ~/Code/claude-project-kit/bootstrap.sh ~/Documents/Claude/Projects/my-new-project \\
+    --tracker jira --jira-project INFRA \\
+    --ci github-actions
 
 After running, edit the copied files (placeholders marked {{LIKE_THIS}}).
 Most common memory placeholders are auto-filled; any that couldn't be
 derived (e.g. {{REPO_SLUG}} when no git remote is set) stay as-is.
-See SETUP.md in the kit repo for the full walk-through.
+
+See also:
+  SETUP.md      — full bootstrap walkthrough, upgrade flow, troubleshooting
+  FEATURES.md   — feature-by-feature reference with example invocations
+  CHANGELOG.md  — what's shipped, with notes for existing adopters
 EOF
 }
 


### PR DESCRIPTION
## Summary

- **README.md** — restructured for polish + discoverability: badges (release / license / platform), table of contents, Quickstart copy-paste block, ASCII diagram of the three-location model, **Features** section (11 bullets), "What this is / isn't", Lifecycle pipeline, Requirements section, Related-docs table, links to CONTRIBUTING / SECURITY / CHANGELOG, file tree collapsed under `<details>`. Existing prose (Why this works, idea-in-one-paragraph, How to use, Scope, Support, License) preserved verbatim.
- **FEATURES.md** — new feature-by-feature reference with example invocations, internal ToC, and a "What the kit does NOT do" section.
- **bootstrap.sh** — `-h` output: reordered so Interactive comes first, added a third example showing a fully-specified scripted invocation (`--tracker jira --jira-project INFRA --ci github-actions`), added a "See also" footer pointing at SETUP / FEATURES / CHANGELOG.

## Motivation

Front-door discoverability gap. The README had no Features section, no badges, no ToC, no quickstart, and the central "three-location" mental model lived in two prose blockquotes that were easy to skim past. Adopters arriving from the Facebook group / LinkedIn (the kit's intended audience) deserve a polished landing page and a single-page feature reference they can link to.

## Design notes

- **Two-tier features approach.** Short bullets in README (front-door scan), full paragraphs in FEATURES.md (depth on demand). Keeps SETUP.md focused on the "how" and lets FEATURES.md own the "what".
- **ASCII diagram, not Mermaid.** Renders identically in GitHub, plain `cat`, and editor previews — no rendering surprises if someone mirrors the repo elsewhere.
- **File tree under `<details>`.** Useful, but ~30 lines mid-page; collapsing it tightens the scroll without losing information.
- **Help text reorder** puts Interactive first because it's the recommended path for first-time users — matches what the README Quickstart now shows.
- **No CLI behavior change** in `bootstrap.sh` — only the help block (heredoc) was edited.

## Test plan

- [x] `./bootstrap.sh -h` renders cleanly with the new examples and "See also" footer
- [x] `bats tests/` — all 65 tests pass
- [x] Confirmed referenced anchors exist: `SETUP.md#manual-alternative`, `SETUP.md#upgrading-an-existing-project`
- [ ] CI: link-check (`lychee --offline`) on the docs changes
- [ ] CI: bats suite on `bootstrap.sh` change

## CHANGELOG

`docs:` → patch bump + CHANGELOG entry (per `release-please-config.json`). Intentional — the kit IS its docs and adopters benefit from knowing the README/FEATURES are new.