### PR TITLE
feat(commands): add /session-start and /refresh-context slash command starters

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -149,10 +149,12 @@ These are **starters**. Edit the frontmatter (model, tool allowlist), customize 
 
 ## Starter slash commands
 
-Two slash commands stage in `<working-folder>/.claude/commands/`. Same activation pattern — copy `.claude/` into your target repo.
+Four slash commands stage in `<working-folder>/.claude/commands/`. Same activation pattern — copy `.claude/` into your target repo.
 
+- **`/session-start`** — packages Prompt 1 from `PROMPTS.md`. Loads `CONTEXT.md`, `SESSION-LOG.md`, and the current phase checklist; hands back a 3–5 bullet grounding summary. Use at the start of a fresh session.
+- **`/refresh-context`** — re-reads the working folder mid-session, after a `/close-phase` or `/session-end` writeback or when a long session has drifted. Hands back a delta read against the latest state.
 - **`/close-phase`** — runs the phase-close writeback (checklist tick, `plan.md` status bump, `CONTEXT.md` update, optional acceptance-results archive). Takes a phase number or infers from `CONTEXT.md`.
-- **`/session-end`** — packages Prompt 3 from `PROMPTS.md` as a slash command. Drafts the four end-of-session updates (SESSION-LOG entry, CONTEXT bump, checklist scan, memory candidates) and waits for confirmation before writing.
+- **`/session-end`** — packages Prompt 3 from `PROMPTS.md`. Drafts the four end-of-session updates (SESSION-LOG entry, CONTEXT bump, checklist scan, memory candidates) and waits for confirmation before writing.
 
 ---
 

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -158,6 +158,40 @@ Don't start coding — wait for me to confirm direction.
 
 ---
 
+## 5. Refreshing context mid-session
+
+Use this mid-session — typically after a `/close-phase` or `/session-end` writeback, or when a long session has drifted and you want to re-anchor on the working folder's current state. Different from Prompt 1 because the session is already going; this just re-reads the docs so subsequent prompts use the updated content.
+
+```
+Re-read my AI working folder so the rest of this session uses the latest state.
+
+## Files to reload
+
+1. `<working-folder>/CONTEXT.md` — project status, current phase, working rules
+2. `<working-folder>/SESSION-LOG.md` — focus on the most recent entry
+3. The current phase's checklist (`<working-folder>/phase-<N>-checklist.md`)
+
+## Hand back
+
+A short delta read (≤5 bullets):
+
+- Current phase / status per CONTEXT.md right now
+- Most recent SESSION-LOG entry — date, focus, what landed
+- Any unticked items in the current phase checklist
+- Open threads / next-steps from the latest log entry
+- One sentence on what shifted since you last had this context loaded, if anything obvious — otherwise "no obvious deltas"
+
+Then wait for my next instruction. Don't propose changes yet.
+```
+
+**Notes:**
+- Useful right after running `/close-phase` or `/session-end` — the writeback updates the docs, but the active session is still working from the pre-writeback version until told to reload.
+- The "what shifted" bullet is intentionally hedged with the fallback. Claude doesn't have perfect visibility into its own loaded context; honest framing beats false confidence.
+- For a cold session start, use Prompt 1 (or `/session-start` if installed) instead — this prompt assumes you're already mid-session.
+- If `reference_ai_working_folder.md` is in auto-memory, the path doesn't need to be in the prompt — Claude knows where to look.
+
+---
+
 ## When to write a new prompt
 
 Add one here whenever you find yourself typing similar setup instructions into a fresh session for the third time. A good prompt is:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ That kicks off interactive mode: it asks for the working-folder path, project na
 - **Phase-based planning docs** — `plan.md` + per-phase checklist + `implementation.md` give Claude scoped, numbered tasks instead of a wall of intent.
 - **SEED-PROMPT auto-fill** — point Claude at one file and it deep-reads your repo, fills `CONTEXT.md`, drafts `research.md`, flags inferences, and stops for your review.
 - **Starter agents** — `code-reviewer` (universal) and `session-summarizer` (kit-aware), staged in the working folder; copy into your repo to activate.
