### PR TITLE
feat(memory-templates): promote four behavioral feedback starters

### DIFF
--- a/memory-templates/MEMORY.md
+++ b/memory-templates/MEMORY.md
@@ -17,5 +17,9 @@ Do not treat these as canonical without reading them first — they encode one o
 - [Check off PR tests on pass](feedback_pr_check_off_on_pass.md) — edit PR body with evidence + ✅ after testing
 - [Watch CI in background](feedback_watch_ci_in_background.md) — spawn `gh run watch` in background after push
 - [Don't push after merge](feedback_no_push_after_merge.md) — once a PR merges, the branch is closed; branch off new `main` for follow-up work
+- [Use the repo's branch-name convention](feedback_branch_naming.md) — rename auto-generated worktree branches to `<type>/<slug>` before pushing
+- [Prefer automated tests over manual smoke](feedback_automated_tests_preferred.md) — default to bats / expect / integration runners; don't ship manual procedures as steady state
+- [Never create tracker projects](feedback_no_tracker_creation.md) — read/reference only for business-owned trackers; let PMs handle creation
+- [Don't manually tag when release automation is configured](feedback_release_per_pr.md) — release-please etc. handle tagging; do nothing release-wise after a normal PR merge
 - [Keep planning docs in sync](feedback_docs_in_sync.md) — update plan / checklist / implementation as work lands
 - [Current project context](project_current.md) — what's being built, why, timeline

--- a/memory-templates/feedback_automated_tests_preferred.md
+++ b/memory-templates/feedback_automated_tests_preferred.md
@@ -1,0 +1,15 @@
+---
+name: Prefer automated tests over documented manual smoke procedures
+description: When closing a test-coverage gap, default to automation (bats, expect, integration runners) over documented manual smoke-test procedures — humans skip or rationalize manual checks.
+type: feedback
+---
+
+When evaluating how to close a test-coverage gap, default to automated test infrastructure (e.g. `bats`, `expect`, integration runners, contract tests) over documented manual smoke-test procedures — even when the surface is small or stable, and even when the automation requires a new tool dependency.
+
+**Why:** humans skip manual test plans or rationalize "it probably still works" when they're tired or in a hurry. A documented script in a README becomes ceremonial within a few iterations; an automated test runs every time and can't be lied about. The setup cost of automation pays back the first time it catches a regression a manual procedure would have missed.
+
+**How to apply:**
+- When given options like "automation vs. manual procedure vs. accept the gap," default to automation unless there's a concrete reason it's infeasible (physical hardware, paid third-party API, irreducibly visual UI without snapshot tooling).
+- Adding a new dependency (`expect`, an integration framework, a snapshot library) is acceptable. CI install time is cheap relative to the cost of an undetected regression.
+- A documented manual smoke procedure is only acceptable as a temporary stopgap with an issue tracking the automation work — never as the steady state.
+- If proposing manual coverage in a design discussion, expect pushback and have the automation alternative ready.

--- a/memory-templates/feedback_branch_naming.md
+++ b/memory-templates/feedback_branch_naming.md
@@ -1,0 +1,19 @@
+---
+name: Use the repo's branch-name convention, not auto-generated worktree defaults
+description: When working in a worktree, rename the auto-generated branch to match the repo's `<type>/<short-slug>` convention before pushing or opening a PR.
+type: feedback
+---
+
+When a worktree is auto-created (e.g. by Claude Code), the branch is named something like `claude/sharp-moore-05b6d9`. **Do not push that name.** Before the first `git push`, rename the branch to match the repo's existing convention. Check `git log --all --oneline` for the pattern — typically `<type>/<short-slug>` like `feat/bootstrap-workspace-flag`, `docs/clarify-existing-repos`, `fix/lychee-placeholder-paths`.
+
+```bash
+git branch -m <new-name>
+```
+
+**Why:** PR titles are visible and reviewed; branch names show up in `git branch`, in PR URLs, in merge-commit messages, and in the repo's branch list long after the PR closes. A branch named `feat/bootstrap-workspace-flag` reads as deliberate; one named `claude/sharp-moore-05b6d9` reads as auto-generated noise. Both costs are small individually; both compound across a project's history.
+
+**How to apply:**
+- Before the first `git push -u origin <branch>` of a session, check `git log --all --oneline | grep -E '^\* |^[a-f0-9]+ '` — or just `gh pr list` — for the existing naming pattern.
+- `git branch -m <type>/<short-slug>` to rename. The `<type>` should match the Conventional Commit type for the work (`feat`, `fix`, `docs`, `chore`, etc.).
+- Apply on any repo where the existing branches follow a clear convention. If the convention isn't obvious from history, ask the user.
+- This is a once-per-session check — after the rename, all subsequent pushes use the renamed branch.

--- a/memory-templates/feedback_no_tracker_creation.md
+++ b/memory-templates/feedback_no_tracker_creation.md
@@ -1,0 +1,16 @@
+---
+name: Never create tracker projects, labels, workflows, or sprint scaffolding
+description: External trackers (JIRA, Linear, etc.) are typically owned by PMs / the business. The kit and Claude operating within it must only read/reference existing projects — never create them or modify their structure.
+type: feedback
+---
+
+When kit features or Claude actions touch external trackers (JIRA, Linear, GitHub Issues, GitLab, Shortcut, etc.), the rule is **read/reference only** for any tracker that's owned by someone other than the user. Never create tracker projects, labels, workflow states, sprint configurations, or any structural artifact in those tools. Capture *references* to projects that already exist (project key, MCP availability, link) and let the human owners handle creation.
+
+**Why:** at most workplaces, tracker projects map to teams or initiatives and are governed by PMs, program managers, or admin teams. A bootstrap that spins up its own project would step on that ownership, create duplicates, and likely violate org policy. The same logic extends to labels and workflows — those encode team-wide conventions that an individual contributor (or AI assistant) shouldn't unilaterally change.
+
+**How to apply:**
+- When designing features that touch trackers (bootstrap prompts, MCP integrations, automation), default to **read/reference only** for business-owned trackers.
+- Do not propose flows that call `gh project create`, `jira project create`, `linear team create`, or equivalents — for any tracker the user doesn't personally own.
+- **Creating individual issues/tickets inside an existing project is on the table** when the user explicitly asks for it. The constraint is on structural / project-level artifacts, not on standard work-item creation.
+- Personal repositories where the user owns the tracker directly (e.g. their own GitHub Issues + Project board on a personal repo) are the exception — there, creation is fine if the user authorizes it.
+- If unsure whether a tracker is "owned by the user" or "owned by the business," ask first. Default to assuming business-owned.

--- a/memory-templates/feedback_release_per_pr.md
+++ b/memory-templates/feedback_release_per_pr.md
@@ -1,0 +1,30 @@
+---
+name: Don't manually tag releases when release automation is configured
+description: If the project uses release-please (or similar), do nothing release-wise after a normal PR merge — the automation opens/updates a release PR. Manual `gh release create` is a fallback for when the automation is broken.
+type: feedback
+---
+
+When a project has release automation configured (e.g. release-please, semantic-release, changesets), **do not manually tag or `gh release create` after a normal PR merge.** The automation handles it.
+
+For release-please specifically:
+- On every push to `main`, the workflow opens or updates a release PR that bundles all commits since the last tag with a generated CHANGELOG section.
+- Merging the release PR creates the tag + GitHub Release in one action.
+
+**How to apply:**
+- When informed that a normal feature / fix PR merged: **do nothing release-wise.** The release automation will open or update its release PR within seconds. The user is responsible for reviewing and merging that PR when they're ready to cut a release.
+- When informed that a **release PR** (titled like `chore(main): release <version>`) merged: the tag + release are already published — no further action needed.
+- **Commit types matter.** `feat:` → minor bump, `fix:` → patch bump, `feat!:` or `BREAKING CHANGE:` in body → major. Non-bumping types (`docs:`, `chore:`, `test:`, etc.) don't trigger a release on their own but appear in the CHANGELOG once the next bumping commit lands. (Some kits intentionally configure `docs:` to bump — check `release-please-config.json` if one's present.)
+- **CHANGELOG-in-PR is not required** under release-please. Hand-written entries in feature PRs are fine (release-please merges cleanly) but not necessary.
+- **Fall back to manual tagging only if** the automation is broken (workflow disabled, config misconfigured, etc.) — and only after proposing the manual commands for user confirmation.
+
+**What to propose if a manual release is needed:**
+
+```bash
+git tag -a v<X.Y.Z> <merge-sha> -m "<short title>"
+git push origin v<X.Y.Z>
+gh release create v<X.Y.Z> --latest --title "v<X.Y.Z> — <title>" --notes "..."
+```
+
+Always get user confirmation before executing.
+
+**Detect whether release-please is configured:** look for `.github/workflows/release-please.yml` and `release-please-config.json` at the repo root.


### PR DESCRIPTION
## Summary

Promotes four behavioral feedback rules from in-use auto-memory into kit memory-templates, so future bootstrapped projects ship with them by default.

- **`feedback_automated_tests_preferred.md`** — when closing a test-coverage gap, default to automation (bats / expect / integration runners) over manual smoke procedures.
- **`feedback_branch_naming.md`** — rename auto-generated worktree branches (e.g. `claude/sharp-moore-05b6d9`) to the repo's `<type>/<short-slug>` convention before pushing.
- **`feedback_no_tracker_creation.md`** — never create tracker projects, labels, workflows, or sprint scaffolding in business-owned trackers; capture references only. Personal repos where the user owns the tracker are the explicit exception.
- **`feedback_release_per_pr.md`** — when release-please (or similar) is configured, do nothing release-wise after a normal PR merge. Manual `gh release create` is the broken-automation fallback.

Plus index entries in `memory-templates/MEMORY.md` for all four.

## Motivation

Tonight's memory inventory found four behavioral rules in this project's auto-memory that aren't generic enough to apply to every project but ARE generic enough to be useful starters that adopters can prune or tune. Shipping as memory-templates means new bootstraps inherit them; adopters can delete what doesn't fit (the kit's own memory-templates intro is explicit that everything in there is a starting point, not canon).

The four rules are exactly the shape of the existing `feedback_*.md` starters: short frontmatter + body with **Why** and **How to apply** sections. No new conventions, just better defaults.

## Design notes

- **Generalized away from project-specific framing.** Personal-memory copies referenced specific PRs and "Aaron's work" — kit-template versions read as universal advice with hypothetical examples.
- **`feedback_release_per_pr.md` documents how to detect release-please** (look for `.github/workflows/release-please.yml`) so the rule applies cleanly to projects that have automation AND projects that don't. Adopters who don't use release-please can delete the file.
- **`feedback_no_tracker_creation.md` carves a clear exception** for personal repos where the user owns the tracker — the kit's own GitHub Issues + Project board is exactly that case, and contributors who copy the rule shouldn't think they can never open issues on their own repos.
- **Single bundled commit, four new files + index update.** All four are conceptually one "promote behavioral starters" operation; granular commits would create churn for no review benefit.
- **Skipped from this batch:** `feedback_terraform_multirepo_prompt.md` from personal memory. Phase 4 §D.3 will encode the same behavior in `bootstrap.sh` itself, so a memory-template would be redundant once that lands.

## Test plan

- [x] All four files have valid frontmatter (`name`, `description`, `type` fields)
- [x] All four follow the existing `feedback_*.md` body structure (rule, **Why**, **How to apply**)
- [x] `memory-templates/MEMORY.md` index has matching entries for all four, in the same one-liner-with-link pattern as existing rows
- [x] No code changes — `bootstrap.sh`, `templates/`, and bats coverage untouched
- [ ] CI: lychee link-check on the new docs
- [ ] CI: bats suite

## CHANGELOG

`feat:` → minor bump per `release-please-config.json`. **For existing adopters:** these are new starter memories; copy whichever apply to your project into your auto-memory:

```bash
cp <kit-dir>/memory-templates/feedback_automated_tests_preferred.md \
   ~/.claude/projects/<sanitized-path>/memory/
# (and the others, plus matching MEMORY.md index entries)
```

Adopters whose projects don't have release automation should skip `feedback_release_per_pr.md`. Those without external trackers can skip `feedback_no_tracker_creation.md`.