### PR TITLE
feat(bootstrap): add --workspace flag for multi-repo initiatives (#61)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -59,6 +59,7 @@ Flags:
 - `--ci TYPE` — primary CI/automation tool: `github-actions`, `gitlab-ci`, `jenkins`, `circleci`, `atlantis`, `ansible-cli`, `other`, or `none`. Skipped if omitted in non-interactive mode.
 - `--force` — proceed even if the working folder is already non-empty
 - `--dry-run` — print what would be created (paths, placeholder substitutions, tracker memory, MEMORY.md index line) and exit without writing anything. Safe to re-run.
+- `--workspace` — treat `<working-folder>` as a workspace path (multi-repo mode). Bootstrap creates a per-repo subfolder for the current repo inside the workspace, and on first use also seeds `workspace-CONTEXT.md` and `tickets/`. See [Workspace mode](#workspace-mode-multi-repo-initiatives) below.
 - `-h` / `--help` — show usage
 
 **On `--tracker other` and `--ci other`:** these are escape hatches for tools the kit doesn't have a named variant for. Picking either seeds a placeholder-rich memory file (`reference_issue_tracker.md` for trackers, `reference_ci.md` for CI) with `{{tracker URL pattern}}`, `{{ticket reference format}}`, `{{CI config location}}`, etc. that need manual fill-in before the memory is useful. The bootstrap end-of-run output flags this; if you're scanning flags to plan an invocation, plan for the follow-up edit.
@@ -209,6 +210,101 @@ For a fully filled-in reference, see [`examples/widget-tracker/CONTEXT.md`](exam
 7. **Don't re-run `bootstrap.sh`** on a populated working folder — it errors by design. If you really need to re-seed, clear the auto-memory dir manually and pass `--force` to the working folder, but you'll lose local customizations.
 
 If a future change is *not* backwards-compatible (rare for a docs-only kit — only likely if a template structure fundamentally changes), the CHANGELOG entry will call that out explicitly.
+
+---
+
+## Workspace mode (multi-repo initiatives)
+
+When a single piece of work spans multiple repos (e.g. Terraform environment definitions in one repo and modules in another), use `--workspace` so bootstrap creates a workspace folder above per-repo subfolders. The model is documented in [ADR-0001](docs/adr/0001-multi-repo-folder-model.md); summary:
+
+```
+~/<projects-root>/<initiative>/
+├── workspace-CONTEXT.md      ← cross-repo overview
+├── tickets/                  ← per-ticket scratchpads
+│   ├── <KEY>-<slug>.md
+│   └── archive/
+├── <repo-a>/                 ← per-repo subfolder (today's working-folder shape)
+│   ├── CONTEXT.md, SESSION-LOG.md, plan.md, ...
+└── <repo-b>/
+    └── ...
+```
+
+### First repo in a new workspace
+
+```bash
+cd <repo-a>
+<framework-dir>/bootstrap.sh --workspace ~/Documents/Claude/Projects/<initiative>/ \
+  --tracker jira --jira-project <KEY> --ci <TOOL>
+```
+
+Bootstrap creates `<initiative>/`, drops `workspace-CONTEXT.md` and `tickets/archive/` at the workspace root, and creates `<initiative>/<repo-a>/` populated with the standard per-repo templates. Auto-memory still keys to the repo (`~/.claude/projects/<sanitized-repo-path>/memory/`) — workspace mode doesn't change memory pathing.
+
+### Adding more repos to an existing workspace
+
+```bash
+cd <repo-b>
+<framework-dir>/bootstrap.sh --workspace ~/Documents/Claude/Projects/<initiative>/
+```
+
+Bootstrap detects the existing workspace (via the presence of `workspace-CONTEXT.md`), preserves it, and adds `<initiative>/<repo-b>/` as a new per-repo subfolder. Repeat for each repo in the initiative.
+
+### What `--workspace` does NOT do (yet)
+
+- **Tracker config substitution into CONTEXT.md** — for now, fill the `## Tracker Configuration` section in `<initiative>/<repo-a>/CONTEXT.md` and `<initiative>/workspace-CONTEXT.md` by hand. Bootstrap-side substitution is on the Phase 4 backlog ([#61](https://github.com/IamMrCupp/claude-project-kit/issues/61) §C.1 / D.1).
+- **Terraform sibling-repo prompt** — bootstrap doesn't yet detect Terraform-shaped repos and prompt about sibling envs/modules. Coming in a follow-up; for now, you decide which repos belong in the workspace.
+- **Interactive workspace prompt** — `--workspace` requires the explicit flag. Interactive mode still defaults to single-repo. Use the flag-based form above for workspace bootstraps.
+
+---
+
+## Upgrading a single-repo working folder to a workspace
+
+If you bootstrapped a single-repo working folder (the default shape) and later realize the work is going to span multiple repos, you can convert that folder into a workspace by hand. Both shapes coexist — there's no requirement to migrate.
+
+Target shape per [ADR-0001](docs/adr/0001-multi-repo-folder-model.md):
+
+```
+~/<projects-root>/<initiative>/                ← was: ~/<projects-root>/<repo-a>/
+├── workspace-CONTEXT.md                       ← new file
+├── tickets/                                   ← new directory
+│   └── archive/
+└── <repo-a>/                                  ← your existing files move here
+    ├── CONTEXT.md
+    ├── SESSION-LOG.md
+    ├── plan.md
+    └── ...
+```
+
+### Steps
+
+```bash
+INITIATIVE=<initiative-name>                   # e.g. lx-platform
+PROJECTS_ROOT=~/Documents/Claude/Projects      # wherever you keep working folders
+REPO_A=<existing-folder-name>                  # the working folder you're upgrading
+
+# 1. Rename the existing folder to act as the workspace
+mv "$PROJECTS_ROOT/$REPO_A" "$PROJECTS_ROOT/$INITIATIVE"
+
+# 2. Create the per-repo subfolder and move per-repo docs into it
+cd "$PROJECTS_ROOT/$INITIATIVE"
+mkdir "$REPO_A"
+mv CONTEXT.md SESSION-LOG.md plan.md implementation.md research.md \
+   acceptance-test-results*.md phase-*.md SEED-PROMPT.md \
+   ".claude" "$REPO_A/" 2>/dev/null || true
+
+# 3. Create the workspace-level scaffolding
+touch workspace-CONTEXT.md
+mkdir -p tickets/archive
+```
+
+### Edits required after the move
+
+- **`workspace-CONTEXT.md`** — fill in the cross-repo overview: what initiative this is, why it exists, which repos belong to it. Link each repo's subfolder. Use [`templates/workspace/workspace-CONTEXT.md`](templates/workspace/workspace-CONTEXT.md) in the kit as a starting template.
+- **`<repo-a>/CONTEXT.md`** — under "How to load this context," update the path: was `<initiative>/CONTEXT.md`, now `<initiative>/<repo-a>/CONTEXT.md`.
+- **Auto-memory** (`~/.claude/projects/<sanitized-path>/memory/reference_ai_working_folder.md`) — update the working-folder path so Claude knows to read from `<initiative>/<repo-a>/` instead of the old single-repo location.
+
+### Adding more repos
+
+Once the workspace exists, additional repos bootstrap into it via `--workspace` (see [Workspace mode](#workspace-mode-multi-repo-initiatives) above).
 
 ---
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -34,6 +34,14 @@ Arguments:
                      Omit to run interactively.
 
 Options:
+  --workspace        Treat <working-folder> as a workspace path (multi-repo
+                     mode) instead of a single-repo working folder. Bootstrap
+                     creates a per-repo subfolder for the current repo inside
+                     the workspace, and on first use also seeds the
+                     workspace's workspace-CONTEXT.md and tickets/ directory.
+                     Subsequent runs against an existing workspace add new
+                     repo subfolders without recreating workspace files.
+                     See ADR-0001 in the kit for the workspace folder model.
   --skip-memory      Skip copying memory-templates/ into the auto-memory
                      folder. Only the working folder will be seeded.
   --project-name NAME
@@ -78,6 +86,12 @@ Examples:
   ~/Code/claude-project-kit/bootstrap.sh ~/Documents/Claude/Projects/my-new-project \\
     --tracker jira --jira-project INFRA \\
     --ci github-actions
+
+  # Workspace mode (multi-repo initiative — adds this repo to the workspace)
+  cd ~/Code/my-terraform-modules
+  ~/Code/claude-project-kit/bootstrap.sh --workspace \\
+    ~/Documents/Claude/Projects/lx-platform/ \\
+    --tracker jira --jira-project LX --ci atlantis
 
 After running, edit the copied files (placeholders marked {{LIKE_THIS}}).
 Most common memory placeholders are auto-filled; any that couldn't be
@@ -124,6 +138,7 @@ ci_index_line() {
 SKIP_MEMORY=0
 FORCE=0
 DRY_RUN=0
+WORKSPACE_MODE=0
 WORKING_FOLDER=""
 PROJECT_NAME=""
 TRACKER=""
@@ -136,6 +151,7 @@ while [ $# -gt 0 ]; do
     --skip-memory) SKIP_MEMORY=1; shift ;;
     --force) FORCE=1; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
+    --workspace) WORKSPACE_MODE=1; shift ;;
     --project-name)
       if [ $# -lt 2 ]; then
         echo "error: --project-name requires a value" >&2
@@ -269,6 +285,14 @@ REPO_ROOT="$(pwd)"
 SANITIZED="$(echo "$REPO_ROOT" | sed 's|/|-|g')"
 MEMORY_DIR="$HOME/.claude/projects/${SANITIZED}/memory"
 
+WORKSPACE_DIR=""
+WORKSPACE_REPO_NAME=""
+if [ "$WORKSPACE_MODE" -eq 1 ]; then
+  WORKSPACE_DIR="$WORKING_FOLDER"
+  WORKSPACE_REPO_NAME="$(basename "$REPO_ROOT")"
+  WORKING_FOLDER="$WORKSPACE_DIR/$WORKSPACE_REPO_NAME"
+fi
+
 if [ -z "$PROJECT_NAME" ]; then
   PROJECT_NAME="$(basename "$WORKING_FOLDER")"
 fi
@@ -327,7 +351,12 @@ if REMOTE_URL="$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null)"; then
     | sed -E 's|^https?://[^/]+/||; s|^git@[^:]+:||; s|\.git$||')"
 fi
 
-echo "Working folder: $WORKING_FOLDER"
+if [ "$WORKSPACE_MODE" -eq 1 ]; then
+  echo "Workspace:      $WORKSPACE_DIR"
+  echo "Repo subfolder: $WORKSPACE_REPO_NAME (full path: $WORKING_FOLDER)"
+else
+  echo "Working folder: $WORKING_FOLDER"
+fi
 echo "Repo root:      $REPO_ROOT"
 echo "Project name:   $PROJECT_NAME"
 if [ "$SKIP_MEMORY" -eq 0 ]; then
@@ -351,6 +380,16 @@ echo
 if [ "$DRY_RUN" -eq 1 ]; then
   echo "=== DRY RUN — no files will be written ==="
   echo
+  if [ "$WORKSPACE_MODE" -eq 1 ]; then
+    echo "Workspace dir: $WORKSPACE_DIR"
+    if [ -f "$WORKSPACE_DIR/workspace-CONTEXT.md" ]; then
+      echo "  ✓ existing workspace (workspace-CONTEXT.md present) — no workspace-level changes"
+    else
+      echo "  + create workspace dir + tickets/archive/"
+      echo "  + copy $KIT_ROOT/templates/workspace/workspace-CONTEXT.md → workspace-CONTEXT.md"
+    fi
+    echo
+  fi
   echo "Would create working folder: $WORKING_FOLDER"
   echo "  + copy $KIT_ROOT/templates/*.md"
   echo "  + rename phase-N-checklist.md → phase-0-checklist.md"
@@ -430,6 +469,17 @@ if [ "$SKIP_MEMORY" -eq 0 ] && [ -d "$MEMORY_DIR" ]; then
 fi
 
 mkdir -p "$WORKING_FOLDER"
+
+if [ "$WORKSPACE_MODE" -eq 1 ]; then
+  mkdir -p "$WORKSPACE_DIR/tickets/archive"
+  if [ ! -f "$WORKSPACE_DIR/workspace-CONTEXT.md" ]; then
+    cp "$KIT_ROOT/templates/workspace/workspace-CONTEXT.md" "$WORKSPACE_DIR/"
+    echo "  ✓ Created workspace at $WORKSPACE_DIR (workspace-CONTEXT.md, tickets/archive/)"
+  else
+    echo "  ✓ Existing workspace at $WORKSPACE_DIR — adding repo subfolder $WORKSPACE_REPO_NAME"
+  fi
+fi
+
 cp "$KIT_ROOT/templates/"*.md "$WORKING_FOLDER/"
 mv "$WORKING_FOLDER/phase-N-checklist.md" "$WORKING_FOLDER/phase-0-checklist.md"
 echo "  ✓ Copied template files to $WORKING_FOLDER"

--- a/tests/bootstrap_workspace.bats
+++ b/tests/bootstrap_workspace.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+# --workspace flag mechanics: workspace folder creation, per-repo subfolder,
+# add-to-existing-workspace flow, dry-run output, help text presence.
+
+load 'helpers'
+
+setup() { bootstrap_setup; }
+teardown() { bootstrap_teardown; }
+
+@test "--workspace appears in --help output" {
+  run "$BOOTSTRAP" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--workspace"* ]]
+  [[ "$output" == *"workspace path"* ]]
+  [[ "$output" == *"multi-repo"* ]]
+}
+
+@test "--workspace creates workspace dir, per-repo subfolder, and tickets/archive/" {
+  WS="$TEST_TMP/lx-platform"
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -eq 0 ]
+
+  REPO_NAME="$(basename "$TEST_REPO")"
+  [ -d "$WS" ]
+  [ -d "$WS/$REPO_NAME" ]
+  [ -d "$WS/tickets" ]
+  [ -d "$WS/tickets/archive" ]
+}
+
+@test "--workspace copies workspace-CONTEXT.md to workspace root" {
+  WS="$TEST_TMP/lx-platform"
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -eq 0 ]
+
+  [ -f "$WS/workspace-CONTEXT.md" ]
+  grep -q "Workspace —" "$WS/workspace-CONTEXT.md"
+}
+
+@test "--workspace populates per-repo subfolder with standard templates" {
+  WS="$TEST_TMP/lx-platform"
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -eq 0 ]
+
+  REPO_NAME="$(basename "$TEST_REPO")"
+  [ -f "$WS/$REPO_NAME/CONTEXT.md" ]
+  [ -f "$WS/$REPO_NAME/SESSION-LOG.md" ]
+  [ -f "$WS/$REPO_NAME/plan.md" ]
+  [ -f "$WS/$REPO_NAME/phase-0-checklist.md" ]
+  [ ! -f "$WS/$REPO_NAME/phase-N-checklist.md" ]
+}
+
+@test "--workspace does NOT copy workspace-only templates to per-repo subfolder" {
+  WS="$TEST_TMP/lx-platform"
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -eq 0 ]
+
+  REPO_NAME="$(basename "$TEST_REPO")"
+  [ ! -f "$WS/$REPO_NAME/workspace-CONTEXT.md" ]
+  [ ! -d "$WS/$REPO_NAME/tickets" ]
+}
+
+@test "--workspace re-run against existing workspace adds new repo without recreating workspace files" {
+  WS="$TEST_TMP/lx-platform"
+
+  # First run — creates workspace
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -eq 0 ]
+  REPO1_NAME="$(basename "$TEST_REPO")"
+  [ -f "$WS/workspace-CONTEXT.md" ]
+
+  # Mark workspace-CONTEXT.md so we can detect if it gets overwritten
+  echo "USER_EDITED" >> "$WS/workspace-CONTEXT.md"
+
+  # Set up a sibling repo and bootstrap it into the same workspace
+  REPO2="$TEST_TMP/repo2"
+  mkdir -p "$REPO2"
+  git -C "$REPO2" init -q
+  cd "$REPO2"
+
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Existing workspace"* ]]
+  [[ "$output" == *"adding repo subfolder repo2"* ]]
+
+  # User edit must survive — workspace-CONTEXT.md NOT overwritten
+  grep -q "USER_EDITED" "$WS/workspace-CONTEXT.md"
+
+  # Both per-repo subfolders should exist
+  [ -d "$WS/$REPO1_NAME" ]
+  [ -d "$WS/repo2" ]
+  [ -f "$WS/repo2/CONTEXT.md" ]
+}
+
+@test "--workspace errors when per-repo subfolder is non-empty (without --force)" {
+  WS="$TEST_TMP/lx-platform"
+  REPO_NAME="$(basename "$TEST_REPO")"
+  mkdir -p "$WS/$REPO_NAME"
+  echo "leftover" > "$WS/$REPO_NAME/CONTEXT.md"
+
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"is not empty"* ]]
+}
+
+@test "--workspace --force proceeds past non-empty per-repo subfolder" {
+  WS="$TEST_TMP/lx-platform"
+  REPO_NAME="$(basename "$TEST_REPO")"
+  mkdir -p "$WS/$REPO_NAME"
+  echo "leftover" > "$WS/$REPO_NAME/leftover.txt"
+
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory --force
+  [ "$status" -eq 0 ]
+  [ -f "$WS/$REPO_NAME/CONTEXT.md" ]
+}
+
+@test "--workspace --dry-run previews workspace creation without writing" {
+  WS="$TEST_TMP/lx-platform"
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY RUN"* ]]
+  [[ "$output" == *"Workspace dir: $WS"* ]]
+  [[ "$output" == *"create workspace dir"* ]]
+  [[ "$output" == *"workspace-CONTEXT.md"* ]]
+
+  # Nothing actually written
+  [ ! -d "$WS" ]
+}
+
+@test "--workspace --dry-run against existing workspace reports no workspace-level changes" {
+  WS="$TEST_TMP/lx-platform"
+  mkdir -p "$WS"
+  touch "$WS/workspace-CONTEXT.md"
+
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"existing workspace"* ]]
+  [[ "$output" == *"no workspace-level changes"* ]]
+}
+
+@test "--workspace summary lines reflect workspace mode" {
+  WS="$TEST_TMP/lx-platform"
+  REPO_NAME="$(basename "$TEST_REPO")"
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Workspace:      $WS"* ]]
+  [[ "$output" == *"Repo subfolder: $REPO_NAME"* ]]
+  # Single-repo "Working folder:" line should NOT appear in workspace mode
+  [[ "$output" != *"Working folder: $WS"* ]]
+}
+
+@test "--workspace seeds memory under repo-keyed path (not workspace-keyed)" {
+  WS="$TEST_TMP/lx-platform"
+  run "$BOOTSTRAP" --workspace "$WS"
+  [ "$status" -eq 0 ]
+
+  # Memory dir is keyed by REPO_ROOT (the actual repo), unchanged by workspace mode
+  MEM="$(memory_dir)"
+  [ -d "$MEM" ]
+  [ -f "$MEM/MEMORY.md" ]
+}


