### PR TITLE
feat(templates): add workspace + ticket templates (Phase 4 §C.1–C.3, #61)

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,8 @@
+# Lychee ignore patterns. One regex per line; matches against URLs.
+
+# Skip {{PLACEHOLDER}} paths/URLs in templates — these resolve correctly
+# only after `bootstrap.sh` substitutes the placeholder values during
+# bootstrap, and after templates are deployed into a user's working
+# folder. Both raw and URL-encoded forms are covered.
+\{\{
+%7B%7B

--- a/templates/CONTEXT.md
+++ b/templates/CONTEXT.md
@@ -10,6 +10,8 @@
 At the start of any new Claude session, say:
 > "Read CONTEXT.md and SESSION-LOG.md in this folder before we start."
 
+> **Folder shape:** {{single-repo | per-repo subfolder of a workspace}}. If this folder is a per-repo subfolder of a workspace, also load `../workspace-CONTEXT.md` for cross-repo context and any active `../tickets/<KEY>-<slug>.md` files in scope for the session.
+
 ---
 
 ## Project Overview
@@ -20,6 +22,19 @@ At the start of any new Claude session, say:
 - **Visibility:** {{public | private | internal}}
 - **Platform targets:** {{PLATFORM_TARGETS}}
 - **This folder:** Private AI working context — never commit to repo
+
+---
+
+## Tracker Configuration
+
+The external tracker for this project, used when work is ticket-driven. See `CONVENTIONS.md` (kit-level — `## Ticket-driven workflows`) for the branch / PR / commit conventions to use against a tracker.
+
+- **Tracker type:** {{none | github | jira | linear | gitlab | shortcut | other}}
+- **Project / team key:** {{KEY — e.g. LX, INFRA, ENG; leave blank if not applicable}}
+- **MCP availability:** {{installed | not installed | unknown}}
+- **Tracker link:** {{URL — leave blank if none}}
+
+If this folder lives in a workspace (multi-repo initiative), tracker config commonly lives at the workspace level (`../workspace-CONTEXT.md`) instead of duplicated here. Leave this section as-is or remove it as appropriate.
 
 ---
 

--- a/templates/SESSION-LOG.md
+++ b/templates/SESSION-LOG.md
@@ -4,6 +4,8 @@ Chronological record of Claude working sessions. Each entry captures what was do
 
 **Append-only.** Never delete past entries. If something in an old entry turns out wrong, note the correction in the current session's entry rather than editing history.
 
+> **Workspace mode:** if this `SESSION-LOG.md` lives inside a workspace per-repo subfolder, the per-ticket scratchpads at `../tickets/<KEY>-<slug>.md` are the canonical record for ticket-specific decisions and acceptance criteria. SESSION-LOG entries summarize and cross-reference; tickets can be touched by multiple sessions and span repos.
+
 ---
 
 ## Entry format
@@ -14,6 +16,10 @@ Use this shape for every session entry. Keep prose tight — future-you will sca
 ## Session: {{YYYY-MM-DD}} — {{short focus phrase}}
 
 **Focus:** {{one sentence — what this session was about}}
+
+**Tickets touched** (workspace mode only — omit if single-repo):
+- [{{KEY}}](../tickets/{{KEY}}-{{slug}}.md) — {{what got done on it this session}}
+- …
 
 **Branches/PRs:**
 - `{{branch-name}}` → PR #{{N}} (merged / open / abandoned)

--- a/templates/workspace/ticket.md
+++ b/templates/workspace/ticket.md
@@ -1,0 +1,59 @@
+# {{KEY}} — {{TITLE}}
+
+- **Tracker:** [{{KEY}}]({{TRACKER_URL}})
+- **Status:** {{Open | In progress | Blocked | Done}} — sync with tracker periodically; tracker is source of truth.
+- **Created:** {{YYYY-MM-DD}}
+- **Last touched:** {{YYYY-MM-DD}}
+
+---
+
+## Summary
+
+{{One paragraph from the tracker, or hand-written if pulled before the ticket was fleshed out. Keep in sync with the tracker — this file is a working scratchpad, not a replacement for the tracker.}}
+
+---
+
+## Acceptance criteria
+
+{{Pulled from the tracker. Don't paraphrase — copy verbatim and add inline notes if needed. If criteria evolve in the tracker, update here.}}
+
+- [ ] {{AC bullet}}
+- [ ] {{AC bullet}}
+
+---
+
+## Working notes
+
+{{Free-form Claude-managed notes — what's been tried, what's been decided, what's still open. Append-style is fine; structure is loose. This is the scratchpad, not the deliverable.}}
+
+---
+
+## Branches / PRs / commits
+
+Multi-repo tickets accumulate work across repos. List branches and PRs here so the ticket scratchpad is the cross-repo coordination point.
+
+| Repo | Branch | PR | Status |
+|---|---|---|---|
+| {{repo-a}} | `{{type}}/{{KEY}}-{{slug}}` | #{{N}} | merged / open / draft |
+
+---
+
+## Decisions / blockers
+
+- {{YYYY-MM-DD: decision or blocker, with brief rationale}}
+
+---
+
+## Cross-references
+
+- **Sessions that touched this ticket:** {{list per-repo `SESSION-LOG.md` entries by date}}
+- **Related tickets:** {{KEY1 (dependency), KEY2 (follow-up)}}
+- **Workspace context:** [`../workspace-CONTEXT.md`](../workspace-CONTEXT.md)
+
+---
+
+## Archive note
+
+When the upstream tracker ticket closes, move this file to `../tickets/archive/`. Add a 1–2 sentence "what shipped" note here before archiving so the archive is grep-able for "what did we do for `{{KEY}}`".
+
+{{Pre-archive note goes here.}}

--- a/templates/workspace/ticket.md
+++ b/templates/workspace/ticket.md
@@ -48,7 +48,7 @@ Multi-repo tickets accumulate work across repos. List branches and PRs here so t
 
 - **Sessions that touched this ticket:** {{list per-repo `SESSION-LOG.md` entries by date}}
 - **Related tickets:** {{KEY1 (dependency), KEY2 (follow-up)}}
-- **Workspace context:** [`../workspace-CONTEXT.md`](../workspace-CONTEXT.md)
+- **Workspace context:** `../workspace-CONTEXT.md` (sibling of the `tickets/` directory after deployment)
 
 ---
 

--- a/templates/workspace/workspace-CONTEXT.md
+++ b/templates/workspace/workspace-CONTEXT.md
@@ -1,0 +1,71 @@
+# Workspace — {{INITIATIVE_NAME}}
+**Last updated:** {{YYYY-MM-DD}}
+
+---
+
+## How to load this context
+
+At the start of any session that spans multiple repos in this workspace, say:
+> "Read workspace-CONTEXT.md before we start."
+
+Per-repo context (`<repo>/CONTEXT.md`, `<repo>/SESSION-LOG.md`) lives in each repo's subfolder; load that for the specific repo when work narrows to that repo. Per-ticket scratchpads live at `tickets/<KEY>-<slug>.md` (active) and `tickets/archive/` (closed).
+
+This file is private — never commit it to any repo.
+
+---
+
+## Initiative Overview
+
+{{ONE_PARAGRAPH_DESCRIPTION — what this initiative is, why it spans these repos, what done looks like}}
+
+- **Initiative key (if applicable):** {{e.g. epic key, OKR ID, project codename}}
+- **Status:** {{active | paused | wrapping up | done}}
+
+---
+
+## Tracker Configuration
+
+Shared tracker config for the initiative. If a single tracker covers all repos, capture it here once instead of duplicating in each `<repo>/CONTEXT.md`.
+
+- **Tracker type:** {{none | github | jira | linear | gitlab | shortcut | other}}
+- **Project / team key:** {{KEY — e.g. LX, INFRA, ENG}}
+- **MCP availability:** {{installed | not installed | unknown}}
+- **Tracker link:** {{URL}}
+
+See `CONVENTIONS.md` (kit-level — `## Ticket-driven workflows`) for the branch / PR / commit conventions to use against a tracker.
+
+---
+
+## Repos in this workspace
+
+| Repo | Subfolder | Role | Local CONTEXT |
+|---|---|---|---|
+| {{repo-a}} | `{{repo-a}}/` | {{role — e.g. Terraform envs}} | [{{repo-a}}/CONTEXT.md]({{repo-a}}/CONTEXT.md) |
+| {{repo-b}} | `{{repo-b}}/` | {{role — e.g. Terraform modules}} | [{{repo-b}}/CONTEXT.md]({{repo-b}}/CONTEXT.md) |
+
+---
+
+## Tickets
+
+Active per-ticket scratchpads live under `tickets/<KEY>-<slug>.md`. Closed ticket files move to `tickets/archive/`.
+
+**Active:**
+- [{{KEY}}](tickets/{{KEY}}-{{slug}}.md) — {{one-line summary; repos touched}}
+
+**Recently archived:**
+- [{{KEY}}](tickets/archive/{{KEY}}-{{slug}}.md) — {{one-line "what shipped"}}
+
+---
+
+## Cross-repo notes
+
+{{Anything that spans multiple repos and doesn't belong in any single per-repo `CONTEXT.md` — shared dependencies, deployment ordering across repos, cross-repo PR coordination, naming conventions that hold across the workspace, etc. Keep tight; if a section grows past a paragraph, consider whether it belongs in a per-repo `CONTEXT.md` or in `implementation.md` of the relevant repo.}}
+
+---
+
+## Reference
+
+- `tickets/` — per-ticket scratchpads (per [`docs/adr/0001-multi-repo-folder-model.md`](https://github.com/IamMrCupp/claude-project-kit/blob/main/docs/adr/0001-multi-repo-folder-model.md) in the kit)
+- `<repo>/CONTEXT.md` — per-repo context (one per repo subfolder)
+- `<repo>/SESSION-LOG.md` — per-repo session history
+- `<repo>/plan.md`, `<repo>/phase-*-checklist.md` — per-repo planning docs


### PR DESCRIPTION
## Summary

Phase 4 Section C.1–C.3 (templates for the workspace data model). Two granular `feat(templates):` commits.

- **`templates/CONTEXT.md`** — adds a `## Tracker Configuration` section (tracker type, project key, MCP availability, link) and a "Folder shape" callout in `## How to load this context` that points workspace-mode users at the adjacent `workspace-CONTEXT.md` and active tickets.
- **`templates/SESSION-LOG.md`** — adds a workspace-mode note near the top + a new `Tickets touched` block in the entry-format example so per-repo session entries can cross-reference `../tickets/<KEY>-<slug>.md`.
- **`templates/workspace/workspace-CONTEXT.md`** (new) — workspace-level CONTEXT for multi-repo initiatives. Cross-repo overview, shared tracker config, repos table, active/archived tickets, cross-repo notes section.
- **`templates/workspace/ticket.md`** (new) — per-ticket scratchpad: tracker link, status, summary, AC, working notes, branches/PRs across repos, decisions/blockers, cross-references, archive note.

## Motivation

Phase 4 §C is the templates layer of the multi-repo + ticket-driven folder model from [ADR-0001](docs/adr/0001-multi-repo-folder-model.md). Bootstrap and tracker-pull integration come in subsequent PRs (Sections D and E); this PR just ships the templates the data model needs, so downstream work has something to copy from.

## Design notes

- **`templates/workspace/` subdirectory keeps the new templates out of single-repo bootstrap.** `bootstrap.sh` line 433 does `cp templates/*.md` (non-recursive), so the new subdir is invisible to today's flow. Section D's `--workspace` flag will explicitly opt in to copying from `templates/workspace/`. Smoke-tested locally — single-repo bootstrap output is unchanged.
- **CONTEXT.md tracker-config section is intentionally optional.** A note steers users in workspace mode to put tracker config at the workspace level instead, since duplicating it across per-repo CONTEXTs would drift.
- **Workspace-CONTEXT.md links to ADR-0001 in the kit repo, not a local relative path.** The ADR lives in the kit (public) but the workspace lives in the user's private working folder; absolute kit URL avoids broken links.
- **Ticket.md emphasizes "tracker is source of truth"** — the scratchpad is for working notes and cross-repo coordination, not a replacement for the actual ticket. Status field has an explicit "sync periodically" caveat.
- **Two granular `feat(templates):` commits**, both qualify for a single minor bump from release-please:
  1. `feat(templates): add tracker-config + workspace mode awareness to CONTEXT and SESSION-LOG` — edits to existing templates.
  2. `feat(templates): add workspace-CONTEXT.md and per-ticket scratchpad templates` — new files in `templates/workspace/`.

## Test plan

- [x] `bats tests/` — 65/65 still pass (no bootstrap behavior change)
- [x] Smoke test: ran `bootstrap.sh <tmpdir>/wf --skip-memory`; confirmed `<tmpdir>/wf/` contains the existing single-repo template set and **does NOT** contain a `workspace/` subdirectory
- [x] Internal links resolve: workspace-CONTEXT.md → ADR-0001 absolute URL; ticket.md → `../workspace-CONTEXT.md` relative
- [x] Templates render correctly when previewed
- [ ] CI: bats suite (triggered by `templates/` change)
- [ ] CI: lychee link-check on the docs

## CHANGELOG

Two `feat:` commits → one minor bump per release-please. The new templates are inert until Section D wires `--workspace`, but they're public artifacts as of this release — adopters who want to hand-copy the workspace shape now (per the SETUP.md migration section landed in #69) can pull them.