-- **Starter slash commands** — `/close-phase` (phase-close writeback) and `/session-end` (end-of-session log + memory pass).
+- **Starter slash commands** — `/session-start` (load working-folder context), `/refresh-context` (re-read mid-session), `/close-phase` (phase-close writeback), and `/session-end` (end-of-session log + memory pass).
 - **Worked example** — `examples/widget-tracker/` is a fictional Go CLI mid-Phase-1 with all docs filled in plausibly.
 - **Conventions baseline** — Conventional Commits, merge-only PRs, test-plan format, etc. Read once, drop or keep per project.
 - **No surprises** — MIT licensed, no telemetry, no network calls, kit never modifies your target repo.
@@ -71,7 +71,7 @@ See [FEATURES.md](FEATURES.md) for one-paragraph-per-feature detail with example
 
 ## What this is / isn't
 
-- **Is:** a workflow scaffold layered on top of Claude Code — templates, memory starters, conventions, two starter agents, two starter slash commands.
+- **Is:** a workflow scaffold layered on top of Claude Code — templates, memory starters, conventions, two starter agents, four starter slash commands.
 - **Isn't:** a Claude Code plugin, a replacement for `CLAUDE.md`, or a project tracker. It complements all three.
 
 ## Why this works
@@ -147,7 +147,7 @@ Works the same for greenfield repos and ones you're adopting it on mid-stream �
 │   ├── research.md
 │   └── .claude/             ← starter agents + slash commands (staged in WF)
 │       ├── agents/          ← code-reviewer, session-summarizer
-│       ├── commands/        ← /close-phase, /session-end
+│       ├── commands/        ← /session-start, /refresh-context, /close-phase, /session-end
 │       └── README.md        ← how to copy into your target repo
 ├── examples/                ← filled-in reference — read, don't copy
 │   └── widget-tracker/      ← fictional Go CLI, mid-Phase-1 snapshot