### PR DESCRIPTION
## Summary

Phase 4 §D.4 — the `--workspace` flag in `bootstrap.sh`. First piece of Section D; D.1 (tracker-config substitution into CONTEXT.md), D.3 (Terraform sibling-repo prompt), and D.2 (assertion that bootstrap never creates tracker artifacts) become follow-up PRs.

- **`bootstrap.sh`** — new `--workspace` flag (no argument; the positional working-folder argument becomes the workspace path). When set, bootstrap derives `WORKSPACE_DIR` from the positional and `WORKSPACE_REPO_NAME` from `basename "$REPO_ROOT"`, then sets the actual `WORKING_FOLDER` to `$WORKSPACE_DIR/$WORKSPACE_REPO_NAME`. The existing per-repo flow continues unchanged inside that subfolder. On first use of a workspace (no `workspace-CONTEXT.md` present), bootstrap also seeds `workspace-CONTEXT.md` from `templates/workspace/` and creates `tickets/archive/`. On subsequent runs against an existing workspace, only the new repo subfolder is added. Help text + dry-run + confirmation summary all updated.
- **`tests/bootstrap_workspace.bats`** — new test file with 12 tests covering: help-text presence, workspace + per-repo + tickets directory creation, workspace-CONTEXT.md copy, per-repo template population, workspace-only templates not leaking into per-repo subfolder, idempotent existing-workspace handling (with user-edit preservation), non-empty per-repo subfolder error + `--force` override, dry-run new vs. existing workspace output, summary lines, and memory still keyed by repo path.
- **`SETUP.md`** — adds a new `## Workspace mode (multi-repo initiatives)` section walking through "first repo in a new workspace" + "adding more repos to an existing workspace," documents `--workspace` in the flag list, and explicitly enumerates what `--workspace` does NOT do yet (tracker-config substitution, Terraform sibling-repo prompt, interactive workspace prompting). Also restores the `## Upgrading a single-repo working folder to a workspace` section that was lost from #69 (committed to that branch but landed after the merge).

