### PR TITLE
feat(bootstrap): tracker config + Terraform detection (Phase 4 §D)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,6 +5,12 @@
 # Run this from the root of the project repo you want to bootstrap. The
 # auto-memory path is derived from the current working directory using
 # the Claude harness's sanitization rule ('/' -> '-', prefixed with '-').
+#
+# CONSTRAINT: This script never creates resources in external trackers
+# (issues, labels, projects, workflows, sprints). It only captures
+# references to existing trackers via --tracker / --jira-project /
+# --linear-team flags. See ADR-0001 D3 and CONVENTIONS.md
+# "Ticket-driven workflows → What the kit does NOT do with trackers".
 set -euo pipefail
 
 if [ -z "${BASH_VERSION:-}" ]; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -141,6 +141,107 @@ ci_index_line() {
   esac
 }
 
+detect_terraform() {
+  # args: repo_root
+  # Returns 0 if the repo shows Terraform / Terragrunt signals.
+  # Per ADR-0001 A.6: *.tf, *.tfvars, .terraform.lock.hcl, terragrunt.hcl,
+  # or terraform/ / modules/ directories that contain *.tf files.
+  local repo="$1"
+  [ -f "$repo/.terraform.lock.hcl" ] && return 0
+  [ -f "$repo/terragrunt.hcl" ] && return 0
+  if compgen -G "$repo/*.tf" > /dev/null 2>&1; then return 0; fi
+  if compgen -G "$repo/*.tfvars" > /dev/null 2>&1; then return 0; fi
+  if [ -d "$repo/terraform" ] && \
+     [ -n "$(find "$repo/terraform" -maxdepth 3 -name '*.tf' 2>/dev/null | head -1)" ]; then
+    return 0
+  fi
+  if [ -d "$repo/modules" ] && \
+     [ -n "$(find "$repo/modules" -maxdepth 3 -name '*.tf' 2>/dev/null | head -1)" ]; then
+    return 0
+  fi
+  return 1
+}
+
+tracker_key_value() {
+  # args: tracker jira_key linear_key
+  # emits the value to substitute for {{TRACKER_KEY}} in CONTEXT.md.
+  local tracker="$1" jira_key="${2:-}" linear_key="${3:-}"
+  case "$tracker" in
+    jira)     printf '%s' "$jira_key" ;;
+    linear)   printf '%s' "$linear_key" ;;
+    github|gitlab|shortcut|other)
+              printf '(not applicable for %s tracker)' "$tracker" ;;
+    none|"")  printf '(no tracker configured)' ;;
+  esac
+}
+
+substitute_memory_placeholders_in_dir() {
+  # Substitute all derivable placeholders in every .md file at the top level
+  # of the given directory. Used for the auto-memory folder, where bootstrap
+  # owns content end-to-end. Reads globals: WORKING_FOLDER, REPO_ROOT,
+  # PROJECT_NAME, REPO_SLUG, JIRA_PROJECT_KEY, LINEAR_TEAM_KEY,
+  # TRACKER_TYPE_VALUE, TRACKER_KEY_VALUE. Echos count of files modified.
+  local target_dir="$1"
+  local count=0
+  local f tmp
+  for f in "$target_dir"/*.md; do
+    [ -e "$f" ] || continue
+    tmp="$(mktemp)"
+    if [ -n "$REPO_SLUG" ]; then
+      sed -e "s|{{WORKING_FOLDER}}|$WORKING_FOLDER|g" \
+          -e "s|{{REPO_PATH}}|$REPO_ROOT|g" \
+          -e "s|{{PROJECT_NAME}}|$PROJECT_NAME|g" \
+          -e "s|{{REPO_SLUG}}|$REPO_SLUG|g" \
+          -e "s|{{JIRA_PROJECT_KEY}}|$JIRA_PROJECT_KEY|g" \
+          -e "s|{{LINEAR_TEAM_KEY}}|$LINEAR_TEAM_KEY|g" \
+          -e "s|{{TRACKER_TYPE}}|$TRACKER_TYPE_VALUE|g" \
+          -e "s|{{TRACKER_KEY}}|$TRACKER_KEY_VALUE|g" \
+          "$f" > "$tmp"
+    else
+      sed -e "s|{{WORKING_FOLDER}}|$WORKING_FOLDER|g" \
+          -e "s|{{REPO_PATH}}|$REPO_ROOT|g" \
+          -e "s|{{PROJECT_NAME}}|$PROJECT_NAME|g" \
+          -e "s|{{JIRA_PROJECT_KEY}}|$JIRA_PROJECT_KEY|g" \
+          -e "s|{{LINEAR_TEAM_KEY}}|$LINEAR_TEAM_KEY|g" \
+          -e "s|{{TRACKER_TYPE}}|$TRACKER_TYPE_VALUE|g" \
+          -e "s|{{TRACKER_KEY}}|$TRACKER_KEY_VALUE|g" \
+          "$f" > "$tmp"
+    fi
+    if ! cmp -s "$f" "$tmp"; then
+      mv "$tmp" "$f"
+      count=$((count + 1))
+    else
+      rm -f "$tmp"
+    fi
+  done
+  printf '%s' "$count"
+}
+
+substitute_tracker_placeholders_in_dir() {
+  # Substitute only tracker placeholders in every .md file at the top level
+  # of the given directory. Used for working-folder + workspace-CONTEXT.md
+  # where SEED-PROMPT.md owns deep-read content; bootstrap only fills the
+  # tracker config it was explicitly told via flags. Reads globals:
+  # TRACKER_TYPE_VALUE, TRACKER_KEY_VALUE. Echos count of files modified.
+  local target_dir="$1"
+  local count=0
+  local f tmp
+  for f in "$target_dir"/*.md; do
+    [ -e "$f" ] || continue
+    tmp="$(mktemp)"
+    sed -e "s|{{TRACKER_TYPE}}|$TRACKER_TYPE_VALUE|g" \
+        -e "s|{{TRACKER_KEY}}|$TRACKER_KEY_VALUE|g" \
+        "$f" > "$tmp"
+    if ! cmp -s "$f" "$tmp"; then
+      mv "$tmp" "$f"
+      count=$((count + 1))
+    else
+      rm -f "$tmp"
+    fi
+  done
+  printf '%s' "$count"
+}
+
 SKIP_MEMORY=0
 FORCE=0
 DRY_RUN=0
@@ -255,14 +356,45 @@ if [ -z "$WORKING_FOLDER" ]; then
   fi
 fi
 
+REPO_ROOT="$(pwd)"
+
+if [ "$WORKSPACE_MODE" -eq 0 ] && detect_terraform "$REPO_ROOT"; then
+  if [ "$INTERACTIVE" -eq 1 ]; then
+    echo
+    echo "Detected Terraform-shaped repo (.tf / *.tfvars / .terraform.lock.hcl /"
+    echo "terragrunt.hcl / terraform/ / modules/ with .tf files)."
+    echo "If a sibling envs/modules repo is part of the same initiative, consider"
+    echo "workspace mode (--workspace) so both repos share one working folder."
+    echo "See ADR-0001 (docs/adr/0001-multi-repo-folder-model.md)."
+    echo
+    read -r -p "Sibling envs/modules repo for this initiative? [y/N]: " INPUT
+    case "$(printf '%s' "$INPUT" | tr '[:upper:]' '[:lower:]')" in
+      y|yes)
+        echo
+        echo "Recommended: re-run with --workspace pointing at a shared workspace path"
+        echo "(e.g. ~/Documents/Claude/Projects/<initiative>) so this repo and the"
+        echo "sibling end up as subfolders under one workspace-CONTEXT.md."
+        read -r -p "Continue in single-repo mode anyway? [y/N]: " INPUT
+        case "$(printf '%s' "$INPUT" | tr '[:upper:]' '[:lower:]')" in
+          y|yes) ;;
+          *) echo "Aborted."; exit 0 ;;
+        esac
+        ;;
+      *) ;;
+    esac
+  else
+    echo "note: Terraform-shaped repo detected — consider --workspace if a sibling envs/modules repo exists for the same initiative." >&2
+  fi
+fi
+
 if [ "$INTERACTIVE" -eq 1 ]; then
-  REPO_BASENAME="$(basename "$(pwd)")"
+  REPO_BASENAME="$(basename "$REPO_ROOT")"
   DEFAULT_WF="$HOME/Documents/Claude/Projects/$REPO_BASENAME"
 
   echo "bootstrap.sh — interactive mode"
   echo "(Run with -h for flags and non-interactive usage.)"
   echo
-  echo "Repo: $(pwd)"
+  echo "Repo: $REPO_ROOT"
   echo
   echo "Working-folder path. Examples:"
   echo "  $DEFAULT_WF"
@@ -287,7 +419,6 @@ if [ ! -d "$KIT_ROOT/templates" ] || [ ! -d "$KIT_ROOT/memory-templates" ]; then
   exit 1
 fi
 
-REPO_ROOT="$(pwd)"
 SANITIZED="$(echo "$REPO_ROOT" | sed 's|/|-|g')"
 MEMORY_DIR="$HOME/.claude/projects/${SANITIZED}/memory"
 
@@ -357,6 +488,9 @@ if REMOTE_URL="$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null)"; then
     | sed -E 's|^https?://[^/]+/||; s|^git@[^:]+:||; s|\.git$||')"
 fi
 
+TRACKER_TYPE_VALUE="${TRACKER:-none}"
+TRACKER_KEY_VALUE="$(tracker_key_value "$TRACKER" "$JIRA_PROJECT_KEY" "$LINEAR_TEAM_KEY")"
+
 if [ "$WORKSPACE_MODE" -eq 1 ]; then
   echo "Workspace:      $WORKSPACE_DIR"
   echo "Repo subfolder: $WORKSPACE_REPO_NAME (full path: $WORKING_FOLDER)"
@@ -401,6 +535,12 @@ if [ "$DRY_RUN" -eq 1 ]; then
   echo "  + rename phase-N-checklist.md → phase-0-checklist.md"
   if [ -d "$KIT_ROOT/templates/.claude" ]; then
     echo "  + copy templates/.claude/ → $WORKING_FOLDER/.claude/ (starter agents + commands)"
+  fi
+  echo "  + substitute tracker placeholders in CONTEXT.md:"
+  echo "      {{TRACKER_TYPE}}      → $TRACKER_TYPE_VALUE"
+  echo "      {{TRACKER_KEY}}       → $TRACKER_KEY_VALUE"
+  if [ "$WORKSPACE_MODE" -eq 1 ] && [ ! -f "$WORKSPACE_DIR/workspace-CONTEXT.md" ]; then
+    echo "  + same substitution in workspace-CONTEXT.md"
   fi
   if [ -e "$WORKING_FOLDER" ] && [ -n "$(ls -A "$WORKING_FOLDER" 2>/dev/null)" ] && [ "$FORCE" -eq 0 ]; then
     echo "  ! working folder already non-empty — real run would fail without --force"
@@ -496,6 +636,18 @@ if [ -d "$KIT_ROOT/templates/.claude" ]; then
   echo "  ✓ Copied .claude/ starters (agents + commands) to $WORKING_FOLDER/.claude/"
 fi
 
+WF_FILLED="$(substitute_tracker_placeholders_in_dir "$WORKING_FOLDER")"
+if [ "$WF_FILLED" -gt 0 ]; then
+  echo "  ✓ Filled tracker config in CONTEXT.md"
+fi
+
+if [ "$WORKSPACE_MODE" -eq 1 ] && [ -f "$WORKSPACE_DIR/workspace-CONTEXT.md" ]; then
+  WS_FILLED="$(substitute_tracker_placeholders_in_dir "$WORKSPACE_DIR")"
+  if [ "$WS_FILLED" -gt 0 ]; then
+    echo "  ✓ Filled tracker config in workspace-CONTEXT.md"
+  fi
+fi
+
 if [ "$SKIP_MEMORY" -eq 0 ]; then
   mkdir -p "$MEMORY_DIR"
   cp "$KIT_ROOT/memory-templates/"*.md "$MEMORY_DIR/"
@@ -523,32 +675,7 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
     echo "  ✓ Seeded CI memory ($CI_TOOL) → reference_ci.md"
   fi
 
-  FILLED_FILES=0
-  for f in "$MEMORY_DIR"/*.md; do
-    tmp="$(mktemp)"
-    if [ -n "$REPO_SLUG" ]; then
-      sed -e "s|{{WORKING_FOLDER}}|$WORKING_FOLDER|g" \
-          -e "s|{{REPO_PATH}}|$REPO_ROOT|g" \
-          -e "s|{{PROJECT_NAME}}|$PROJECT_NAME|g" \
-          -e "s|{{REPO_SLUG}}|$REPO_SLUG|g" \
-          -e "s|{{JIRA_PROJECT_KEY}}|$JIRA_PROJECT_KEY|g" \
-          -e "s|{{LINEAR_TEAM_KEY}}|$LINEAR_TEAM_KEY|g" \
-          "$f" > "$tmp"
-    else
-      sed -e "s|{{WORKING_FOLDER}}|$WORKING_FOLDER|g" \
-          -e "s|{{REPO_PATH}}|$REPO_ROOT|g" \
-          -e "s|{{PROJECT_NAME}}|$PROJECT_NAME|g" \
-          -e "s|{{JIRA_PROJECT_KEY}}|$JIRA_PROJECT_KEY|g" \
-          -e "s|{{LINEAR_TEAM_KEY}}|$LINEAR_TEAM_KEY|g" \
-          "$f" > "$tmp"
-    fi
-    if ! cmp -s "$f" "$tmp"; then
-      mv "$tmp" "$f"
-      FILLED_FILES=$((FILLED_FILES + 1))
-    else
-      rm -f "$tmp"
-    fi
-  done
+  FILLED_FILES="$(substitute_memory_placeholders_in_dir "$MEMORY_DIR")"
   echo "  ✓ Filled placeholders in $FILLED_FILES memory files"
   if [ -z "$REPO_SLUG" ]; then
     echo "    (no git remote 'origin' found — {{REPO_SLUG}} left for manual fill)"

--- a/templates/CONTEXT.md
+++ b/templates/CONTEXT.md
@@ -29,8 +29,8 @@ At the start of any new Claude session, say:
 
 The external tracker for this project, used when work is ticket-driven. See `CONVENTIONS.md` (kit-level — `## Ticket-driven workflows`) for the branch / PR / commit conventions to use against a tracker.
 
-- **Tracker type:** {{none | github | jira | linear | gitlab | shortcut | other}}
-- **Project / team key:** {{KEY — e.g. LX, INFRA, ENG; leave blank if not applicable}}
+- **Tracker type:** {{TRACKER_TYPE}}
+- **Project / team key:** {{TRACKER_KEY}}
 - **MCP availability:** {{installed | not installed | unknown}}
 - **Tracker link:** {{URL — leave blank if none}}
 

--- a/templates/workspace/workspace-CONTEXT.md
+++ b/templates/workspace/workspace-CONTEXT.md
@@ -27,8 +27,8 @@ This file is private — never commit it to any repo.
 
 Shared tracker config for the initiative. If a single tracker covers all repos, capture it here once instead of duplicating in each `<repo>/CONTEXT.md`.
 
-- **Tracker type:** {{none | github | jira | linear | gitlab | shortcut | other}}
-- **Project / team key:** {{KEY — e.g. LX, INFRA, ENG}}
+- **Tracker type:** {{TRACKER_TYPE}}
+- **Project / team key:** {{TRACKER_KEY}}
 - **MCP availability:** {{installed | not installed | unknown}}
 - **Tracker link:** {{URL}}
 

--- a/tests/bootstrap_constraints.bats
+++ b/tests/bootstrap_constraints.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# Phase 4 D.2 — Defensive assertions that bootstrap.sh never creates resources
+# in external trackers. See ADR-0001 D3 and CONVENTIONS.md "Ticket-driven
+# workflows → What the kit does NOT do with trackers".
+
+load 'helpers'
+
+setup() { bootstrap_setup; }
+teardown() { bootstrap_teardown; }
+
+@test "bootstrap.sh source contains no tracker-mutation commands" {
+  # Static check: scan bootstrap.sh for any command that would create or
+  # mutate resources in an external tracker. This is the load-bearing
+  # assertion behind ADR-0001 D3.
+  local forbidden=(
+    "gh issue create"
+    "gh issue edit"
+    "gh issue close"
+    "gh issue delete"
+    "gh issue reopen"
+    "gh label create"
+    "gh label edit"
+    "gh label delete"
+    "gh project create"
+    "gh project edit"
+    "gh project delete"
+    "gh project item-add"
+    "gh project field-create"
+    "gh repo create"
+    "gh workflow"
+    "jira issue create"
+    "jira issue edit"
+    "jira issue close"
+    "jira issue assign"
+    "jira issue move"
+    "linear ticket create"
+    "linear ticket edit"
+    "glab issue create"
+    "glab issue close"
+    "glab issue delete"
+    "glab label create"
+  )
+  local pattern
+  for pattern in "${forbidden[@]}"; do
+    if grep -F -q "$pattern" "$BOOTSTRAP"; then
+      echo "FAIL: bootstrap.sh contains forbidden tracker-mutation pattern: $pattern" >&2
+      return 1
+    fi
+  done
+}
+
+@test "bootstrap.sh has explicit constraint comment about not creating tracker resources" {
+  grep -q "never creates resources in external trackers" "$BOOTSTRAP"
+  grep -q "ADR-0001 D3" "$BOOTSTRAP"
+}
+
+@test "bootstrap output never claims to create tracker resources (github)" {
+  run "$BOOTSTRAP" --tracker github "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Created issue"* ]]
+  [[ "$output" != *"Created label"* ]]
+  [[ "$output" != *"Created project"* ]]
+  [[ "$output" != *"Created workflow"* ]]
+  [[ "$output" != *"Created sprint"* ]]
+}
+
+@test "bootstrap output never claims to create tracker resources (jira)" {
+  run "$BOOTSTRAP" --tracker jira --jira-project INFRA "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Created issue"* ]]
+  [[ "$output" != *"Created project"* ]]
+  [[ "$output" != *"Created sprint"* ]]
+  [[ "$output" != *"Created board"* ]]
+}
+
+@test "dry-run output never previews tracker resource creation" {
+  run "$BOOTSTRAP" --dry-run --tracker jira --jira-project LX "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"create issue"* ]]
+  [[ "$output" != *"create label"* ]]
+  [[ "$output" != *"create project in"* ]]
+  [[ "$output" != *"create sprint"* ]]
+}

--- a/tests/bootstrap_terraform.bats
+++ b/tests/bootstrap_terraform.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# Phase 4 D.3 / A.6 — Terraform-shape detection and sibling-repo prompt.
+# Detection signals: *.tf, *.tfvars, .terraform.lock.hcl, terragrunt.hcl,
+# terraform/ or modules/ directories that contain *.tf files.
+
+load 'helpers'
+
+setup() { bootstrap_setup; }
+teardown() { bootstrap_teardown; }
+
+# --- Detection signals ---
+
+@test "Terraform detection: *.tf at repo root triggers hint" {
+  : > "$TEST_REPO/main.tf"
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Terraform-shaped repo detected"* ]]
+}
+
+@test "Terraform detection: *.tfvars at repo root triggers hint" {
+  : > "$TEST_REPO/terraform.tfvars"
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Terraform-shaped repo detected"* ]]
+}
+
+@test "Terraform detection: .terraform.lock.hcl triggers hint" {
+  : > "$TEST_REPO/.terraform.lock.hcl"
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Terraform-shaped repo detected"* ]]
+}
+
+@test "Terraform detection: terragrunt.hcl triggers hint" {
+  : > "$TEST_REPO/terragrunt.hcl"
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Terraform-shaped repo detected"* ]]
+}
+
+@test "Terraform detection: terraform/ subdir with .tf files triggers hint" {
+  mkdir -p "$TEST_REPO/terraform"
+  : > "$TEST_REPO/terraform/main.tf"
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Terraform-shaped repo detected"* ]]
+}
+
+@test "Terraform detection: modules/ subdir with nested .tf files triggers hint" {
+  mkdir -p "$TEST_REPO/modules/vpc"
+  : > "$TEST_REPO/modules/vpc/main.tf"
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Terraform-shaped repo detected"* ]]
+}
+
+# --- Negative cases ---
+
+@test "no Terraform signals: hint does not appear" {
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Terraform-shaped repo detected"* ]]
+}
+
+@test "empty terraform/ subdir does not trigger hint" {
+  mkdir -p "$TEST_REPO/terraform"
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Terraform-shaped repo detected"* ]]
+}
+
+@test "empty modules/ subdir does not trigger hint" {
+  mkdir -p "$TEST_REPO/modules"
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Terraform-shaped repo detected"* ]]
+}
+
+@test "modules/ with non-.tf files (e.g. JS modules) does not trigger hint" {
+  mkdir -p "$TEST_REPO/modules"
+  : > "$TEST_REPO/modules/index.js"
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Terraform-shaped repo detected"* ]]
+}
+
+# --- Workspace mode suppresses the hint ---
+
+@test "--workspace mode does not emit Terraform sibling-repo hint" {
+  : > "$TEST_REPO/main.tf"
+  WS="$TEST_TMP/lx-platform"
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Terraform-shaped repo detected"* ]]
+}
+
+# --- Hint also fires in dry-run mode (so users can preview the recommendation) ---
+
+@test "Terraform hint fires in --dry-run mode" {
+  : > "$TEST_REPO/main.tf"
+  run "$BOOTSTRAP" --dry-run "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Terraform-shaped repo detected"* ]]
+}

--- a/tests/bootstrap_tracker.bats
+++ b/tests/bootstrap_tracker.bats
@@ -90,3 +90,52 @@ teardown() { bootstrap_teardown; }
   [ "$status" -eq 0 ]
   ! grep -q "reference_issue_tracker.md" "$(memory_dir)/MEMORY.md"
 }
+
+# --- Phase 4 D.1 — tracker config substitution into CONTEXT.md ---
+
+@test "--tracker jira substitutes tracker config into CONTEXT.md" {
+  run "$BOOTSTRAP" --tracker jira --jira-project INFRA "$TEST_WF"
+  [ "$status" -eq 0 ]
+  grep -q '^- \*\*Tracker type:\*\* jira$' "$TEST_WF/CONTEXT.md"
+  grep -q '^- \*\*Project / team key:\*\* INFRA$' "$TEST_WF/CONTEXT.md"
+  ! grep -q '{{TRACKER_TYPE}}' "$TEST_WF/CONTEXT.md"
+  ! grep -q '{{TRACKER_KEY}}' "$TEST_WF/CONTEXT.md"
+}
+
+@test "--tracker linear substitutes tracker config into CONTEXT.md" {
+  run "$BOOTSTRAP" --tracker linear --linear-team ENG "$TEST_WF"
+  [ "$status" -eq 0 ]
+  grep -q '^- \*\*Tracker type:\*\* linear$' "$TEST_WF/CONTEXT.md"
+  grep -q '^- \*\*Project / team key:\*\* ENG$' "$TEST_WF/CONTEXT.md"
+}
+
+@test "--tracker github substitutes type with not-applicable key" {
+  run "$BOOTSTRAP" --tracker github "$TEST_WF"
+  [ "$status" -eq 0 ]
+  grep -q '^- \*\*Tracker type:\*\* github$' "$TEST_WF/CONTEXT.md"
+  grep -q 'not applicable for github tracker' "$TEST_WF/CONTEXT.md"
+}
+
+@test "no --tracker flag substitutes tracker type as none" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+  grep -q '^- \*\*Tracker type:\*\* none$' "$TEST_WF/CONTEXT.md"
+  grep -q 'no tracker configured' "$TEST_WF/CONTEXT.md"
+}
+
+@test "tracker substitution does not touch non-CONTEXT working-folder files" {
+  # SEED-PROMPT.md owns deep-read content; bootstrap should leave its
+  # placeholders alone (e.g. {{PROJECT_NAME}}, {{REPO_PATH}}).
+  run "$BOOTSTRAP" --tracker jira --jira-project INFRA "$TEST_WF"
+  [ "$status" -eq 0 ]
+  grep -q '{{PROJECT_NAME}}' "$TEST_WF/plan.md"
+  grep -q '{{REPO_PATH}}' "$TEST_WF/CONTEXT.md"
+}
+
+@test "dry-run shows tracker placeholder substitutions for CONTEXT.md" {
+  run "$BOOTSTRAP" --dry-run --tracker jira --jira-project LX "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"substitute tracker placeholders in CONTEXT.md"* ]]
+  [[ "$output" == *"{{TRACKER_TYPE}}"*"jira"* ]]
+  [[ "$output" == *"{{TRACKER_KEY}}"*"LX"* ]]
+}

--- a/tests/bootstrap_workspace.bats
+++ b/tests/bootstrap_workspace.bats
@@ -158,3 +158,48 @@ teardown() { bootstrap_teardown; }
   [ -d "$MEM" ]
   [ -f "$MEM/MEMORY.md" ]
 }
+
+# --- Phase 4 D.1 — tracker config substitution into workspace-CONTEXT.md ---
+
+@test "--workspace --tracker jira fills tracker config in workspace-CONTEXT.md" {
+  WS="$TEST_TMP/lx-platform"
+  REPO_NAME="$(basename "$TEST_REPO")"
+  run "$BOOTSTRAP" --workspace "$WS" --tracker jira --jira-project LX --skip-memory
+  [ "$status" -eq 0 ]
+
+  grep -q '^- \*\*Tracker type:\*\* jira$' "$WS/workspace-CONTEXT.md"
+  grep -q '^- \*\*Project / team key:\*\* LX$' "$WS/workspace-CONTEXT.md"
+  ! grep -q '{{TRACKER_TYPE}}' "$WS/workspace-CONTEXT.md"
+  ! grep -q '{{TRACKER_KEY}}' "$WS/workspace-CONTEXT.md"
+
+  # Per-repo CONTEXT.md also gets the same substitution
+  grep -q '^- \*\*Tracker type:\*\* jira$' "$WS/$REPO_NAME/CONTEXT.md"
+  grep -q '^- \*\*Project / team key:\*\* LX$' "$WS/$REPO_NAME/CONTEXT.md"
+}
+
+@test "--workspace re-run against existing workspace does not re-substitute tracker config" {
+  WS="$TEST_TMP/lx-platform"
+
+  # First run with jira/LX
+  run "$BOOTSTRAP" --workspace "$WS" --tracker jira --jira-project LX --skip-memory
+  [ "$status" -eq 0 ]
+  grep -q '^- \*\*Project / team key:\*\* LX$' "$WS/workspace-CONTEXT.md"
+
+  # User manually edits workspace-CONTEXT.md
+  sed -i.bak 's/Project \/ team key:\*\* LX/Project \/ team key:\*\* LX-EDITED/' "$WS/workspace-CONTEXT.md"
+  rm -f "$WS/workspace-CONTEXT.md.bak"
+  grep -q 'LX-EDITED' "$WS/workspace-CONTEXT.md"
+
+  # Bootstrap a sibling repo into the same workspace with different tracker key
+  REPO2="$TEST_TMP/repo2"
+  mkdir -p "$REPO2"
+  git -C "$REPO2" init -q
+  cd "$REPO2"
+
+  run "$BOOTSTRAP" --workspace "$WS" --tracker jira --jira-project DIFFERENT --skip-memory
+  [ "$status" -eq 0 ]
+
+  # User's edit survives — workspace-CONTEXT.md was not overwritten
+  grep -q 'LX-EDITED' "$WS/workspace-CONTEXT.md"
+  ! grep -q 'DIFFERENT' "$WS/workspace-CONTEXT.md"
+}


### PR DESCRIPTION
Phase 4 §D close — finishes the bootstrap pieces of [#61](https://github.com/IamMrCupp/claude-project-kit/issues/61) by landing D.1, D.2, D.3, and the remaining bats coverage that closes D.5.

## Summary

- **D.1 — Tracker config in CONTEXT.md.** Two new placeholders, ` + '`{{TRACKER_TYPE}}`' + ` and ` + '`{{TRACKER_KEY}}`' + `, in ` + '`templates/CONTEXT.md`' + ` and ` + '`templates/workspace/workspace-CONTEXT.md`' + `. Bootstrap fills them post-copy via a new ` + '`substitute_tracker_placeholders_in_dir()`' + ` helper. MCP availability + tracker link stay as prose hints for SEED-PROMPT/user. The existing memory placeholder loop is refactored into ` + '`substitute_memory_placeholders_in_dir()`' + ` for symmetry. Working-folder pass is intentionally narrow (tracker only) to preserve the Phase 2 separation where SEED-PROMPT owns deep-read content.
- **D.2 — Defensive assertion that bootstrap never creates tracker resources.** Explicit constraint comment at the top of ` + '`bootstrap.sh`' + ` (cites ADR-0001 D3 + ` + '`CONVENTIONS.md`' + `) plus a new ` + '`tests/bootstrap_constraints.bats`' + ` that statically scans the script for forbidden mutation commands (` + '`gh issue create`' + `, ` + '`jira issue create`' + `, ` + '`gh label create`' + `, etc.) and asserts no run / dry-run output ever claims to create tracker resources.
- **D.3 — Terraform detection + sibling-repo prompt.** New ` + '`detect_terraform()`' + ` helper covers ADR-0001 A.6 signals: ` + '`*.tf`' + `, ` + '`*.tfvars`' + `, ` + '`.terraform.lock.hcl`' + `, ` + '`terragrunt.hcl`' + `, and ` + '`terraform/`' + ` / ` + '`modules/`' + ` subdirs containing ` + '`*.tf`' + ` files. In interactive mode + non-workspace, prompts about a sibling envs/modules repo and recommends ` + '`--workspace`' + ` (offering an out-out before continuing in single-repo mode). In non-interactive mode, emits a one-line stderr hint. ` + '`--workspace`' + ` mode suppresses the hint entirely.
- **D.5 — bats coverage closed.** 25 new tests across 4 files; full suite 77 → 102.

Off-issue but in-scope: dry-run output now mentions the tracker substitution; ` + '`REPO_ROOT`' + ` is computed once early so the Terraform prompt fires before the working-folder path prompt.

Closes the D-section of [#61](https://github.com/IamMrCupp/claude-project-kit/issues/61). Phase 4 §C.4 (SEED-PROMPT prompts for these new fields), §C.5 (.claude README), §E (` + '`/pull-ticket`' + ` command), §F (top-level docs), and §G (workspace example) follow in subsequent PRs.

## Test plan

- [x] ` + '`bash -n bootstrap.sh`' + ` (syntax check)
- [x] ` + '`bats tests/`' + ` — full suite passes (102/102, +25 new)
- [x] Smoke-tested non-interactive single-repo with ` + '`--tracker jira --jira-project LX`' + ` against a fresh repo: ` + '`CONTEXT.md`' + ` substituted correctly; other working-folder files untouched
- [x] Smoke-tested ` + '`--workspace --tracker jira --jira-project LX`' + `: workspace-CONTEXT.md AND per-repo CONTEXT.md both substituted
- [x] Smoke-tested Terraform detection in non-interactive mode: stderr hint fires when ` + '`*.tf`' + ` present, suppressed under ` + '`--workspace`' + `
- [ ] GitHub render check on this PR body
- [ ] Lychee link-check passes on the new bats file references in the PR description (CI gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)