### PR TITLE
feat(pull-ticket): /pull-ticket command + helper script + Prompt 6 (Phase 4 §E + C.5)

### DIFF
--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -206,6 +206,57 @@ Then wait for my next instruction. Don't propose changes yet.
 
 ---
 
+## 6. Pulling a ticket into a per-ticket scratchpad
+
+Use this when starting work on a tracker ticket (JIRA, GitHub Issues, Linear, etc.) and you want a local working scratchpad seeded from the tracker — summary, AC, status. Read-only — pulls from the tracker, never pushes back. The scratchpad lives at `tickets/<KEY>-<slug>.md` and accumulates working notes, branches, and PRs as work happens; the tracker stays the source of truth.
+
+```
+Pull ticket <KEY> from the tracker.
+
+## Step 1 — read tracker config
+
+Read `<working-folder>/CONTEXT.md`. Find the **Tracker Configuration** section.
+If `<working-folder>/../workspace-CONTEXT.md` exists, read that too — workspace-level
+tracker config takes precedence in workspace mode.
+
+Stop and ask before proceeding if:
+- Tracker type is `none` or `other`
+- MCP availability is `not installed` or `unknown`
+- The ticket key doesn't match the project key
+
+## Step 2 — fetch the ticket
+
+Use the tracker MCP that matches the configured type (JIRA / GitHub Issues / Linear /
+GitLab / Shortcut). Read-only — get / view / search only. Never create, edit,
+transition, or comment.
+
+## Step 3 — write tickets/<KEY>-<slug>.md
+
+Use the kit's `templates/workspace/ticket.md` shape. Fill key, title, tracker URL,
+status, summary, and acceptance criteria. Leave working notes, branches, decisions
+empty for now. Slug is the title lowercased and dashed (max ~40 chars).
+
+If a file with the `<KEY>-` prefix already exists in `tickets/` or
+`tickets/archive/`, stop and ask before overwriting.
+
+## Step 4 — update workspace-CONTEXT.md (workspace mode only)
+
+Append the ticket to the **Active:** sub-section under `## Tickets` and bump
+the **Last updated:** date.
+
+## Step 5 — hand back
+
+Print the file path, the first three lines (key + title, tracker link, status), and
+remind me the tracker is the source of truth. Don't propose a branch — wait.
+```
+
+**Notes:**
+- The `/pull-ticket <KEY>` slash command (in `templates/.claude/commands/`) runs this flow as a one-step invocation. Copy it into your repo's `.claude/commands/` to enable.
+- For terminal-driven use without Claude, the `pull-ticket.sh <KEY>` helper script does the same thing (uses `gh` / `jira` / `glab` CLIs when available, writes a stub for tracker types without a CLI fallback).
+- This is read/reference only. The kit never creates, edits, transitions, or comments on tracker resources — see ADR-0001 D3 and CONVENTIONS.md "Ticket-driven workflows → What the kit does NOT do with trackers".
+
+---
+
 ## When to write a new prompt
 
 Add one here whenever you find yourself typing similar setup instructions into a fresh session for the third time. A good prompt is:

--- a/pull-ticket.sh
+++ b/pull-ticket.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# pull-ticket.sh — terminal-driven version of /pull-ticket
+#
+# Reads tracker config from CONTEXT.md (or ../workspace-CONTEXT.md in
+# workspace mode) and creates a per-ticket scratchpad at
+# tickets/<KEY>-<slug>.md, fetching ticket data via CLI when available
+# (gh for GitHub Issues; jira-cli for JIRA; glab for GitLab) or falling
+# back to a stub template when not.
+#
+# CONSTRAINT: This script is read-only against external trackers. It
+# never creates, edits, transitions, or comments on tracker resources.
+# See ADR-0001 D3 and CONVENTIONS.md "Ticket-driven workflows → What
+# the kit does NOT do with trackers".
+set -euo pipefail
+
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "error: pull-ticket.sh requires bash" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KIT_ROOT="$SCRIPT_DIR"
+
+usage() {
+  cat <<EOF
+Usage: pull-ticket.sh <KEY> [--working-folder <path>]
+
+Fetch a tracker ticket (read-only) and write a per-ticket scratchpad
+to tickets/<KEY>-<slug>.md. Pulls from CLI tools (\`gh\`, \`jira\`, \`glab\`)
+when the tracker type is configured in the working folder's CONTEXT.md.
+For trackers without a CLI fallback, writes a placeholder stub for
+manual fill.
+
+Arguments:
+  <KEY>                  The ticket key (e.g. LX-1234, INFRA-42, 123 for
+                         GitHub Issues).
+
+Options:
+  --working-folder PATH  Path to the Claude working folder for the
+                         current project. If omitted, defaults to
+                         \$HOME/Documents/Claude/Projects/\$(basename \$(pwd))
+                         (the same default \`bootstrap.sh\` uses).
+  --dry-run              Print what would be created and exit without
+                         writing anything.
+  -h, --help             Show this help and exit.
+
+Tracker support:
+  github       \`gh issue view <NUM> --json title,body,state,...\`
+  jira         \`jira issue view <KEY>\` (requires jira-cli)
+  gitlab       \`glab issue view <NUM>\`
+  linear       (no CLI fallback — writes a stub; use the /pull-ticket
+               slash command in Claude with the Linear MCP instead)
+  shortcut     (no CLI fallback — writes a stub)
+  other        (writes a stub for manual fill)
+  none         (errors — set up tracker config first or pass --working-folder)
+
+Examples:
+  cd ~/Code/my-terraform-modules
+  ~/Code/claude-project-kit/pull-ticket.sh LX-1234
+
+  ~/Code/claude-project-kit/pull-ticket.sh 42 \\
+      --working-folder ~/Documents/Claude/Projects/my-project
+EOF
+}
+
+KEY=""
+WORKING_FOLDER=""
+DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --working-folder)
+      if [ $# -lt 2 ]; then
+        echo "error: --working-folder requires a value" >&2
+        usage >&2
+        exit 2
+      fi
+      WORKING_FOLDER="$2"
+      shift 2
+      ;;
+    --*) echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *)
+      if [ -z "$KEY" ]; then
+        KEY="$1"
+      else
+        echo "error: unexpected extra argument: $1" >&2
+        usage >&2
+        exit 2
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$KEY" ]; then
+  echo "error: <KEY> argument is required" >&2
+  usage >&2
+  exit 2
+fi
+
+# Default working folder follows bootstrap.sh's default convention.
+if [ -z "$WORKING_FOLDER" ]; then
+  WORKING_FOLDER="$HOME/Documents/Claude/Projects/$(basename "$(pwd)")"
+fi
+
+case "$WORKING_FOLDER" in
+  "~") WORKING_FOLDER="$HOME" ;;
+  "~/"*) WORKING_FOLDER="$HOME/${WORKING_FOLDER#"~/"}" ;;
+esac
+
+if [ ! -d "$WORKING_FOLDER" ]; then
+  echo "error: working folder does not exist: $WORKING_FOLDER" >&2
+  echo "       Run bootstrap.sh first, or pass --working-folder explicitly." >&2
+  exit 1
+fi
+
+CONTEXT_FILE=""
+if [ -f "$WORKING_FOLDER/../workspace-CONTEXT.md" ]; then
+  # Workspace mode: workspace-CONTEXT.md takes precedence
+  CONTEXT_FILE="$WORKING_FOLDER/../workspace-CONTEXT.md"
+  TICKETS_DIR="$WORKING_FOLDER/../tickets"
+elif [ -f "$WORKING_FOLDER/CONTEXT.md" ]; then
+  CONTEXT_FILE="$WORKING_FOLDER/CONTEXT.md"
+  TICKETS_DIR="$WORKING_FOLDER/tickets"
+else
+  echo "error: no CONTEXT.md found at $WORKING_FOLDER/CONTEXT.md" >&2
+  echo "       (and no workspace-CONTEXT.md one level up)." >&2
+  exit 1
+fi
+
+# Parse tracker config from the CONTEXT file. Looking for lines like
+#   - **Tracker type:** jira
+#   - **Project / team key:** LX
+TRACKER_TYPE="$(grep -E '^- \*\*Tracker type:\*\*' "$CONTEXT_FILE" | sed -E 's/.*\*\*Tracker type:\*\*[[:space:]]+//' | head -1)"
+TRACKER_KEY="$(grep -E '^- \*\*Project / team key:\*\*' "$CONTEXT_FILE" | sed -E 's/.*\*\*Project \/ team key:\*\*[[:space:]]+//' | head -1)"
+
+if [ -z "$TRACKER_TYPE" ]; then
+  echo "error: could not parse 'Tracker type:' from $CONTEXT_FILE" >&2
+  echo "       Expected a line like '- **Tracker type:** jira'." >&2
+  exit 1
+fi
+
+# Strip trailing whitespace
+TRACKER_TYPE="$(printf '%s' "$TRACKER_TYPE" | sed 's/[[:space:]]*$//')"
+
+if [ "$TRACKER_TYPE" = "none" ]; then
+  echo "error: tracker type is 'none' in $CONTEXT_FILE" >&2
+  echo "       Set up tracker config first (re-run bootstrap with --tracker)" >&2
+  echo "       or fill in CONTEXT.md manually." >&2
+  exit 1
+fi
+
+# Try to fetch summary + status. Fall back to stub if no CLI / fetch fails.
+TITLE=""
+STATUS="Open"
+SUMMARY=""
+TRACKER_URL=""
+FETCH_METHOD="stub"
+
+case "$TRACKER_TYPE" in
+  github)
+    NUM="${KEY#\#}"  # accept '#42' or '42'
+    if command -v gh > /dev/null 2>&1; then
+      if FETCH="$(gh issue view "$NUM" --json title,state,body,url 2>/dev/null)"; then
+        TITLE="$(printf '%s' "$FETCH" | sed -nE 's/.*"title":"([^"]*)".*/\1/p')"
+        STATUS="$(printf '%s' "$FETCH" | sed -nE 's/.*"state":"([^"]*)".*/\1/p')"
+        TRACKER_URL="$(printf '%s' "$FETCH" | sed -nE 's/.*"url":"([^"]*)".*/\1/p')"
+        FETCH_METHOD="gh-cli"
+      fi
+    fi
+    ;;
+  jira)
+    if command -v jira > /dev/null 2>&1; then
+      # jira-cli (https://github.com/ankitpokhrel/jira-cli) — best-effort
+      if FETCH="$(jira issue view "$KEY" --plain 2>/dev/null)"; then
+        TITLE="$(printf '%s' "$FETCH" | head -1 | sed -E 's/^[[:space:]]*//')"
+        STATUS="$(printf '%s' "$FETCH" | grep -i '^Status:' | head -1 | sed -E 's/^[Ss]tatus:[[:space:]]*//' || echo "Open")"
+        FETCH_METHOD="jira-cli"
+      fi
+    fi
+    ;;
+  gitlab)
+    NUM="${KEY#\#}"
+    if command -v glab > /dev/null 2>&1; then
+      if FETCH="$(glab issue view "$NUM" 2>/dev/null)"; then
+        TITLE="$(printf '%s' "$FETCH" | grep -i '^title:' | head -1 | sed -E 's/^[Tt]itle:[[:space:]]*//')"
+        FETCH_METHOD="glab-cli"
+      fi
+    fi
+    ;;
+esac
+
+# Generate slug. Fall back to "stub" if no title fetched.
+if [ -n "$TITLE" ]; then
+  SLUG="$(printf '%s' "$TITLE" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+    | cut -c1-40 \
+    | sed -E 's/-+$//')"
+else
+  SLUG="stub"
+fi
+
+TICKET_FILE="$TICKETS_DIR/${KEY}-${SLUG}.md"
+TODAY="$(date +%Y-%m-%d)"
+
+# Idempotence guard: refuse to overwrite an existing scratchpad.
+if [ -e "$TICKET_FILE" ]; then
+  echo "error: ticket file already exists: $TICKET_FILE" >&2
+  echo "       Inspect or remove it manually, or pick a different slug." >&2
+  exit 1
+fi
+EXISTING="$(find "$TICKETS_DIR" -maxdepth 2 -name "${KEY}-*.md" 2>/dev/null | head -1 || true)"
+if [ -n "$EXISTING" ]; then
+  echo "error: a scratchpad with key prefix ${KEY}- already exists: $EXISTING" >&2
+  echo "       Remove or rename it, or use the /pull-ticket slash command in Claude" >&2
+  echo "       to update via the tracker MCP." >&2
+  exit 1
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "=== DRY RUN — no files will be written ==="
+  echo "Tracker file:   $CONTEXT_FILE"
+  echo "Tracker type:   $TRACKER_TYPE"
+  echo "Tracker key:    $TRACKER_KEY"
+  echo "Tickets dir:    $TICKETS_DIR"
+  echo "Fetch method:   $FETCH_METHOD"
+  echo "Ticket key:     $KEY"
+  echo "Title:          ${TITLE:-(not fetched — stub will be written)}"
+  echo "Slug:           $SLUG"
+  echo "Would write:    $TICKET_FILE"
+  exit 0
+fi
+
+mkdir -p "$TICKETS_DIR"
+[ -d "$TICKETS_DIR/archive" ] || mkdir -p "$TICKETS_DIR/archive"
+
+TEMPLATE="$KIT_ROOT/templates/workspace/ticket.md"
+if [ ! -f "$TEMPLATE" ]; then
+  echo "error: ticket template not found: $TEMPLATE" >&2
+  exit 1
+fi
+
+# Use a here-doc for status with placeholder when not fetched.
+TITLE_FILL="${TITLE:-{{TITLE — fill in from tracker}}}"
+URL_FILL="${TRACKER_URL:-{{TRACKER_URL}}}"
+
+sed -e "s|{{KEY}}|$KEY|g" \
+    -e "s|{{TITLE}}|$TITLE_FILL|g" \
+    -e "s|{{TRACKER_URL}}|$URL_FILL|g" \
+    -e "s#{{Open | In progress | Blocked | Done}}#$STATUS#g" \
+    -e "s|{{YYYY-MM-DD}}|$TODAY|g" \
+    "$TEMPLATE" > "$TICKET_FILE"
+
+echo "  ✓ Wrote $TICKET_FILE"
+echo "  ✓ Fetch method: $FETCH_METHOD"
+if [ "$FETCH_METHOD" = "stub" ]; then
+  echo "    (no CLI fallback for tracker '$TRACKER_TYPE' — fill Summary / AC manually,"
+  echo "     or use the /pull-ticket slash command in Claude with the relevant MCP.)"
+fi
+echo
+echo "Next:"
+echo "  1. Open $TICKET_FILE and fill or verify Summary / Acceptance criteria."
+echo "  2. See CONVENTIONS.md \"Ticket-driven workflows\" for branch / PR / commit shape."

--- a/templates/.claude/README.md
+++ b/templates/.claude/README.md
@@ -15,6 +15,7 @@ Two agents and four slash commands that follow the kit's session-start, session-
 - **`/refresh-context`** — re-reads the working folder mid-session (after a `/close-phase` or `/session-end` writeback, or when a long session has drifted). Hands back a delta summary. Same flow as Prompt 5 in `PROMPTS.md`.
 - **`/close-phase`** — runs the phase-close writeback (checklist tick, `plan.md` status, `CONTEXT.md`, `SESSION-LOG.md`, optional acceptance-results archive). Takes a phase number or infers from `CONTEXT.md`.
 - **`/session-end`** — Prompt 3 from `PROMPTS.md` packaged as a slash command. Drafts the end-of-session updates, waits for confirmation before writing.
+- **`/pull-ticket <KEY>`** — pull a tracker ticket (JIRA / GitHub Issues / Linear / GitLab / Shortcut) into a per-ticket scratchpad at `tickets/<KEY>-<slug>.md`. Reads tracker config from `CONTEXT.md` (or `../workspace-CONTEXT.md` in workspace mode), fetches via the relevant MCP, fills the kit's ticket template. Updates `workspace-CONTEXT.md` and stages a `SESSION-LOG.md` line. **Read-only against the tracker** — never creates, edits, transitions, or comments. Same flow as Prompt 6 in `PROMPTS.md`. For terminal-driven use without Claude, see `pull-ticket.sh` at the kit root.
 
 ## How to activate them
 

--- a/templates/.claude/commands/pull-ticket.md
+++ b/templates/.claude/commands/pull-ticket.md
@@ -1,0 +1,98 @@
+---
+description: Pull a tracker ticket into a per-ticket scratchpad. Reads tracker config from CONTEXT.md, fetches ticket data via the relevant MCP (JIRA / GitHub Issues / Linear), creates tickets/<KEY>-<slug>.md from the kit's template, updates workspace-CONTEXT.md, appends to SESSION-LOG.md. Read/reference only — never pushes back to the tracker.
+argument-hint: <KEY>
+---
+
+I want to pull ticket `$ARGUMENTS` from the project's tracker into a per-ticket scratchpad. Read-only — do not push anything back to the tracker.
+
+## Step 1 — determine tracker config
+
+Read `CONTEXT.md` in the working folder. Find the **Tracker Configuration** section. If `../workspace-CONTEXT.md` exists, also read it — workspace-level tracker config takes precedence in workspace mode.
+
+Pull these values:
+
+- **Tracker type** (jira / github / linear / gitlab / shortcut / other / none)
+- **Project / team key** (e.g. `LX`, `INFRA`, `ENG`)
+- **MCP availability**
+
+Stop and ask the user before continuing if any of these hold:
+
+- Tracker type is `none` or `other` — there's no automated path; the user can either set up tracker config first or fall back to a manual stub.
+- MCP availability says `not installed` or `unknown` — confirm the relevant MCP is available before attempting to fetch.
+- The ticket key doesn't match the project key — e.g. tracker is JIRA project `LX` but the user asked for `INFRA-42`. This is usually a typo or wrong-project mistake.
+
+## Step 2 — fetch ticket data
+
+Use the tracker MCP that matches the configured type. **Read-only** operations only: get / view / search. Never create, edit, transition, or comment.
+
+- **JIRA** — use the JIRA MCP. Fetch: summary, description, acceptance criteria (or definition of done if AC isn't separate), status, assignee, sprint, parent epic if any.
+- **GitHub Issues** — use the GitHub MCP if available, otherwise fall back to `gh issue view <NUM> --json title,body,state,labels,assignees,milestone`. The issue lives at `<REPO_URL>/issues/<NUM>`.
+- **Linear** — use the Linear MCP. Fetch: title, description, state, priority, AC, project / cycle.
+- **GitLab** — use the GitLab MCP if available, otherwise `glab issue view <NUM>` against the configured repo.
+- **Shortcut** — use the Shortcut MCP if available, otherwise pause and ask the user how to fetch.
+
+If the relevant MCP isn't available and there's no CLI fallback, stop and tell the user — don't silently produce a stub. The user can choose to install the MCP, install the CLI, or proceed with a manual stub.
+
+## Step 3 — create the ticket file
+
+**Determine the tickets directory:**
+
+- Workspace mode (`../workspace-CONTEXT.md` exists): tickets go in `../tickets/`. The `tickets/archive/` subdirectory should already exist from `bootstrap.sh --workspace`.
+- Single-repo mode: tickets go in `<working-folder>/tickets/`. Create `tickets/` and `tickets/archive/` with `mkdir -p` if they don't exist.
+
+**Generate the slug:**
+
+- Take the ticket title from the tracker.
+- Lowercase, replace non-alphanumeric runs with `-`, trim leading/trailing dashes, cap at ~40 chars.
+- Example: title "Fix LB path-routing for /api/v2" → slug `fix-lb-path-routing-for-api-v2`.
+
+**File path:** `<tickets-dir>/<KEY>-<slug>.md` (e.g. `tickets/LX-1234-fix-lb-path-routing.md`).
+
+**Idempotence guard:** if a file matching `<KEY>-*.md` already exists in either `tickets/` or `tickets/archive/`, stop and ask the user before overwriting. They may have an existing scratchpad with notes worth preserving.
+
+**Fill the template:** use the kit's `templates/workspace/ticket.md` shape (already in the workspace if `bootstrap.sh --workspace` ran; otherwise read from the kit checkout). Substitute:
+
+- `{{KEY}}` → the ticket key
+- `{{TITLE}}` → from the tracker
+- `{{TRACKER_URL}}` → canonical tracker link to this specific ticket
+- `{{Open | In progress | Blocked | Done}}` → actual status (map tracker-specific status names to one of these four; note the tracker-native name in parens if it doesn't fit cleanly)
+- `{{YYYY-MM-DD}}` → today's date (both Created and Last touched)
+- **Summary section** → fill from the tracker description (one paragraph, plain prose; don't paste the entire ticket body if it's long — that's what the tracker is for)
+- **Acceptance criteria** → copy verbatim from the tracker. Convert numbered/bulleted lists to `- [ ] {{...}}` checkboxes if not already.
+- **Working notes** → leave empty (Claude/user fills as work happens)
+- **Branches / PRs / commits** → leave the example row in place as a structure hint
+- **Decisions / blockers** → leave empty
+- **Cross-references → Sessions** → leave empty (filled by `/session-end` or `/close-phase`)
+- **Cross-references → Related tickets** → if the tracker shows links / blockers / dependencies, list them; otherwise leave the placeholder
+
+## Step 4 — update workspace-CONTEXT.md (workspace mode only)
+
+If in workspace mode, open `../workspace-CONTEXT.md`. Find the `## Tickets` section, then the `**Active:**` sub-section.
+
+If the placeholder example bullet is still there (`- [{{KEY}}](tickets/{{KEY}}-{{slug}}.md) — {{one-line summary; repos touched}}`), replace it. Otherwise append a new bullet:
+
+```
+- [<KEY>](tickets/<KEY>-<slug>.md) — <one-line summary from tracker>; <repos touched, or "TBD" if unknown>
+```
+
+Bump the `**Last updated:**` date at the top of `workspace-CONTEXT.md`.
+
+## Step 5 — log it
+
+Stage (do not yet write) a one-line addition to the working folder's `SESSION-LOG.md` for the current session entry:
+
+```
+- Pulled <KEY> — <one-line summary>
+```
+
+If `/session-end` runs later this session, this line should be folded into the session entry's "Branches/PRs/Tickets" block. If you're appending to an in-flight entry, append directly.
+
+## Step 6 — hand back
+
+Print:
+
+1. Path to the new ticket file (e.g. `tickets/LX-1234-fix-lb-path-routing.md`).
+2. First three lines of the file: key + title, tracker link, status.
+3. A reminder: "Tracker is source of truth — re-run `/pull-ticket <KEY>` if the tracker changes. This file is the local working scratchpad."
+
+Then stop. Don't propose a branch name, don't open a worktree, don't start work. The user drives next — typically by checking the kit's CONVENTIONS.md (Ticket-driven workflows section) for the branch / PR / commit shape and starting from there.

