### PR TITLE
feat(memory-templates): add feedback_no_push_after_merge starter

### DIFF
--- a/memory-templates/MEMORY.md
+++ b/memory-templates/MEMORY.md
@@ -16,5 +16,6 @@ Do not treat these as canonical without reading them first — they encode one o
 - [PR test plans](feedback_pr_test_plans.md) — detailed numbered manual-test steps with expected logs
 - [Check off PR tests on pass](feedback_pr_check_off_on_pass.md) — edit PR body with evidence + ✅ after testing
 - [Watch CI in background](feedback_watch_ci_in_background.md) — spawn `gh run watch` in background after push
+- [Don't push after merge](feedback_no_push_after_merge.md) — once a PR merges, the branch is closed; branch off new `main` for follow-up work
 - [Keep planning docs in sync](feedback_docs_in_sync.md) — update plan / checklist / implementation as work lands
 - [Current project context](project_current.md) — what's being built, why, timeline

--- a/memory-templates/feedback_no_push_after_merge.md
+++ b/memory-templates/feedback_no_push_after_merge.md
@@ -1,0 +1,25 @@
+---
+name: Don't push commits to a branch after its PR has been merged
+description: Once a PR is merged, the branch is closed. Commits pushed afterward get orphaned — they sit on the remote branch but never reach `main`. Branch off new `main` for follow-up work.
+type: feedback
+---
+
+Once a PR has been merged, treat the branch as closed. **Do not push additional commits to it.** They land on the remote branch but the merge already happened, so the new commits are unreferenced from `main` and silently get lost on the next branch cleanup.
+
+If you have more work for the same scope after the PR merged:
+
+```bash
+git checkout main
+git pull --ff-only
+git checkout -b <type>/<new-slug>
+```
+
+If the user is about to merge a PR and you have pending changes that should land in it (a follow-up commit you haven't pushed, a fix you noticed mid-review), **say so before they merge**. Either get the changes onto the branch first, or explicitly agree to a follow-up PR. Don't assume "I'll push it after" — after merge, the commit gets orphaned.
+
+**Why:** the failure mode is silent. There's no error, no warning, no missing-commit alarm. The push succeeds, the branch shows the new commit on the remote, but `gh pr view` reports the original (pre-merge) file list, and `main` never gains the new content. Discovered cost can be substantial — the change has to be re-done in a follow-up PR, or worse, the original work feels "done" while the gap goes unnoticed for a while.
+
+**How to apply:**
+- After every PR merge, branch off the updated `main` for any follow-up work — never reuse the merged branch.
+- Before the user merges, scan: is there work staged or in-flight that belongs in this PR? If yes, stop them and push first. If no, confirm and let them merge.
+- If a commit *did* get orphaned (you notice the file list in `gh pr view` doesn't match what you expected), open a small recovery PR explicitly named "restore X (lost from #N)" rather than silently bundling it into a future feature PR.
+- This rule applies equally to PRs the user merges and to auto-merged PRs (release-please, dependabot, etc.) — once merged is once merged.


### PR DESCRIPTION
## Summary

- **`memory-templates/feedback_no_push_after_merge.md`** (new) — feedback memory template capturing the rule "once a PR is merged, the branch is closed; don't push more commits to it. Branch off new `main` for follow-up work."
- **`memory-templates/MEMORY.md`** — index entry added so the new template is discoverable.

## Motivation

Tonight's session shipped PR #69 (the ADR + SETUP migration section). The user merged the PR with the 3 ADR-only commits before I'd pushed the migration commit. The migration commit landed on the (already-merged) branch and was orphaned — `gh pr view 69` showed only the 3 originally-merged files; the migration section never reached `main`. I didn't notice until #76, where I had to restore the section as part of an unrelated PR.

The failure mode is silent: no error, no warning, the push succeeds, the remote branch shows the commit, but `main` never gains the content. Cost on this session: a partial section had to be re-done in a follow-up PR. Cost in general: bigger if the orphaned work isn't noticed quickly.

The kit ships several "behavioral guardrail" memory-templates (`feedback_watch_ci_in_background.md`, `feedback_no_ai_coauthor.md`, `feedback_pr_check_off_on_pass.md`, etc.) for exactly this kind of failure mode — rules that aren't expressible in code but matter for keeping the workflow tight. This adds one more.

## Design notes

- **Single feedback file, mirrors the existing `feedback_*.md` pattern.** Frontmatter + body with **Why** and **How to apply** sections, same as `feedback_watch_ci_in_background.md`.
- **No CONVENTIONS.md addition.** The rule fits the "behavioral guardrail" pattern (memory-template territory), not the "universal convention" pattern (CONVENTIONS.md territory). Most kit users won't trip this often; the memory entry catches it for Claude when it does come up.
- **Single `feat:` commit.** New starter file → user-facing feature for downstream adopters → minor bump per release-please.
- **Index update bundled** — keeping `memory-templates/MEMORY.md` in sync with the new file is a hard rule (see the index file's own intro), so it lands in the same commit.

## Test plan

- [x] New memory file frontmatter parses cleanly (`name`, `description`, `type` fields all present)
- [x] `memory-templates/MEMORY.md` index entry added under the existing CI bullet
- [x] No code changes — `bootstrap.sh`, `templates/`, and bats coverage untouched
- [ ] CI: lychee link-check on the new docs
- [ ] CI: bats suite (memory-templates touch may trigger it)

## CHANGELOG

`feat:` → minor bump + Documentation entry per `release-please-config.json`. **For existing adopters:** new memory-template; copy into your project's auto-memory if you want the rule applied:

```bash
cp <kit-dir>/memory-templates/feedback_no_push_after_merge.md \
   ~/.claude/projects/<sanitized-path>/memory/
```

Then add the matching index entry to your project's `MEMORY.md`.