--- a/SETUP.md
+++ b/SETUP.md
@@ -160,7 +160,7 @@ mv "<working-folder>/phase-N-checklist.md" "<working-folder>/phase-0-checklist.m
 [ -d "<framework-dir>/templates/.claude" ] && cp -R "<framework-dir>/templates/.claude" "<working-folder>/"
 ```
 
-The `.claude/` directory holds starter agents and slash commands that match the kit's session-end / phase-close conventions. They're staged in the working folder; copy into your target repo's `.claude/` if you want them active. See [`templates/.claude/README.md`](templates/.claude/README.md) for the four starters and how to activate them.
+The `.claude/` directory holds starter agents and slash commands that match the kit's session-start, session-end, and phase-close conventions. They're staged in the working folder; copy into your target repo's `.claude/` if you want them active. See [`templates/.claude/README.md`](templates/.claude/README.md) for the full list (two agents + four slash commands) and how to activate them.
 
 ### Seed auto-memory
 The harness expects memory at `~/.claude/projects/<sanitized-path>/memory/`. Sanitization rule: absolute repo path with `/` replaced by `-`, prefixed with `-`. Example: `/Users/you/Code/acme/foo` → `-Users-you-Code-acme-foo`.

--- a/templates/.claude/README.md
+++ b/templates/.claude/README.md
@@ -1,6 +1,6 @@
 # `.claude/` starters
 
-Two agents and two slash commands that follow the kit's session-end + phase-close conventions. Staged here in your working folder; copy into your target repo's `.claude/` if you want them.
+Two agents and four slash commands that follow the kit's session-start, session-end, and phase-close conventions. Staged here in your working folder; copy into your target repo's `.claude/` if you want them.
 
 ## What's here
 
@@ -11,6 +11,8 @@ Two agents and two slash commands that follow the kit's session-end + phase-clos
 
 ### Slash commands (`.claude/commands/`)
 
+- **`/session-start`** — Prompt 1 from `PROMPTS.md` packaged as a slash command. Loads `CONTEXT.md`, `SESSION-LOG.md`, and the current phase checklist; hands back a 3–5 bullet grounding summary. Use at the start of a fresh session.
+- **`/refresh-context`** — re-reads the working folder mid-session (after a `/close-phase` or `/session-end` writeback, or when a long session has drifted). Hands back a delta summary. Same flow as Prompt 5 in `PROMPTS.md`.
 - **`/close-phase`** — runs the phase-close writeback (checklist tick, `plan.md` status, `CONTEXT.md`, `SESSION-LOG.md`, optional acceptance-results archive). Takes a phase number or infers from `CONTEXT.md`.
 - **`/session-end`** — Prompt 3 from `PROMPTS.md` packaged as a slash command. Drafts the end-of-session updates, waits for confirmation before writing.
 

--- a/templates/.claude/commands/refresh-context.md
+++ b/templates/.claude/commands/refresh-context.md
@@ -1,0 +1,31 @@
+---
+description: Re-read CONTEXT.md, SESSION-LOG.md, and the current phase checklist mid-session — for picking up changes after a /close-phase or /session-end writeback, or re-anchoring on a long session. Same flow as Prompt 5 in PROMPTS.md.
+---
+
+Re-read my AI working folder so the rest of this session uses the latest state.
+
+## Files to reload
+
+1. `<working-folder>/CONTEXT.md` — project status, current phase, working rules
+2. `<working-folder>/SESSION-LOG.md` — focus on the most recent entry
+3. The current phase's checklist (`<working-folder>/phase-<N>-checklist.md`)
+
+The working-folder path comes from `reference_ai_working_folder.md` in auto-memory. If that's not set, ask before guessing.
+
+## Hand back
+
+A short delta read (≤5 bullets):
+
+- Current phase / status per CONTEXT.md right now
+- Most recent SESSION-LOG entry — date, focus, what landed
+- Any unticked items in the current phase checklist
+- Open threads / next-steps from the latest log entry
+- One sentence on what shifted since you last had this context loaded, if anything obvious — otherwise "no obvious deltas"
+
+Then wait for my next instruction. Don't propose changes yet.
+
+## Notes
+
+- Useful right after running `/close-phase` or `/session-end` — the writeback updates the docs, but the active session is still working from the pre-writeback version until told to reload.
+- The "what shifted" bullet is intentionally hedged with the fallback. Claude doesn't have perfect visibility into its own loaded context; honest framing beats false confidence.
+- For a cold session start, use `/session-start` instead — this command assumes you're already mid-session.

--- a/templates/.claude/commands/session-start.md
+++ b/templates/.claude/commands/session-start.md
@@ -1,0 +1,30 @@
+---
+description: Load the working folder's CONTEXT.md, SESSION-LOG.md, and current phase checklist into the session, then hand back a grounding summary. Same flow as Prompt 1 in PROMPTS.md, packaged as a slash command.
+---
+
+Before we start, read these files in my AI working folder, in order:
+
+1. `<working-folder>/CONTEXT.md` — project overview, working rules, current phase
+2. `<working-folder>/SESSION-LOG.md` — chronological session history
+3. The current phase's checklist (e.g. `<working-folder>/phase-<N>-checklist.md`)
+
+These are my persistent project context — they live outside the repo and hold scope, decisions, and current status. Don't edit them unless I ask; updates happen at session end.
+
+The working-folder path comes from `reference_ai_working_folder.md` in auto-memory. If that's not set, ask before guessing.
+
+## Hand back
+
+A 3–5 bullet summary of:
+
+- Where we are in the project (current phase + status)
+- What landed most recently (most recent SESSION-LOG entry — date, focus, PRs)
+- Any open threads / next-steps called out in the latest log entry
+- Any unticked items in the current phase checklist worth flagging
+- The likely starting point for this session, if obvious
+
+Then wait for my next instruction. Don't propose changes or start coding yet.
+
+## When to use a different command
+
+- **Resuming mid-PR with a branch in flight** → use Prompt 4 in PROMPTS.md instead. It loads the same context plus a structured branch / PR / CI assessment.
+- **Refreshing context mid-session** (after a `/close-phase` or `/session-end` writeback) → use `/refresh-context`. This command is for cold session starts.


### PR DESCRIPTION
## Summary

- **`templates/.claude/commands/session-start.md`** (new) — Prompt 1 from `PROMPTS.md` packaged as a slash command. Loads `CONTEXT.md`, `SESSION-LOG.md`, and the current phase checklist; hands back a 3–5 bullet grounding summary. Closes the symmetry gap with the existing `/session-end`.
- **`templates/.claude/commands/refresh-context.md`** (new) — re-reads the working folder mid-session. Useful right after `/close-phase` or `/session-end` writes back updates that the active session is still working from the pre-writeback version of, or when a long session has drifted.
- **`PROMPTS.md`** — adds **Prompt 5: Refreshing context mid-session**, the prose form of `/refresh-context`. Same pattern as Prompt 3 ↔ `/session-end` — keeps the prompt available even for users who don't install the slash command starters.
- **Count + name updates** in `README.md`, `SETUP.md`, `FEATURES.md`, and `templates/.claude/README.md` to reflect four slash commands instead of two.

## Motivation

Spotted during a real `/session-end` run on the kit's own working folder. The roster was asymmetric — `/session-end` shipped via [#53](https://github.com/IamMrCupp/claude-project-kit/pull/53), but the matching `/session-start` did not, even though Prompt 1 in `PROMPTS.md` defined the exact same flow. Closing that gap is one missing file.

`/refresh-context` is net new and addresses a real workflow pain: after `/close-phase` or `/session-end` writes back to the working folder, the active session is still working from the pre-writeback version of those docs until told to reload. Without a command, users either restart the session or paste a re-read prompt by hand. Either is friction.

## Design notes

- **`/session-start` mirrors Prompt 1 verbatim**, same way `/session-end` mirrors Prompt 3. The frontmatter description explicitly says so. Consistency with the existing pattern is the load-bearing piece — the kit's invariant is that the prose prompt is the source of truth and the slash command is a packaged convenience.
- **`/refresh-context` is hedged on the "what shifted" line.** Claude doesn't have great visibility into its own loaded context, so the prompt explicitly allows "no obvious deltas" as a valid answer rather than forcing a fabricated diff. Honest framing beats false confidence.
- **Two commits, granular.** `feat(commands):` for the new files + count updates (release-please bumps minor); `docs(prompts):` for the new Prompt 5 in PROMPTS.md (release-please bumps patch + adds CHANGELOG entry). Matches the granularity convention from prior PRs.
- **No bats changes needed.** Existing test 43 (`templates/.claude/ starters are copied to working folder`) is directory-level; new files inside the directory get picked up by `cp -R` automatically. End-to-end smoke test confirmed all four commands land in a fresh working folder via `bootstrap.sh`.
- **Cross-pollination of existing commands deferred.** `/close-phase` could plausibly nudge the user toward `/refresh-context` after a writeback, but adding that hint to existing command bodies would expand scope. Better as a follow-up if it turns out to be desired.

## Test plan

- [x] `bats tests/` — all 65 tests pass (no regressions; no new tests needed since `templates/.claude/` copy is directory-level)
- [x] End-to-end: ran `bootstrap.sh <tmpdir>/wf --skip-memory`; confirmed `<tmpdir>/wf/.claude/commands/` contains all four files (`session-start.md`, `refresh-context.md`, `close-phase.md`, `session-end.md`)
- [ ] CI: bats suite (triggered by `templates/` change)
- [ ] CI: lychee link-check on docs changes
- [ ] Visual: README / FEATURES / SETUP renders cleanly on GitHub with the updated slash-command lists

## CHANGELOG

`feat(commands):` → minor bump (slash command surface area expanded). `docs(prompts):` → patch bump + Documentation entry (Prompt 5 is user-facing). Combined effect on release-please: one minor bump with both entries in the next release.