--- a/tests/pull_ticket.bats
+++ b/tests/pull_ticket.bats
@@ -1,0 +1,199 @@
+#!/usr/bin/env bats
+# Phase 4 §E.1 — pull-ticket.sh terminal-driven helper.
+#
+# These tests cover the script's structural behavior (path resolution,
+# tracker config parsing, idempotence, dry-run, workspace detection).
+# They do not exercise live tracker MCPs / CLIs — those paths are
+# fall-through; the stub path is the testable one.
+
+load 'helpers'
+
+PULL_TICKET=""
+
+setup() {
+  bootstrap_setup
+  PULL_TICKET="$KIT_ROOT/pull-ticket.sh"
+}
+
+teardown() { bootstrap_teardown; }
+
+# Helper: seed a single-repo working folder with a tracker-configured CONTEXT.md.
+seed_single_repo_wf() {
+  local tracker="${1:-jira}"
+  local key="${2:-LX}"
+  mkdir -p "$TEST_WF"
+  cat > "$TEST_WF/CONTEXT.md" <<EOF
+# Claude Working Context — test-project
+
+## Tracker Configuration
+
+- **Tracker type:** $tracker
+- **Project / team key:** $key
+- **MCP availability:** unknown
+EOF
+}
+
+# Helper: seed a workspace + per-repo subfolder.
+seed_workspace_wf() {
+  local tracker="${1:-jira}"
+  local key="${2:-LX}"
+  WS="$TEST_TMP/lx-workspace"
+  WS_REPO="$WS/repo-a"
+  mkdir -p "$WS_REPO" "$WS/tickets/archive"
+  cat > "$WS/workspace-CONTEXT.md" <<EOF
+# Workspace — lx-platform
+
+## Tracker Configuration
+
+- **Tracker type:** $tracker
+- **Project / team key:** $key
+EOF
+  cat > "$WS_REPO/CONTEXT.md" <<EOF
+# Per-repo CONTEXT
+EOF
+}
+
+# --- Argument parsing ---
+
+@test "pull-ticket.sh prints help on -h" {
+  run "$PULL_TICKET" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: pull-ticket.sh"* ]]
+  [[ "$output" == *"--working-folder"* ]]
+}
+
+@test "pull-ticket.sh errors when no KEY argument" {
+  run "$PULL_TICKET"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"<KEY> argument is required"* ]]
+}
+
+@test "pull-ticket.sh errors on unknown flag" {
+  run "$PULL_TICKET" --bogus LX-1
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown option"* ]]
+}
+
+@test "pull-ticket.sh errors when working folder doesn't exist" {
+  run "$PULL_TICKET" LX-1 --working-folder /tmp/nonexistent-$$-pull-ticket
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"working folder does not exist"* ]]
+}
+
+# --- Tracker config parsing ---
+
+@test "pull-ticket.sh errors when CONTEXT.md missing" {
+  mkdir -p "$TEST_WF"
+  run "$PULL_TICKET" LX-1 --working-folder "$TEST_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no CONTEXT.md found"* ]]
+}
+
+@test "pull-ticket.sh errors when tracker type is none" {
+  seed_single_repo_wf "none" ""
+  run "$PULL_TICKET" LX-1 --working-folder "$TEST_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"tracker type is 'none'"* ]]
+}
+
+@test "pull-ticket.sh parses jira tracker config and uses stub fallback" {
+  seed_single_repo_wf jira LX
+  run "$PULL_TICKET" LX-1234 --working-folder "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_WF/tickets/LX-1234-stub.md" ]
+  grep -q "^# LX-1234" "$TEST_WF/tickets/LX-1234-stub.md"
+  grep -q "Tracker:.*LX-1234" "$TEST_WF/tickets/LX-1234-stub.md"
+}
+
+# --- Dry-run ---
+
+@test "pull-ticket.sh --dry-run does not write the file" {
+  seed_single_repo_wf jira LX
+  run "$PULL_TICKET" LX-1234 --working-folder "$TEST_WF" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY RUN"* ]]
+  [[ "$output" == *"Would write:"* ]]
+  [ ! -e "$TEST_WF/tickets/LX-1234-stub.md" ]
+}
+
+# --- Idempotence ---
+
+@test "pull-ticket.sh refuses to overwrite an existing scratchpad" {
+  seed_single_repo_wf jira LX
+  mkdir -p "$TEST_WF/tickets"
+  echo "existing notes" > "$TEST_WF/tickets/LX-1234-existing.md"
+
+  run "$PULL_TICKET" LX-1234 --working-folder "$TEST_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"already exists"* ]]
+
+  # User's edits survive
+  grep -q "existing notes" "$TEST_WF/tickets/LX-1234-existing.md"
+}
+
+@test "pull-ticket.sh refuses to overwrite an archived scratchpad with same key" {
+  seed_single_repo_wf jira LX
+  mkdir -p "$TEST_WF/tickets/archive"
+  echo "archived" > "$TEST_WF/tickets/archive/LX-1234-old.md"
+
+  run "$PULL_TICKET" LX-1234 --working-folder "$TEST_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"already exists"* ]]
+}
+
+# --- Workspace mode ---
+
+@test "pull-ticket.sh writes to workspace tickets/ when ../workspace-CONTEXT.md exists" {
+  seed_workspace_wf jira LX
+  run "$PULL_TICKET" LX-1234 --working-folder "$WS_REPO"
+  [ "$status" -eq 0 ]
+  [ -f "$WS/tickets/LX-1234-stub.md" ]
+  [ ! -d "$WS_REPO/tickets" ]  # per-repo subfolder should NOT have its own tickets/
+}
+
+@test "pull-ticket.sh in workspace mode reads workspace-level tracker config" {
+  # Per-repo CONTEXT.md is intentionally empty / no tracker config —
+  # the workspace-level one is what matters.
+  seed_workspace_wf jira LX
+  run "$PULL_TICKET" LX-1234 --working-folder "$WS_REPO" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Tracker type:   jira"* ]]
+  [[ "$output" == *"Tracker key:    LX"* ]]
+}
+
+# --- Constraint: read-only ---
+
+@test "pull-ticket.sh source contains no tracker-mutation commands" {
+  # Same defensive scan as bootstrap.sh's bootstrap_constraints.bats.
+  local forbidden=(
+    "gh issue create"
+    "gh issue edit"
+    "gh issue close"
+    "gh issue delete"
+    "gh issue reopen"
+    "gh label create"
+    "gh project create"
+    "gh project edit"
+    "gh project item-add"
+    "jira issue create"
+    "jira issue edit"
+    "jira issue assign"
+    "jira issue move"
+    "linear ticket create"
+    "linear ticket edit"
+    "glab issue create"
+    "glab issue close"
+  )
+  local pattern
+  for pattern in "${forbidden[@]}"; do
+    if grep -F -q "$pattern" "$KIT_ROOT/pull-ticket.sh"; then
+      echo "FAIL: pull-ticket.sh contains forbidden tracker-mutation pattern: $pattern" >&2
+      return 1
+    fi
+  done
+}
+
+@test "pull-ticket.sh has explicit constraint comment about being read-only" {
+  grep -q "read-only against external trackers" "$KIT_ROOT/pull-ticket.sh"
+  grep -q "ADR-0001 D3" "$KIT_ROOT/pull-ticket.sh"
+}


