### PR TITLE
docs(conventions): reframe CI principle as 'PR not done until green'

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -35,14 +35,16 @@ Project-agnostic habits that have proven out across real work. Start from these,
 
 ## CI
 
-**Principle:** after a push on an iterating PR, fire off an async watcher so CI completion pings you — don't poll.
+**Principle:** after a push on an iterating PR, fire off an async watcher so CI completion pings you — don't poll, and don't move on until you've seen the result.
+
+**Hard rule:** a PR isn't ready, complete, or "open for review" until checks pass. If you push and report the PR back without first watching CI, you'll either claim success on a red check or force the reviewer to spot the failure for you. Both cost trust. The watcher is how you avoid this — spawn it the same turn as the push, surface failures the moment the watcher reports them, and re-watch after every fix push.
 
 **GitHub Actions + `gh` CLI:**
 ```bash
 RUN_ID=$(gh run list --branch <branch> --workflow "<name>" --limit 1 --json databaseId --jq '.[0].databaseId')
 gh run watch "$RUN_ID" --exit-status
 ```
-Run with `run_in_background: true` on the Bash tool. Sleep 3–5 s before grabbing the run ID so the new push has time to register. One watcher per push (pick the workflow you're iterating on, don't spam).
+Run with `run_in_background: true` on the Bash tool. Sleep 3–5 s before grabbing the run ID so the new push has time to register. One watcher per push (pick the workflow you're iterating on, don't spam) — or one per workflow if multiple are likely to fail independently (e.g. lint + test).
 
 **Other platforms:**
 - **GitLab CI:** `glab ci watch` on the pipeline for the latest commit

--- a/memory-templates/feedback_watch_ci_in_background.md
+++ b/memory-templates/feedback_watch_ci_in_background.md
@@ -1,10 +1,10 @@
 ---
-name: Watch CI runs in the background
-description: After pushing to a PR with active CI, spawn `gh run watch` in background mode. The task-notification system fires when CI completes — no polling.
+name: Watch CI runs in the background and surface failures before the user does
+description: After pushing to a PR with active CI, spawn `gh run watch --exit-status` in background mode. A PR isn't "done" until checks are green — never claim success without watching.
 type: feedback
 ---
 
-After any `git push` to a branch with active CI, immediately start `gh run watch` in background mode:
+After any `git push` to a branch with active CI, immediately start `gh run watch` in background mode in the same turn as the push:
 
 ```bash
 sleep 3
@@ -14,12 +14,15 @@ gh run watch "$RUN_ID" --exit-status
 
 Run with `run_in_background: true` on the Bash tool. The harness delivers a task-notification when CI completes.
 
-**Why:** each CI iteration on a typical PR takes 3–10 minutes; over a multi-iteration session that's a lot of dead time if you're polling. Background watching converts every CI run into an async notification that lands exactly when it's ready to act on — so you can keep working on something else or end the session and come back when the ping fires.
+**Why:** two reasons, both load-bearing.
+1. **Trust.** A PR isn't ready, complete, or "open for review" until checks pass. If you push and report the PR back without watching, you'll either claim success on a red check or force the reviewer to spot the failure for you. Both cost trust the kit's whole pacing relies on.
+2. **Productivity.** Each CI iteration takes 3–10 minutes; over a multi-iteration session that's a lot of dead time if you're polling. Background watching converts every CI run into an async notification that lands exactly when it's ready to act on — so you can keep working on something else or end the session and come back when the ping fires.
 
 **How to apply:**
-- After every push to an actively-iterating PR, spawn the watcher
-- `sleep 3–5s` before grabbing run ID — GitHub needs a moment to register the new push
-- One watcher per push, picking the workflow that's being iterated on (usually the one whose config just changed). Don't spam multiple watchers.
-- Each push creates new run IDs — re-spawn after each iteration push
-- When a PR is finalized and all CI is green, no further watching needed
-- Read the notification's output file to see the tail of `gh run watch` — it shows final step status
+- After every push to an actively-iterating PR, spawn the watcher in the **same turn** as the push — not the next turn, not after summarizing the PR.
+- `sleep 3–5s` before grabbing run ID — GitHub needs a moment to register the new push.
+- One watcher per push, picking the workflow that's being iterated on (usually the one whose config just changed). Spawn one per workflow if multiple are likely to fail independently (e.g. lint + test).
+- Each push creates new run IDs — re-spawn after each iteration push.
+- If a check fails, surface it immediately with the failing log, propose a fix, and re-watch after the fix push. Don't wait for the user to ask.
+- When a PR is finalized and all CI is green, no further watching needed.
+- Read the notification's output file to see the tail of `gh run watch` — it shows final step status.


### PR DESCRIPTION
## Summary

- **`CONVENTIONS.md` `## CI`** — adds an explicit "Hard rule" paragraph: a PR isn't ready / complete / open-for-review until checks pass; the watcher is how you avoid claiming success on a red check or making the reviewer spot it for you.
- **`memory-templates/feedback_watch_ci_in_background.md`** — restructures the "Why" to lead with **trust** (don't claim done until green) and keep **productivity** (no polling) as the secondary reason. Adds explicit "spawn in the same turn as the push" and "surface failures before the user does" guidance to the "How to apply" list.

## Motivation

Tonight on PR #72 (workspace + ticket templates) I pushed and moved on without spawning the watcher. Lychee link-check failed; the user spotted it before I did and had to flag it. The kit already shipped the right convention — `feedback_watch_ci_in_background.md` and CONVENTIONS.md `## CI` both said "watch async, don't poll" — but the framing was about productivity (no dead time), not trust (don't claim done).

Reframing makes the rule sharper: "watch CI" reads as a *nice to have* when the reason is just productivity, but as a *contract* when the reason is "you will otherwise lie to the reviewer about whether the PR is ready." This PR makes the contract explicit so future-me (and any future contributor) reads "fire off the watcher" as non-negotiable, not optional.

## Design notes

- **Two files, one change.** Both `CONVENTIONS.md` (kit-level discipline) and the matching memory-template (per-project auto-memory seed) get the same reframe so they don't drift.
- **Single `docs(conventions):` commit.** The two files are one logical change to the same convention.
- **No new mechanism.** The kit already ships `gh run watch` snippets and the `--exit-status` flag. The strengthening is in the prose, not the tooling. If a future signal surfaces that prose isn't enough, a hook or slash command could land in a follow-up.
- **Scope:** kit-level only. The `feedback_watch_ci_in_background.md` is a template — adopters who already have an older copy in their auto-memory pick up the new framing on their next bootstrap or by hand-copying the updated template.

## Test plan

- [x] Both edits render correctly when previewed; section flow in CONVENTIONS.md is unchanged
- [x] No code changes — `bootstrap.sh`, `templates/`, and bats coverage untouched
- [ ] CI: lychee link-check on the prose changes
- [ ] CI: bats suite

## CHANGELOG

`docs:` → patch bump + Documentation entry per `release-please-config.json`.