### PR TITLE
docs: surface Phase 4 features (workspace, tickets, /pull-ticket) in README/SETUP/FEATURES

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -5,7 +5,9 @@ A feature-by-feature reference. For setup steps, see [SETUP.md](SETUP.md). For t
 ## Contents
 
 - [Bootstrap](#bootstrap)
+- [Workspace mode (multi-repo)](#workspace-mode-multi-repo)
 - [Issue tracker awareness](#issue-tracker-awareness)
+- [Per-ticket scratchpads](#per-ticket-scratchpads)
 - [CI awareness](#ci-awareness)
 - [Auto-memory seeding](#auto-memory-seeding)
 - [Phase-based planning docs](#phase-based-planning-docs)
@@ -57,6 +59,49 @@ Override the auto-derived project name used to fill `{{PROJECT_NAME}}` in seeded
 bootstrap.sh ~/Documents/Claude/Projects/foo --project-name "Foo Service"
 ```
 
+### Terraform sibling-repo detection
+
+Bootstrap detects Terraform-shaped repos (signals: `*.tf`, `*.tfvars`, `.terraform.lock.hcl`, `terragrunt.hcl`, or `terraform/` / `modules/` subdirs containing `.tf` files) and prompts about a possible sibling envs/modules repo. In interactive mode it asks "Sibling envs/modules repo for this initiative?" and recommends `--workspace` if yes. In non-interactive mode it emits a one-line stderr hint. Suppressed under `--workspace`.
+
+The signal list comes from [ADR-0001 §A.6](docs/adr/0001-multi-repo-folder-model.md). Pulumi (`Pulumi.yaml`) and CDK (`cdk.json`) are deferred — promote in a follow-up if the demand surfaces.
+
+---
+
+## Workspace mode (multi-repo)
+
+`--workspace <path>` flips bootstrap into multi-repo mode for initiatives that span repos (the canonical case: Terraform environment definitions in one repo + Terraform modules in another). Bootstrap creates a workspace folder above per-repo subfolders:
+
+```
+~/Documents/Claude/Projects/<initiative>/
+├── workspace-CONTEXT.md      ← cross-repo overview, shared tracker config
+├── tickets/                  ← per-ticket scratchpads
+│   └── archive/              ← closed tickets
+├── <repo-a>/                 ← per-repo working folder (CONTEXT.md, SESSION-LOG.md, …)
+└── <repo-b>/                 ← second repo joins via re-running bootstrap
+```
+
+```bash
+# First repo in a new workspace
+cd ~/Code/my-terraform-modules
+~/Code/claude-project-kit/bootstrap.sh --workspace \
+  ~/Documents/Claude/Projects/lx-platform/ \
+  --tracker jira --jira-project LX --ci atlantis
+
+# Second repo joins the same workspace
+cd ~/Code/my-terraform-envs
+~/Code/claude-project-kit/bootstrap.sh --workspace \
+  ~/Documents/Claude/Projects/lx-platform/ \
+  --tracker jira --jira-project LX --ci atlantis
+```
+
+Re-running against an existing workspace (detected via `workspace-CONTEXT.md` presence) is idempotent: per-repo subfolders get added without recreating workspace files. User edits to `workspace-CONTEXT.md` survive.
+
+Tracker config flags (`--tracker jira --jira-project LX`) substitute into `workspace-CONTEXT.md`'s Tracker Configuration section AND into each per-repo `CONTEXT.md`. MCP availability and tracker link stay as prose hints for SEED-PROMPT or human fill.
+
+Auto-memory keys to the repo (`~/.claude/projects/<sanitized-repo-path>/memory/`), not the workspace path. Workspace is a working-folder layout choice; memory stays per-repo.
+
+For converting an existing single-repo working folder into a workspace by hand, see [SETUP.md §Upgrading a single-repo working folder to a workspace](SETUP.md#upgrading-a-single-repo-working-folder-to-a-workspace). The kit doesn't ship an automated migration helper — the manual flow is a handful of `mv` commands.
+
 ---
 
 ## Issue tracker awareness
@@ -74,6 +119,37 @@ bootstrap.sh ~/Documents/Claude/Projects/foo --project-name "Foo Service"
 | `none` | — | Skips tracker memory entirely. |
 
 In non-interactive mode, omitting `--tracker` is the same as `--tracker none` — bootstrap won't guess.
+
+`--tracker` and `--jira-project` / `--linear-team` also fill `{{TRACKER_TYPE}}` and `{{TRACKER_KEY}}` in `CONTEXT.md` (and `workspace-CONTEXT.md` in workspace mode), so the working folder's Tracker Configuration section is pre-populated alongside the auto-memory file. MCP availability + tracker link stay as prose hints for SEED-PROMPT or human fill.
+
+**Read-only constraint:** the kit never creates, edits, transitions, or comments on tracker resources. It captures references to existing trackers only — JIRA / Linear / GitHub Issues projects must exist before bootstrap. See [ADR-0001 §D3](docs/adr/0001-multi-repo-folder-model.md) and `CONVENTIONS.md` "Ticket-driven workflows → What the kit does NOT do with trackers".
+
+---
+
+## Per-ticket scratchpads
+
+For ticket-driven work (JIRA, GitHub Issues, Linear, GitLab, Shortcut), the kit ships a per-ticket scratchpad pattern: `tickets/<KEY>-<slug>.md` accumulates working notes, branches, and PRs as the ticket progresses; the upstream tracker stays the source of truth.
+
+Two entry points fetch tracker data and seed the scratchpad — both **read-only** against the tracker:
+
+- **`/pull-ticket <KEY>` slash command** — reads tracker config from `CONTEXT.md` (or `../workspace-CONTEXT.md` in workspace mode), fetches via the relevant tracker MCP, fills `templates/workspace/ticket.md`, updates the workspace-CONTEXT "Active tickets" list, and stages a `SESSION-LOG.md` entry. Use from inside Claude.
+
+- **`pull-ticket.sh <KEY>` helper script** — terminal-driven equivalent. Uses `gh issue view` for GitHub Issues, `jira` (jira-cli) for JIRA, `glab issue view` for GitLab; falls back to a placeholder stub for Linear / Shortcut / `other` (or if no CLI is available). Writes the scratchpad; doesn't update workspace-CONTEXT or SESSION-LOG.
+
+Both refuse to overwrite an existing scratchpad with the same `<KEY>-` prefix (active or archived) — your working notes survive a re-pull.
+
+```bash
+# In Claude:  /pull-ticket LX-1234
+
+# In a terminal:
+cd ~/Code/my-terraform-modules
+~/Code/claude-project-kit/pull-ticket.sh LX-1234
+# → writes <workspace>/tickets/LX-1234-fix-lb-routing.md (or stub if no CLI)
+```
+
+`templates/workspace/ticket.md` defines the file shape: tracker link, status, summary, AC, working notes, branches/PRs across repos (for multi-repo tickets), decisions, cross-references. When the upstream ticket closes, move the file to `tickets/archive/` with a 1-2 sentence "what shipped" note — the archive becomes a grep-able record of what the team delivered for each ticket.
+
+The branch / PR / commit conventions for ticket-driven work (JIRA-style key in the branch slug, PR title, and commit subject) are in `CONVENTIONS.md` "Ticket-driven workflows".
 
 ---
 
@@ -149,12 +225,13 @@ These are **starters**. Edit the frontmatter (model, tool allowlist), customize 
 
 ## Starter slash commands
 
-Four slash commands stage in `<working-folder>/.claude/commands/`. Same activation pattern — copy `.claude/` into your target repo.
+Five slash commands stage in `<working-folder>/.claude/commands/`. Same activation pattern — copy `.claude/` into your target repo.
 
 - **`/session-start`** — packages Prompt 1 from `PROMPTS.md`. Loads `CONTEXT.md`, `SESSION-LOG.md`, and the current phase checklist; hands back a 3–5 bullet grounding summary. Use at the start of a fresh session.
 - **`/refresh-context`** — re-reads the working folder mid-session, after a `/close-phase` or `/session-end` writeback or when a long session has drifted. Hands back a delta read against the latest state.
 - **`/close-phase`** — runs the phase-close writeback (checklist tick, `plan.md` status bump, `CONTEXT.md` update, optional acceptance-results archive). Takes a phase number or infers from `CONTEXT.md`.
 - **`/session-end`** — packages Prompt 3 from `PROMPTS.md`. Drafts the four end-of-session updates (SESSION-LOG entry, CONTEXT bump, checklist scan, memory candidates) and waits for confirmation before writing.
+- **`/pull-ticket <KEY>`** — packages Prompt 6 from `PROMPTS.md`. Fetches a tracker ticket (JIRA / GitHub Issues / Linear / GitLab / Shortcut) via the relevant MCP, creates `tickets/<KEY>-<slug>.md` from the kit's ticket template, updates `workspace-CONTEXT.md` "Active tickets" list, stages a `SESSION-LOG.md` line. Read-only against the tracker. See [Per-ticket scratchpads](#per-ticket-scratchpads) for the full flow.
 
 ---
 
@@ -182,6 +259,6 @@ Every step has a manual alternative — see [SETUP.md §Manual alternative](SETU
 
 - **Doesn't modify your target repo.** Templates land in the working folder; memory lands in the harness path. Your repo stays clean.
 - **Doesn't make network calls.** No telemetry, no auto-update check, no remote dependencies at runtime.
-- **Doesn't manage your tracker / CI.** It seeds memory so Claude knows the conventions; it doesn't create JIRA projects, push GitHub Actions workflows, or open issues for you.
+- **Doesn't manage your tracker / CI.** It seeds memory so Claude knows the conventions; it doesn't create JIRA projects, push GitHub Actions workflows, or open issues for you. Tracker integration (`/pull-ticket`, `pull-ticket.sh`) is **one-way read** — fetches summary / AC / status, never creates / edits / transitions / comments. See [ADR-0001 §D3](docs/adr/0001-multi-repo-folder-model.md).
 - **Doesn't replace `CLAUDE.md`.** They're complementary — the kit handles cross-session state and preferences; `CLAUDE.md` handles in-repo guidance Claude reads automatically.
 - **Doesn't auto-upgrade installed projects.** When the kit ships new templates, existing adopters apply changes manually with the diff in [CHANGELOG.md](CHANGELOG.md). Bootstrap is write-once by design.

--- a/README.md
+++ b/README.md
@@ -68,15 +68,17 @@ That kicks off interactive mode: it asks for the working-folder path, project na
 ## Features
 
 - **Idempotent bootstrap** — write-once by default, with `--dry-run` (preview), `--force` (override the empty-folder check), and `--skip-memory` (working folder only).
-- **Issue tracker awareness** — `--tracker {github,jira,linear,gitlab,shortcut,other,none}` seeds tracker-specific memory. JIRA and Linear take a project / team key.
+- **Workspace mode** — `--workspace <path>` sets up a multi-repo initiative folder (workspace-CONTEXT.md + per-repo subfolders + shared `tickets/`). Detects Terraform / Terragrunt repos and prompts about sibling envs/modules repos.
+- **Issue tracker awareness** — `--tracker {github,jira,linear,gitlab,shortcut,other,none}` seeds tracker-specific memory AND fills `{{TRACKER_TYPE}}` / `{{TRACKER_KEY}}` in `CONTEXT.md`. JIRA and Linear take a project / team key.
+- **Per-ticket scratchpads** — `/pull-ticket <KEY>` slash command + `pull-ticket.sh` helper script fetch ticket data via tracker MCPs / CLIs and seed `tickets/<KEY>-<slug>.md`. **Read-only** against the tracker — never creates, edits, transitions, or comments.
 - **CI awareness** — `--ci {github-actions,gitlab-ci,jenkins,circleci,atlantis,ansible-cli,other,none}` seeds CI-specific memory.
 - **Auto-memory seeding** — starter memory files for role, conventions, project context, and external references, with placeholder substitution from your repo (`{{PROJECT_NAME}}`, `{{REPO_SLUG}}`, etc.).
 - **Phase-based planning docs** — `plan.md` + per-phase checklist + `implementation.md` give Claude scoped, numbered tasks instead of a wall of intent.
 - **SEED-PROMPT auto-fill** — point Claude at one file and it deep-reads your repo, fills `CONTEXT.md`, drafts `research.md`, flags inferences, and stops for your review.
 - **Starter agents** — `code-reviewer` (universal) and `session-summarizer` (kit-aware), staged in the working folder; copy into your repo to activate.
-- **Starter slash commands** — `/session-start` (load working-folder context), `/refresh-context` (re-read mid-session), `/close-phase` (phase-close writeback), and `/session-end` (end-of-session log + memory pass).
+- **Starter slash commands** — `/session-start`, `/refresh-context`, `/close-phase`, `/session-end`, `/pull-ticket`.
 - **Worked example** — `examples/widget-tracker/` is a fictional Go CLI mid-Phase-1 with all docs filled in plausibly.
-- **Conventions baseline** — Conventional Commits, merge-only PRs, test-plan format, etc. Read once, drop or keep per project.
+- **Conventions baseline** — Conventional Commits, merge-only PRs, ticket-driven branch / PR / commit shape, test-plan format, etc. Read once, drop or keep per project.
 - **No surprises** — MIT licensed, no telemetry, no network calls, kit never modifies your target repo.
 
 See [FEATURES.md](FEATURES.md) for one-paragraph-per-feature detail with example invocations.
@@ -148,6 +150,7 @@ Works the same for greenfield repos and ones you're adopting it on mid-stream �
 ├── SECURITY.md              ← reporting vulnerabilities
 ├── LICENSE
 ├── bootstrap.sh             ← one-command setup (see SETUP.md step 2)
+├── pull-ticket.sh           ← terminal-driven /pull-ticket equivalent (read-only)
 ├── docs/adr/                ← Architecture Decision Records (see README inside)
 ├── templates/               ← copied into a new working folder
 │   ├── SEED-PROMPT.md       ← instructions for Claude to auto-fill the rest
@@ -158,9 +161,12 @@ Works the same for greenfield repos and ones you're adopting it on mid-stream �
 │   ├── phase-N-checklist.md
 │   ├── acceptance-test-results.md
 │   ├── research.md
+│   ├── workspace/           ← workspace-mode-only templates
+│   │   ├── workspace-CONTEXT.md   ← cross-repo overview (--workspace)
+│   │   └── ticket.md              ← per-ticket scratchpad shape
 │   └── .claude/             ← starter agents + slash commands (staged in WF)
 │       ├── agents/          ← code-reviewer, session-summarizer
-│       ├── commands/        ← /session-start, /refresh-context, /close-phase, /session-end
+│       ├── commands/        ← /session-start, /refresh-context, /close-phase, /session-end, /pull-ticket
 │       └── README.md        ← how to copy into your target repo
 ├── examples/                ← filled-in reference — read, don't copy
 │   └── widget-tracker/      ← fictional Go CLI, mid-Phase-1 snapshot

--- a/SETUP.md
+++ b/SETUP.md
@@ -248,11 +248,23 @@ cd <repo-b>
 
 Bootstrap detects the existing workspace (via the presence of `workspace-CONTEXT.md`), preserves it, and adds `<initiative>/<repo-b>/` as a new per-repo subfolder. Repeat for each repo in the initiative.
 
+### Pulling a ticket into the workspace
+
+Once a workspace is set up with tracker config (`--tracker jira --jira-project LX`), the `/pull-ticket <KEY>` slash command (in `templates/.claude/commands/`) or the `pull-ticket.sh <KEY>` helper script at the kit root fetch ticket data from the configured tracker and seed `tickets/<KEY>-<slug>.md`. Read-only against the tracker — fetches summary / AC / status; never creates, edits, transitions, or comments.
+
+```bash
+# In Claude:  /pull-ticket LX-1234
+# In a terminal:
+~/Code/claude-project-kit/pull-ticket.sh LX-1234
+```
+
+Idempotence: both refuse to overwrite an existing scratchpad with the same `<KEY>-` prefix (active or archived). Re-pull by removing or archiving the old file first, or do it from Claude (the slash command can re-pull if you confirm).
+
 ### What `--workspace` does NOT do (yet)
 
-- **Tracker config substitution into CONTEXT.md** — for now, fill the `## Tracker Configuration` section in `<initiative>/<repo-a>/CONTEXT.md` and `<initiative>/workspace-CONTEXT.md` by hand. Bootstrap-side substitution is on the Phase 4 backlog ([#61](https://github.com/IamMrCupp/claude-project-kit/issues/61) §C.1 / D.1).
-- **Terraform sibling-repo prompt** — bootstrap doesn't yet detect Terraform-shaped repos and prompt about sibling envs/modules. Coming in a follow-up; for now, you decide which repos belong in the workspace.
 - **Interactive workspace prompt** — `--workspace` requires the explicit flag. Interactive mode still defaults to single-repo. Use the flag-based form above for workspace bootstraps.
+
+(Tracker config substitution into `CONTEXT.md` / `workspace-CONTEXT.md` and the Terraform sibling-repo prompt landed in v0.17.0. The interactive workspace prompt is the only remaining `--workspace` polish item.)
 
 ---
 


### PR DESCRIPTION
Phase 4 §F close — surfaces the workspace, per-ticket scratchpad, and `/pull-ticket` features in the top-level docs so adopters can find them. F.3 (PROMPTS.md) already landed in [#96](https://github.com/IamMrCupp/claude-project-kit/pull/96) via Prompt 6. F.4 (CONTRIBUTING.md) skipped — no contributor-facing workflow changed.

## Summary

- **`FEATURES.md`** — three new sections plus existing-section updates:
  - **Workspace mode (multi-repo)** — full feature description with the per-repo / workspace folder shape, example invocations for first repo + adding a sibling, idempotence note, tracker-config-flows-in note, auto-memory keying note.
  - **Per-ticket scratchpads** — `/pull-ticket` slash command + `pull-ticket.sh` helper script + the `tickets/<KEY>-<slug>.md` file shape and lifecycle (active → archive on close).
  - **Terraform sibling-repo detection** sub-section under Bootstrap.
  - **Issue tracker awareness** updated to note `{{TRACKER_TYPE}}` / `{{TRACKER_KEY}}` substitution into CONTEXT.md + the read-only constraint.
  - **Starter slash commands** updated from 4 → 5 commands (adds `/pull-ticket`).
  - **What the kit does NOT do** clarified about one-way read.
  - **Contents** ToC updated.
- **`README.md`** — Features list adds workspace mode, per-ticket scratchpads, /pull-ticket bullets; existing tracker bullet notes the CONTEXT.md substitution; slash-commands bullet collapsed to a list (5 commands) with detail in FEATURES.md; file tree updated for ` + '`pull-ticket.sh`' + `, ` + '`templates/workspace/`' + `, and the new `/pull-ticket` command.
- **`SETUP.md`** — adds "Pulling a ticket into the workspace" sub-section under Workspace mode; prunes the stale "What `--workspace` does NOT do (yet)" list (tracker substitution + Terraform prompt landed in v0.17.0; only the interactive workspace prompt is still deferred).

## Test plan

- [x] ` + '`bats tests/`' + ` — full suite still passes (116/116; no test changes in this PR)
- [x] Self-review of the diff for ToC consistency, no broken cross-references
- [ ] GitHub render check on the PR body
- [ ] Lychee link-check passes (the new ADR-0001 § references and FEATURES.md anchors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)