### PR TITLE
docs(demo): add VHS bootstrap walkthrough source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@
 .vscode/
 .idea/
 *.swp
+
+# VHS-rendered demos — sources committed under demo/, renders hosted via
+# GitHub user-attachments and embedded by URL in README.md (see demo/README.md).
+demo/*.gif
+demo/*.mp4
+demo/*.webm
+demo/*.png

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A reusable scaffold for starting new projects with Claude. Battle-tested on real projects and generalized so it works for personal code, open-source, or work projects.
 
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/48ab501b-46d8-47d6-950c-88ba6721232d" alt="bootstrap.sh interactive walkthrough — runs in ~22 seconds" width="800">
+</p>
+
 > **Heads up — Claude state for a bootstrapped project lives in three places, none of them your repo:**
 >
 > ```

--- a/demo/README.md
+++ b/demo/README.md
@@ -27,12 +27,16 @@ Output lands at `demo/bootstrap.gif`.
 
 `demo/*.gif` and `demo/*.mp4` are git-ignored. The kit is docs-and-templates only; binary artifacts would bloat the repo over time.
 
-The canonical rendered copy lives as a GitHub user-attachment referenced from the main `README.md`. To update the embedded demo:
+The canonical rendered copy lives as a GitHub user-attachment referenced from the main `README.md`. The currently embedded `bootstrap.gif` is at:
+
+> `https://github.com/user-attachments/assets/48ab501b-46d8-47d6-950c-88ba6721232d`
+
+To update the embedded demo:
 
 1. Edit and re-render the tape locally.
 2. Drag the new `bootstrap.gif` into any GitHub PR or issue comment.
-3. GitHub returns a `user-images.githubusercontent.com/...` URL.
-4. Update the `<img>` / `![]()` reference in `README.md` to that URL.
+3. GitHub returns a `https://github.com/user-attachments/assets/...` URL.
+4. Update the `<img>` reference in `README.md` (and the URL above) to the new attachment.
 
 ## Why no CI re-rendering
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,39 @@
+# demo/
+
+VHS-rendered demos that get embedded in the main `README.md`.
+
+## Tapes
+
+- `bootstrap.tape` — interactive `bootstrap.sh` walkthrough (Phase 1)
+- `second-session.tape` — fresh Claude Code session loading kit context (Phase 2, pending — see [#87](https://github.com/IamMrCupp/claude-project-kit/issues/87))
+
+## Rendering
+
+[VHS](https://github.com/charmbracelet/vhs) is required:
+
+```sh
+brew install vhs
+```
+
+Render a tape **from the kit checkout root** (each tape captures `$PWD` at start so it can locate `bootstrap.sh` regardless of where the kit is checked out):
+
+```sh
+vhs demo/bootstrap.tape
+```
+
+Output lands at `demo/bootstrap.gif`.
+
+## Why renders aren't committed
+
+`demo/*.gif` and `demo/*.mp4` are git-ignored. The kit is docs-and-templates only; binary artifacts would bloat the repo over time.
+
+The canonical rendered copy lives as a GitHub user-attachment referenced from the main `README.md`. To update the embedded demo:
+
+1. Edit and re-render the tape locally.
+2. Drag the new `bootstrap.gif` into any GitHub PR or issue comment.
+3. GitHub returns a `user-images.githubusercontent.com/...` URL.
+4. Update the `<img>` / `![]()` reference in `README.md` to that URL.
+
+## Why no CI re-rendering
+
+VHS output is non-deterministic across environments (font availability, shell prompt, animation timing). Manual local rendering on the maintainer's machine is the right tradeoff at this scale.

--- a/demo/bootstrap.tape
+++ b/demo/bootstrap.tape
@@ -1,0 +1,85 @@
+# demo/bootstrap.tape — claude-project-kit bootstrap walkthrough
+#
+# Render with:  vhs demo/bootstrap.tape   (run from the kit checkout root)
+# Outputs:      demo/bootstrap.gif
+#
+# Tracks issue #87, Phase 1.
+
+Output demo/bootstrap.gif
+
+Set Shell "bash"
+Set FontSize 18
+Set Width 1200
+Set Height 900
+Set TypingSpeed 50ms
+
+# ---- Hidden setup -----------------------------------------------------------
+# Capture the kit checkout root, scrub any prior demo state, and spin up a
+# throwaway target repo at /tmp/widget-tracker. PS1 is normalised so the
+# demo doesn't show the maintainer's daily-driver prompt.
+Hide
+Type "export KIT=$(pwd) && rm -rf /tmp/widget-tracker $HOME/Documents/Claude/Projects/widget-tracker $HOME/.claude/projects/-tmp-widget-tracker"
+Enter
+Sleep 200ms
+Type "mkdir -p /tmp/widget-tracker && cd /tmp/widget-tracker && git init -q && touch README.md && git add . && git -c user.email=demo@local -c user.name=demo commit -qm 'init' && git remote add origin git@github.com:demo/widget-tracker.git"
+Enter
+Sleep 200ms
+Type "PS1='$ ' && clear"
+Enter
+Show
+# -----------------------------------------------------------------------------
+
+# Show we're sitting in a clean target repo with nothing Claude-related yet.
+Type "pwd && ls -A"
+Enter
+Sleep 1500ms
+
+# Run the bootstrap script.
+Type "$KIT/bootstrap.sh"
+Enter
+Sleep 2500ms
+
+# Working folder path — accept the suggested default.
+Enter
+Sleep 800ms
+
+# Project name — accept default ("widget-tracker").
+Enter
+Sleep 800ms
+
+# Seed auto-memory — yes.
+Type "y"
+Enter
+Sleep 800ms
+
+# Issue tracker — accept the github default.
+Enter
+Sleep 800ms
+
+# CI / automation tool.
+Type "github-actions"
+Enter
+Sleep 800ms
+
+# Confirm the plan.
+Type "y"
+Enter
+Sleep 6000ms
+
+# What got created in the working folder:
+Type "ls -1 ~/Documents/Claude/Projects/widget-tracker/"
+Enter
+Sleep 3000ms
+
+# What got seeded in auto-memory:
+Type "ls -1 ~/.claude/projects/-tmp-widget-tracker/memory/"
+Enter
+Sleep 4000ms
+
+# ---- Hidden cleanup ---------------------------------------------------------
+# Nuke everything the demo created so re-rendering stays reproducible and
+# the maintainer's real Claude state isn't polluted.
+Hide
+Type "rm -rf /tmp/widget-tracker $HOME/Documents/Claude/Projects/widget-tracker $HOME/.claude/projects/-tmp-widget-tracker"
+Enter
+Show


### PR DESCRIPTION
## Summary

Phase 1 of the demo work tracked in #87 — adds the VHS source for the interactive `bootstrap.sh` walkthrough plus tooling docs, and embeds the rendered GIF at the top of the main README.

- `demo/bootstrap.tape` — VHS script, ~22s rendered, captures `KIT=$(pwd)` so it works from any kit checkout location, scrubs `/tmp/widget-tracker` + `~/Documents/Claude/Projects/widget-tracker` + `~/.claude/projects/-tmp-widget-tracker` before and after to keep renders reproducible without polluting the maintainer's real Claude state
- `demo/README.md` — render instructions, why renders aren't committed, how to update the embedded GIF in the main README
- `.gitignore` — adds `demo/*.{gif,mp4,webm,png}` so renders stay out of the repo (canonical copy lives as a GitHub user-attachment referenced from `README.md`)
- `README.md` — embeds the live GIF immediately after the tagline, before the "Heads up" callout

Phase 2 (the second-session demo, the hero clip for social posts) ships in a separate PR per the plan in #87.

## Test plan

- [x] `vhs demo/bootstrap.tape` renders cleanly (1.0MB GIF, 1200×900, ~22s)
- [x] Cleanup block at end of tape removes all three demo paths after render
- [x] Tape works from any kit checkout location (uses `KIT=$(pwd)` not a hardcoded path)
- [x] GIF embed in `README.md` renders correctly on github.com after upload
- [x] CI link-check passes on both commits

Closes #87 (Phase 1 only — leaves #87 open until Phase 2 ships).