## Motivation

Phase 4's anchor [#61](https://github.com/IamMrCupp/claude-project-kit/issues/61) defines a multi-repo workspace shape; ADR-0001 locks the design contract. PR #72 shipped the templates. This PR ships the bootstrap surface that creates the shape — without it, the workspace templates from #72 are inert.

D.4 (the flag) is the foundation; the rest of Section D builds on top:
- D.1 (tracker-config substitution) — needs the workspace flow as a copy target.
- D.3 (Terraform detection) — extends `--workspace` with a proactive prompt; meaningless without the flag.
- D.2 (no-tracker-creation assertion) — tightens runtime invariants once the flag is established.

## Design notes

- **Single flag, no argument.** `--workspace` is a boolean; the positional `<working-folder>` argument is reinterpreted as the workspace path. Avoids `--workspace PATH` which would conflict with the existing positional convention.
- **Repo subfolder name = `basename "$REPO_ROOT"`.** No `--workspace-repo` flag for v1; the repo's directory name is the natural identifier and matches how users think about workspaces. Override via `--workspace-repo` is a clean follow-up if a real signal surfaces.
- **Existing-workspace detection via `workspace-CONTEXT.md` presence.** Simple, structural, no metadata file needed. If the file's there, we're adding to an existing workspace; otherwise, we're creating a new one. `mkdir -p $WORKSPACE_DIR/tickets/archive` runs unconditionally — `mkdir -p` is idempotent.
- **User edits to `workspace-CONTEXT.md` are preserved** across re-runs (verified by test 6). Bootstrap only copies the file if it doesn't already exist.
- **Auto-memory unchanged.** `MEMORY_DIR` is still derived from `REPO_ROOT` (the actual git repo), not the workspace path. Workspace mode is a working-folder layout choice, not a memory-keying choice.
- **Empty-folder check applies to the per-repo subfolder, not the workspace.** After `WORKING_FOLDER` is reassigned to the per-repo path, the existing non-empty check works correctly out of the box.
- **Three granular commits**: `feat(bootstrap):` for the script, `test(bootstrap):` for the bats coverage, `docs(setup):` for the user-facing docs. Release-please picks the highest bump (minor for `feat:`).
- **SETUP.md restoration.** While editing SETUP.md I noticed the `## Upgrading a single-repo working folder to a workspace` section was missing from main — I'd committed it to PR #69's branch after the user merged that PR, so it never landed. This PR includes that section so the migration path is documented alongside the new workspace mode it migrates *to*.
- **Interactive mode deliberately not extended.** Adding a "workspace mode? (y/N)" prompt is more UX work; defer until v2 once the flag-based workflow proves out.

## Test plan

- [x] New `tests/bootstrap_workspace.bats` — 12/12 pass
- [x] Full bats suite — 77/77 pass (65 prior + 12 new)
- [x] Smoke test: `bootstrap.sh --workspace <tmpdir>/acme-platform --skip-memory` from a fresh git repo creates the expected workspace shape (`workspace-CONTEXT.md`, `tickets/archive/`, per-repo subfolder with standard templates)
- [x] `bootstrap.sh -h` renders the new `--workspace` option and the new workspace example
- [x] Dry-run (`--dry-run --workspace`) prints the workspace-creation step without writing
- [ ] CI: bats suite (triggered by `bootstrap.sh` + `tests/` changes)
- [ ] CI: lychee link-check on SETUP.md changes

## CHANGELOG

Three commits — `feat(bootstrap):` (minor bump), `test(bootstrap):` (patch entry, hidden by default), `docs(setup):` (patch entry under Documentation). Release-please picks minor as the overall bump. **For existing adopters:** workspace mode is opt-in via `--workspace`; today's single-repo flow is unchanged.
