### PR TITLE
docs(conventions): add ticket-driven workflows section (#61)

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -50,6 +50,23 @@ Run with `run_in_background: true` on the Bash tool. Sleep 3–5 s before grabbi
 - **Azure Pipelines:** `az pipelines runs show --id <N> --open` or poll the REST API
 - **Any platform:** if the CLI doesn't expose a blocking "wait for completion" command, a small shell loop polling the run's status endpoint every 15–30 s works and still feeds Claude's notification system when the script exits
 
+## Ticket-driven workflows
+
+When working against an external tracker (JIRA, GitHub Issues, Linear, etc.), the conventions above extend with a ticket key woven through branches, PR titles, commits, and PR bodies. Examples below use a JIRA-style key (`LX-1234`); substitute your tracker's format.
+
+### Branch / PR / commit conventions
+
+- **Branch:** `<type>/<KEY>-<short-slug>` — e.g. `feat/LX-1234-fix-lb-path-routing`. The same ticket key is reused across multiple repos when a single ticket drives work in both (e.g. a Terraform envs change + a modules change both against `LX-1234`). Multi-repo initiatives keep one key, not one per repo.
+- **PR title:** Conventional Commits with the key in parens — e.g. `feat(modules): add VPC module (LX-1234)`. **No `Closes` / `Fixes` keyword** unless your tracker has auto-transitions configured AND you want them; many orgs (including JIRA without explicit setup) don't, and the keyword does nothing useful in that case.
+- **PR body:** dedicated `## JIRA` (or `## Linear`, `## Issue`, etc.) section linking the ticket plus the usual Summary / Test plan sections. No transition magic — humans transition the ticket.
+- **Commits:** Conventional Commits with the key in the subject — e.g. `feat(modules): add VPC module — LX-1234`. The single-line `-m` rule from `## Git & commits` still applies; the key goes in the subject, not a body.
+- **Smart Commits** (`#time`, `#comment`, `#transition` for trackers that support them) — **opt-in per project**, not part of the default convention. If your team uses them, document the local conventions in `CONTEXT.md` so contributors don't accidentally trigger transitions.
+
+### What the kit does NOT do with trackers
+
+- **Never creates tracker projects, labels, workflows, or sprint scaffolding** on your behalf. JIRA projects, GitHub Project boards, Linear teams, etc. are owned by PMs and the business — bootstrap captures *references* to projects that already exist (project key, MCP availability, link), never creates them.
+- **Creating individual issues/tickets inside an existing project** is only on the table when you explicitly ask for it. The kit's own GitHub repo is the exception (a personal project), not the rule.
+
 ## Documentation (in the working folder)
 
 - **Keep planning docs in sync as work lands** — not only at phase boundaries.


### PR DESCRIPTION
## Summary

- **`CONVENTIONS.md`** — adds a new `## Ticket-driven workflows` section between `## CI` and `## Documentation`. Covers all three Section B items from the Phase 4 checklist in one cohesive block:
  - Branch / PR / commit conventions for ticket-driven work (Phase 4 B.1) — verbatim from #61's "Branch & PR conventions (JIRA-driven work)" with one editorial tightening (added explicit "the key goes in the subject, not a body" reinforcement).
  - Multi-repo "same key in both repos" rule (B.2) — folded into the branch convention bullet.
  - Smart Commits opt-in note (B.3) — bottom of the conventions list.
  - Plus an explicit "What the kit does NOT do with trackers" sub-section capturing the constraint from ADR-0001 D3 and the kit's posture (never creates projects/labels/workflows; doesn't open issues without explicit ask).

## Motivation

Phase 4 Section B in the working folder. The conventions are locked-in per [#61](https://github.com/IamMrCupp/claude-project-kit/issues/61) — no design surface, just operationalizing what was already decided. The "no tracker artifact creation" constraint was implicit in ADR-0001 but not in any public-facing doc; CONVENTIONS.md is the right home since that's where Claude's behavioral defaults live.

## Design notes

- **Single new H2 section, not edits scattered across `## Git & commits` and `## PRs`.** Ticket-driven conventions are an extension layer that some users (no tracker) won't need; a dedicated section makes it skippable.
- **Placement after `## CI`, before `## Documentation`.** The reader has full context on plain commit + PR + CI conventions first; ticket-driven workflows extend them. Keeps the default-conventions narrative coherent.
- **JIRA-style key in examples** (`ACME-1234`) per the issue, with a leading sentence telling readers to substitute their tracker's format. Avoids the docs reading as JIRA-specific while still being concrete.
- **Smart Commits framed as opt-in, not banned.** Some teams use them productively; the convention is "decide once per project, document in CONTEXT.md." Same posture as squash-vs-merge.
- **One commit, one PR.** All three checklist items are one cohesive addition to one file.

## Test plan

- [x] Section renders correctly when previewed locally; placement between CI and Documentation flows naturally
- [x] Internal references (`## Git & commits`, `CONTEXT.md`) resolve
- [x] No code changes — `bootstrap.sh`, `templates/`, and bats coverage untouched
- [ ] CI: lychee link-check on the new content
- [ ] CI: bats suite

## CHANGELOG

`docs:` → patch bump + Documentation entry per `release-please-config.json`. One commit, one CHANGELOG line.
