### PR TITLE
docs: surface the auto-memory short-form session-start prompt

### DIFF
--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -8,6 +8,20 @@ Ready-to-paste prompts for starting Claude sessions in common scenarios. Copy th
 
 Use this when opening a fresh Claude session in a repo you've already bootstrapped with the kit's templates and memory starters. The prompt points Claude at your persistent working folder so it picks up project state from where the last session left off.
 
+### Short form — recommended for daily use
+
+Once `reference_ai_working_folder.md` is in your project's auto-memory (the kit seeds it during bootstrap), the prompt collapses to one line:
+
+```
+Load context and give me a 3-bullet summary of where we are.
+```
+
+The memory tells Claude where the working folder lives, so you don't need to repeat the path. **This is the steady-state prompt** — paste it in, get your grounding summary, start working.
+
+### Verbose form — first session, or no auto-memory yet
+
+Use this if it's your very first session in a project, the auto-memory reference isn't set up yet, or you want Claude to see the full instructions explicitly:
+
 ```
 Before we start, read these files in my AI working folder, in order:
 
@@ -24,9 +38,9 @@ landed most recently, and any open threads. Then wait for my next instruction.
 ```
 
 **Notes:**
-- Replace `<working-folder>` with the actual path (e.g. `~/Documents/Claude/Projects/my-project/`)
-- **Once you've set up `memory-templates/reference_ai_working_folder.md` for the project**, the memory tells Claude where to look automatically — you can shorten the prompt to *"Load context and give me a 3-bullet summary of where we are."*
-- If you're resuming mid-PR, use [Prompt 4](#4-resuming-mid-pr) instead of this one — it loads the same context but adds a structured branch + PR + CI assessment.
+- Replace `<working-folder>` with the actual path (e.g. `~/Documents/Claude/Projects/my-project/`).
+- If you're resuming mid-PR, use [Prompt 4](#4-resuming-mid-pr) instead of either form above — it loads the same context but adds a structured branch + PR + CI assessment.
+- The `/session-start` slash command (in `templates/.claude/commands/`) runs the verbose flow as a one-step invocation. Copy it into your repo's `.claude/commands/` to enable.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Works the same for greenfield repos and ones you're adopting it on mid-stream �
    - **Interactive (hand-held):** `bootstrap.sh` with no arguments prompts for working-folder path, project name, whether to seed auto-memory, your issue tracker (GitHub Issues / JIRA / Linear / GitLab / Shortcut / other / none), and your primary CI/automation tool (GitHub Actions / GitLab CI / Jenkins / CircleCI / Atlantis / Ansible CLI / other / none). For JIRA and Linear, it also prompts for the project or team key.
    - **Non-interactive (scripted):** `bootstrap.sh <working-folder> [--tracker TYPE] [--jira-project KEY | --linear-team KEY] [--ci TYPE]` — see `bootstrap.sh -h` for the full flag list.
 4. Open Claude Code in the target repo and say *"Follow the instructions in `<working-folder>/SEED-PROMPT.md`."* Claude deep-reads your repo, fills the templates, flags anything it inferred or can't derive, and stops for your review.
-5. Answer Claude's questions, confirm the inferences, and start working. The normal per-session prompt lives in [PROMPTS.md](PROMPTS.md).
+5. Answer Claude's questions, confirm the inferences, and start working. From the next session onward (once `reference_ai_working_folder.md` is in auto-memory, which bootstrap seeds for you), the daily-use prompt is just *"Load context and give me a 3-bullet summary of where we are."* — full prompt library, including the verbose first-session form and mid-PR resume, in [PROMPTS.md](PROMPTS.md).
 
 ## The lifecycle
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -117,13 +117,13 @@ For work projects especially, vet each rule against your employer's policies bef
 
 ## 6. First session
 
-Open Claude in the repo and paste **Prompt 1 ("Starting work on a project that uses this kit")** from [PROMPTS.md](PROMPTS.md). That prompt tells Claude to read your working folder's `CONTEXT.md` + `SESSION-LOG.md` + current phase checklist, then hand back a short summary — so you start every session grounded in real project state.
+Open Claude in the repo and paste the **verbose form of Prompt 1 ("Starting work on a project that uses this kit")** from [PROMPTS.md](PROMPTS.md). It tells Claude to read your working folder's `CONTEXT.md` + `SESSION-LOG.md` + current phase checklist, then hand back a short summary — so you start every session grounded in real project state.
 
-For quick reference, the bare minimum version is:
+After your first session, your auto-memory has `reference_ai_working_folder.md` (seeded by bootstrap), which means Claude already knows where the working folder lives. From then on, your **daily-use prompt** collapses to one line:
 
-> Read `CONTEXT.md` and `SESSION-LOG.md` in `<working-folder>` before we start.
+> Load context and give me a 3-bullet summary of where we are.
 
-…but the full PROMPTS.md version handles edge cases (what to summarize, when to wait, not editing the working folder) and scales to more scenarios as you find them.
+That's the steady-state prompt for every subsequent session — short, paste-able, and discoverable in [PROMPTS.md §1](PROMPTS.md). The verbose form is still there for edge cases (no auto-memory yet, switching machines, debugging an unexpected response).
 
 From there, the normal flow:
 


### PR DESCRIPTION
Closes #84.

## Summary

The short-form session-start prompt — *"Load context and give me a 3-bullet summary of where we are."* — has always existed but was buried in a Note below the verbose Prompt 1 in `PROMPTS.md`. The kit's own author kept forgetting it was there, which strongly suggested users would too.

This change promotes the short form to a peer of the verbose prompt across the three docs a user is likely to look at when starting a session.

## Changes

- **`PROMPTS.md` §1** — split into "Short form (recommended for daily use)" and "Verbose form (first session, or no auto-memory yet)" subsections. Both prompts are now first-class. Notes section trimmed to the items that still apply.
- **`SETUP.md` §6** — replaced the awkward "bare minimum version" callout (which didn't reflect that auto-memory makes the path implicit) with the actual auto-memory short form, framed as the steady-state daily-use prompt.
- **`README.md` "How to use" step 5** — added the daily-use prompt inline so it's discoverable without diving into PROMPTS.md.

No behavior changes, no template/script changes, no tests affected.

## Test plan

- [ ] `PROMPTS.md` renders cleanly on GitHub — both prompt blocks readable, subheadings show in the TOC anchor list
- [ ] `SETUP.md` §6 reads as a coherent first-session walkthrough with the daily-use callout placed right after the verbose-form pointer
- [ ] `README.md` step 5 still scans as a single bullet — not so long that it overwhelms the rest of the "How to use" list
- [ ] Cross-references elsewhere ("Prompt 1", "/session-start") still work since the section is still called "Prompt 1"