### PR TITLE
docs(demo): add VHS second-session walkthrough — daily-use demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,16 @@
 
 A reusable scaffold for starting new projects with Claude. Battle-tested on real projects and generalized so it works for personal code, open-source, or work projects.
 
+**Setup runs once, in ~30 seconds:**
+
 <p align="center">
   <img src="https://github.com/user-attachments/assets/48ab501b-46d8-47d6-950c-88ba6721232d" alt="bootstrap.sh interactive walkthrough — runs in ~22 seconds" width="800">
+</p>
+
+**Every session after starts grounded — one line and Claude knows the project:**
+
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/822251d0-9252-4326-bce1-eed07d50a6fe" alt="steady-state daily-use prompt — Claude loads CONTEXT.md + SESSION-LOG.md from auto-memory" width="800">
 </p>
 
 > **Heads up — Claude state for a bootstrapped project lives in three places, none of them your repo:**

--- a/demo/README.md
+++ b/demo/README.md
@@ -4,8 +4,8 @@ VHS-rendered demos that get embedded in the main `README.md`.
 
 ## Tapes
 
-- `bootstrap.tape` — interactive `bootstrap.sh` walkthrough (Phase 1)
-- `second-session.tape` — fresh Claude Code session loading kit context (Phase 2, pending — see [#87](https://github.com/IamMrCupp/claude-project-kit/issues/87))
+- `bootstrap.tape` — interactive `bootstrap.sh` walkthrough; setup-time demo
+- `second-session.tape` — fresh Claude Code session loading kit context via auto-memory; daily-use demo. Assumes `~/Code/recipe-card-maker` is already bootstrapped (working folder + auto-memory populated). Adjust the repo path if you fork this for your own kit.
 
 ## Rendering
 
@@ -27,9 +27,10 @@ Output lands at `demo/bootstrap.gif`.
 
 `demo/*.gif` and `demo/*.mp4` are git-ignored. The kit is docs-and-templates only; binary artifacts would bloat the repo over time.
 
-The canonical rendered copy lives as a GitHub user-attachment referenced from the main `README.md`. The currently embedded `bootstrap.gif` is at:
+The canonical rendered copies live as GitHub user-attachments referenced from the main `README.md`:
 
-> `https://github.com/user-attachments/assets/48ab501b-46d8-47d6-950c-88ba6721232d`
+- `bootstrap.gif` → `https://github.com/user-attachments/assets/48ab501b-46d8-47d6-950c-88ba6721232d`
+- `second-session.gif` → `https://github.com/user-attachments/assets/822251d0-9252-4326-bce1-eed07d50a6fe`
 
 To update the embedded demo:
 

--- a/demo/second-session.tape
+++ b/demo/second-session.tape
@@ -1,0 +1,59 @@
+# demo/second-session.tape — claude-project-kit steady-state usage demo
+#
+# Render with:  vhs demo/second-session.tape   (run from the kit checkout root)
+# Outputs:      demo/second-session.gif
+#
+# Tracks issue #87, Phase 2.
+#
+# Setup assumption: ~/Code/recipe-card-maker is already bootstrapped with the
+# kit. This tape does NOT bootstrap — it expects:
+#   - ~/Documents/Claude/Projects/recipe-card-maker/ populated with CONTEXT.md,
+#     SESSION-LOG.md, plan.md, etc.
+#   - ~/.claude/projects/-Users-aaroncupp-Code-recipe-card-maker/memory/ with
+#     reference_ai_working_folder.md pointing at the working folder above.
+#
+# The demo shows the steady-state daily-use prompt: one line, Claude reads
+# the persistent context via auto-memory and returns a grounding summary.
+
+Output demo/second-session.gif
+
+Set Shell "bash"
+Set FontSize 18
+Set Width 1200
+Set Height 900
+Set TypingSpeed 40ms
+
+# ---- Hidden setup -----------------------------------------------------------
+# Unset CLAUDECODE so `claude` launches cleanly (the binary refuses to run
+# nested inside another Claude Code session, which matters when this tape is
+# rendered from a Claude Code agent terminal). No-op when rendering locally.
+Hide
+Type "unset CLAUDECODE && PS1='$ ' && cd ~/Code/recipe-card-maker && clear"
+Enter
+Show
+# -----------------------------------------------------------------------------
+
+# Show what's in the working folder — establishes the docs Claude has access to.
+Type "ls -1 ~/Documents/Claude/Projects/recipe-card-maker/"
+Enter
+Sleep 3000ms
+
+# Open Claude Code. --add-dir pre-approves the working folder so Claude
+# doesn't hit a permission prompt mid-render when reading CONTEXT.md /
+# SESSION-LOG.md (those live outside the repo's cwd).
+Type "claude --add-dir ~/Documents/Claude/Projects/recipe-card-maker/"
+Enter
+Sleep 5000ms
+
+# The standard daily-use prompt. Auto-memory points Claude at the working
+# folder so one line fully grounds the session.
+Type "Load context and give me a 3-bullet summary of where we are."
+Enter
+Sleep 30000ms
+
+# ---- Hidden cleanup ---------------------------------------------------------
+Hide
+Ctrl+C
+Sleep 500ms
+Ctrl+C
+Show


### PR DESCRIPTION
## Summary

Phase 2 of the demo work tracked in #87 — adds the VHS source for the daily-use "second session" demo (the steady-state prompt where Claude loads project context via auto-memory) and embeds the rendered GIF in the main README beside the bootstrap GIF.

The two GIFs together tell the kit's full story: setup runs once via `bootstrap.sh` (top GIF), then every session after starts grounded with a single one-line prompt (this PR's GIF).

- `demo/second-session.tape` — VHS script, ~40s rendered, runs against the already-bootstrapped `~/Code/recipe-card-maker` repo. Uses the kit's canonical short-form prompt: *"Load context and give me a 3-bullet summary of where we are."* Claude reads CONTEXT.md + SESSION-LOG.md via the auto-memory pointer and produces a 3-bullet grounding summary.
- `demo/README.md` — updated tape index and canonical-render reference list now includes both GIFs.
- `README.md` — embeds both GIFs back-to-back at the top with brief framing labels (*Setup runs once* / *Every session after starts grounded*).

### Production notes (for future re-renders)

- The tape unsets `CLAUDECODE` before launching `claude` so it works when rendered from a Claude Code agent terminal (the binary refuses to nest otherwise).
- Launches `claude --add-dir ~/Documents/Claude/Projects/recipe-card-maker/` so the working folder is pre-approved — without this, Claude hits an interactive permission prompt mid-render and the tape stalls.
- Claude's response is non-deterministic. Render once, eyeball, accept or re-render. The version in this PR is the third render — first hit `CLAUDECODE` nesting refusal, second hit the permission prompt, third is clean.

### Out of scope

- Animated demos for the seed-prompt fill-in flow or the bootstrap-on-real-repo arc (deferred — Phase 1 + 2 GIFs cover the headline value props for the launch).

## Test plan

- [x] `vhs demo/second-session.tape` renders cleanly (565KB, 1200×900, ~40s)
- [x] Real Claude Code TUI renders end-to-end (welcome banner → prompt entry → tool use → 3-bullet response)
- [x] Response content is accurate to the working folder (references real phase-1-checklist.md tasks, real repo state, no hallucinations)
- [x] CI link-check passes on both commits
- [x] Both GIFs render correctly side-by-side on github.com

Closes #87.