### PR TITLE
chore: expand .gitattributes to surface all tracked file types in language graph

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,11 @@
 # Make the GitHub language graph reflect the kit's actual content mix.
-# Without this, *.md is treated as linguist-documentation and excluded from
-# the language stats — and since the kit is ~90% markdown by content, the
-# default graph shows "Shell 100%", which misrepresents what's in here.
+# Without these overrides, Linguist hides markdown (documentation), YAML/JSON
+# (data), and unknown extensions like .tape (VHS) — leaving "Shell 100%",
+# which misrepresents a repo that is ~90% markdown.
 
-*.md linguist-documentation=false linguist-detectable=true
+*.md   linguist-documentation=false linguist-detectable=true
+*.yml  linguist-detectable=true
+*.json linguist-detectable=true
+*.tape linguist-detectable=true linguist-language=VHS
+*.exp  linguist-detectable=true linguist-language=Expect
+*.bats linguist-detectable=true linguist-language=Shell


### PR DESCRIPTION
## Summary

- Builds on #55 (which forced `*.md` into the language graph). The existing override only covered markdown — `.yml`, `.json`, and `.tape` were still hidden by Linguist's defaults (data / unknown).
- Adds detectable overrides for `*.yml`, `*.json`, `*.tape`, `*.exp`, and `*.bats` so the GitHub language graph reflects the full content mix.
- `*.tape`, `*.exp`, and `*.bats` get explicit `linguist-language` pins so heuristics don't drift.

## Test plan

- [ ] After merge, confirm the GitHub language graph on the repo home page shows YAML / JSON / VHS / Expect / Shell alongside Markdown (Linguist re-runs on push to default branch).