### PR DESCRIPTION
Phase 4 §E close + §C.5 — ships the JIRA / GitHub Issues / Linear / GitLab / Shortcut ticket-pull integration. Closes [#61](https://github.com/IamMrCupp/claude-project-kit/issues/61) §E.1, E.2, E.3, and C.5 in one PR.

## Summary

- **`/pull-ticket <KEY>` slash command** in `templates/.claude/commands/pull-ticket.md`. Reads tracker config from `CONTEXT.md` (or `../workspace-CONTEXT.md` in workspace mode), fetches ticket data via the relevant MCP (JIRA / GitHub Issues / Linear / GitLab / Shortcut), creates `tickets/<KEY>-<slug>.md` from the kit's ticket template, updates `workspace-CONTEXT.md` "Active tickets" list, stages a `SESSION-LOG.md` line. Idempotence guard refuses to overwrite existing scratchpads (active or archived).
- **`pull-ticket.sh` helper script** at the kit root. Terminal-driven equivalent — uses `gh` for GitHub Issues, `jira` (jira-cli) for JIRA, `glab` for GitLab; falls back to a stub template when no CLI matches the configured tracker. Same idempotence guards. Same workspace-vs-single-repo detection.
- **Prompt 6 in `PROMPTS.md`** — prose source of truth for the flow, mirroring the existing pattern (`/session-start` ↔ Prompt 1, `/session-end` ↔ Prompt 3, `/refresh-context` ↔ Prompt 5).
- **`templates/.claude/README.md`** updated to list the new slash command (closes C.5).

## Read-only constraint

Both the slash command and the helper script are read-only against external trackers — they fetch / view / search; they never create, edit, transition, or comment. Same defensive bats scan as `bootstrap.sh` (forbidden patterns: ` + '`gh issue create`' + `, ` + '`jira issue create`' + `, ` + '`gh project edit`' + `, ` + '`linear ticket create`' + `, ` + '`glab issue close`' + `, etc.). See ADR-0001 D3 and CONVENTIONS.md "Ticket-driven workflows → What the kit does NOT do with trackers".

## What this leaves for later

- §F (top-level docs — README / SETUP / FEATURES surfacing the new flows)
- §G (filled-in example showing multi-repo + ticket layout end-to-end)
- §H (real-work ACME dogfood)

## Test plan

- [x] ` + '`bash -n pull-ticket.sh`' + ` (syntax)
- [x] ` + '`bats tests/`' + ` — 116 tests pass (was 102; +14 from ` + '`pull_ticket.bats`' + `)
- [x] Smoke-tested ` + '`pull-ticket.sh ACME-1234`' + ` against a fake single-repo working folder with ` + '`--tracker jira`' + ` config: stub written to ` + '`tickets/ACME-1234-stub.md`' + `, idempotence guard fires on re-run
- [x] Smoke-tested workspace mode: stub lands at ` + '`<workspace>/tickets/`' + `, per-repo subfolder doesn't get its own ` + '`tickets/`' + `
- [x] Defensive grep: no tracker-mutation commands in either ` + '`bootstrap.sh`' + `, ` + '`pull-ticket.sh`' + `, or the slash command file
- [ ] GitHub render check on this PR body
- [ ] Lychee link-check passes (no new external links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
