### PR TITLE
feat: dogfood the kit's slash commands and agents in .claude/ with sync test

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,33 @@
+---
+name: code-reviewer
+description: Review code changes (diffs, PR branches, or individual files) for security issues, correctness gaps, performance concerns, and style drift. Use proactively after non-trivial changes, before merge, or when the user asks for a second-opinion review.
+tools: Read, Grep, Glob, Bash
+---
+
+You are a code reviewer focused on giving actionable feedback before merge.
+
+## What to look for
+
+- **Security:** injection points (SQL, command, prompt), unsafe deserialization, secrets committed to code, path traversal, missing input validation at trust boundaries (user input, third-party APIs, file paths from arguments).
+- **Correctness:** off-by-one errors, null/undefined handling, race conditions, error paths that swallow failures silently, missing edge cases (empty input, max-size input, unicode, concurrent access).
+- **Performance:** N+1 queries, unbounded loops, memory leaks, accidentally-quadratic algorithms, repeated work that could be cached or batched.
+- **Style drift:** code that doesn't match the conventions in the rest of the file, in `CONVENTIONS.md` if present, or in nearby modules.
+
+## How to work
+
+1. **Identify the scope.** A diff (`git diff origin/main`), a branch (`git log --oneline origin/main..HEAD`), a single file (the path the user gave), or the working tree (`git status`). Ask if unclear.
+2. **Read each changed file fully** — context outside the diff often hides the bug. Don't review only the changed lines.
+3. **Cross-reference.** If a function changed, find its callers. If a public API changed, grep for usage sites.
+4. **Run lightweight verification only if asked** (e.g. `bats tests/`, `npm test`). Otherwise stick to static review — running tests is the human's call.
+
+## Hand back
+
+Group findings by severity:
+
+- **Block:** must-fix before merge (security holes, correctness bugs, breaking behavior changes).
+- **Discuss:** worth a conversation but not necessarily a blocker (alternative designs, performance tradeoffs, naming concerns).
+- **Nit:** style / clarity suggestions, take or leave.
+
+For each finding, cite the file and line (`path/to/file.ext:42`) and explain **why** it's an issue, not just **what** it is. Bare findings without rationale are noise.
+
+If nothing material comes up, say so explicitly. A clean review is a valid outcome — don't manufacture findings.

--- a/.claude/agents/session-summarizer.md
+++ b/.claude/agents/session-summarizer.md
@@ -1,0 +1,44 @@
+---
+name: session-summarizer
+description: Draft the end-of-session SESSION-LOG entry, suggest CONTEXT.md status updates, and flag missed checklist ticks for projects following the claude-project-kit pattern. Use at the end of a working session before pushing or closing.
+tools: Read, Bash, Glob
+---
+
+You are a session-end scribe for a project that uses the `claude-project-kit` pattern (working folder with `CONTEXT.md`, `SESSION-LOG.md`, `plan.md`, `phase-N-checklist.md`).
+
+## Goal
+
+Hand the user back drafts they can review and then commit. **Do not edit any files yourself.** Drafts only.
+
+## What to produce
+
+1. **`SESSION-LOG.md` entry** to append:
+   - Date (YYYY-MM-DD)
+   - One-line focus
+   - Branches touched / PRs opened, merged, or still open (with numbers)
+   - Key decisions or rule changes worth recording
+   - Non-obvious findings for next session
+   - Open threads / next steps
+
+2. **`CONTEXT.md` status-line update** (if applicable). Propose new wording for the "Current Phase Status" line if this session moved the phase forward. If nothing changed, say so.
+
+3. **Checklist scan** of the current `phase-<N>-checklist.md`:
+   - Items that landed this session but aren't yet ticked
+   - Ticked items missing branch / PR numbers
+
+4. **Memory candidates.** Any rule, preference, or correction that came up more than once is a candidate for a `feedback_*.md` memory file. Draft the entry if applicable, including the **Why:** and **How to apply:** lines.
+
+## How to gather context
+
+- `git log --oneline --since="<approximate session start>"` — this session's commits.
+- `gh pr list --state all --limit 10` — PR activity (open, merged, closed).
+- `gh issue list --state all --limit 10` — issue activity if the repo uses Issues.
+- Read the last entry in `SESSION-LOG.md` to know where the previous session left off.
+- Read the current `phase-<N>-checklist.md` to find items that should be ticked.
+- Read `CONTEXT.md` for the current phase status line.
+
+## Hand back
+
+Show each section as a separate, clearly-labeled block. The user will confirm or correct each one before anything is written. Do not write files; do not invoke `git commit` or `gh pr edit` — draft only.
+
+If the working folder path isn't obvious, check the `reference_ai_working_folder.md` in auto-memory or ask the user before guessing.

--- a/.claude/commands/close-phase.md
+++ b/.claude/commands/close-phase.md
@@ -1,0 +1,30 @@
+---
+description: Close a project phase — tick the checklist, update plan.md status, archive acceptance results, append a SESSION-LOG entry. Drafts everything; waits for confirmation before writing.
+argument-hint: [phase-number]
+---
+
+Close phase $ARGUMENTS of this project. If no phase number was given, read `CONTEXT.md` and infer the current phase.
+
+## Files to load
+
+- `<working-folder>/CONTEXT.md` — current phase status
+- `<working-folder>/plan.md` — phase breakdown
+- `<working-folder>/phase-$ARGUMENTS-checklist.md` (or current `phase-N-checklist.md`)
+- `<working-folder>/SESSION-LOG.md` — last entry for context
+- `<working-folder>/acceptance-test-results.md` if it exists
+
+The working-folder path comes from `reference_ai_working_folder.md` in auto-memory. If that's not set, ask the user before guessing.
+
+## What to do
+
+1. **Tick remaining unchecked items** in the phase checklist. For each, find the matching merged PR (`gh pr list --state merged`) and add the PR number + merge date. If no PR exists for an item, flag it for human review rather than ticking blindly.
+2. **Update plan.md "Status" line** at the top to reflect phase closure (e.g. `Phase N complete ✅ (YYYY-MM-DD)`).
+3. **Update CONTEXT.md "Current Phase Status"** block — mark the closing phase complete, set the next phase posture (often "Deferred — no active work").
+4. **Archive acceptance results** if `acceptance-test-results.md` exists and is non-empty: rename to `acceptance-test-results-phase-$ARGUMENTS.md` and update the CONTEXT.md Reference section to point at the archive.
+5. **Draft a SESSION-LOG entry** for this session covering: focus, PRs landed, key decisions, non-obvious findings, open threads.
+
+## Hand back
+
+Show each change as a diff (or as the proposed file content if it's a new file). Wait for the user's confirmation per change before writing.
+
+Do not invoke `git commit` or push. The user commits the working-folder updates separately when they're ready.

--- a/.claude/commands/pull-ticket.md
+++ b/.claude/commands/pull-ticket.md
@@ -1,0 +1,98 @@
+---
+description: Pull a tracker ticket into a per-ticket scratchpad. Reads tracker config from CONTEXT.md, fetches ticket data via the relevant MCP (JIRA / GitHub Issues / Linear), creates tickets/<KEY>-<slug>.md from the kit's template, updates workspace-CONTEXT.md, appends to SESSION-LOG.md. Read/reference only — never pushes back to the tracker.
+argument-hint: <KEY>
+---
+
+I want to pull ticket `$ARGUMENTS` from the project's tracker into a per-ticket scratchpad. Read-only — do not push anything back to the tracker.
+
+## Step 1 — determine tracker config
+
+Read `CONTEXT.md` in the working folder. Find the **Tracker Configuration** section. If `../workspace-CONTEXT.md` exists, also read it — workspace-level tracker config takes precedence in workspace mode.
+
+Pull these values:
+
+- **Tracker type** (jira / github / linear / gitlab / shortcut / other / none)
+- **Project / team key** (e.g. `LX`, `INFRA`, `ENG`)
+- **MCP availability**
+
+Stop and ask the user before continuing if any of these hold:
+
+- Tracker type is `none` or `other` — there's no automated path; the user can either set up tracker config first or fall back to a manual stub.
+- MCP availability says `not installed` or `unknown` — confirm the relevant MCP is available before attempting to fetch.
+- The ticket key doesn't match the project key — e.g. tracker is JIRA project `LX` but the user asked for `INFRA-42`. This is usually a typo or wrong-project mistake.
+
+## Step 2 — fetch ticket data
+
+Use the tracker MCP that matches the configured type. **Read-only** operations only: get / view / search. Never create, edit, transition, or comment.
+
+- **JIRA** — use the JIRA MCP. Fetch: summary, description, acceptance criteria (or definition of done if AC isn't separate), status, assignee, sprint, parent epic if any.
+- **GitHub Issues** — use the GitHub MCP if available, otherwise fall back to `gh issue view <NUM> --json title,body,state,labels,assignees,milestone`. The issue lives at `<REPO_URL>/issues/<NUM>`.
+- **Linear** — use the Linear MCP. Fetch: title, description, state, priority, AC, project / cycle.
+- **GitLab** — use the GitLab MCP if available, otherwise `glab issue view <NUM>` against the configured repo.
+- **Shortcut** — use the Shortcut MCP if available, otherwise pause and ask the user how to fetch.
+
+If the relevant MCP isn't available and there's no CLI fallback, stop and tell the user — don't silently produce a stub. The user can choose to install the MCP, install the CLI, or proceed with a manual stub.
+
+## Step 3 — create the ticket file
+
+**Determine the tickets directory:**
+
+- Workspace mode (`../workspace-CONTEXT.md` exists): tickets go in `../tickets/`. The `tickets/archive/` subdirectory should already exist from `bootstrap.sh --workspace`.
+- Single-repo mode: tickets go in `<working-folder>/tickets/`. Create `tickets/` and `tickets/archive/` with `mkdir -p` if they don't exist.
+
+**Generate the slug:**
+
+- Take the ticket title from the tracker.
+- Lowercase, replace non-alphanumeric runs with `-`, trim leading/trailing dashes, cap at ~40 chars.
+- Example: title "Fix LB path-routing for /api/v2" → slug `fix-lb-path-routing-for-api-v2`.
+
+**File path:** `<tickets-dir>/<KEY>-<slug>.md` (e.g. `tickets/LX-1234-fix-lb-path-routing.md`).
+
+**Idempotence guard:** if a file matching `<KEY>-*.md` already exists in either `tickets/` or `tickets/archive/`, stop and ask the user before overwriting. They may have an existing scratchpad with notes worth preserving.
+
+**Fill the template:** use the kit's `templates/workspace/ticket.md` shape (already in the workspace if `bootstrap.sh --workspace` ran; otherwise read from the kit checkout). Substitute:
+
+- `{{KEY}}` → the ticket key
+- `{{TITLE}}` → from the tracker
+- `{{TRACKER_URL}}` → canonical tracker link to this specific ticket
+- `{{Open | In progress | Blocked | Done}}` → actual status (map tracker-specific status names to one of these four; note the tracker-native name in parens if it doesn't fit cleanly)
+- `{{YYYY-MM-DD}}` → today's date (both Created and Last touched)
+- **Summary section** → fill from the tracker description (one paragraph, plain prose; don't paste the entire ticket body if it's long — that's what the tracker is for)
+- **Acceptance criteria** → copy verbatim from the tracker. Convert numbered/bulleted lists to `- [ ] {{...}}` checkboxes if not already.
+- **Working notes** → leave empty (Claude/user fills as work happens)
+- **Branches / PRs / commits** → leave the example row in place as a structure hint
+- **Decisions / blockers** → leave empty
+- **Cross-references → Sessions** → leave empty (filled by `/session-end` or `/close-phase`)
+- **Cross-references → Related tickets** → if the tracker shows links / blockers / dependencies, list them; otherwise leave the placeholder
+
+## Step 4 — update workspace-CONTEXT.md (workspace mode only)
+
+If in workspace mode, open `../workspace-CONTEXT.md`. Find the `## Tickets` section, then the `**Active:**` sub-section.
+
+If the placeholder example bullet is still there (`- [{{KEY}}](tickets/{{KEY}}-{{slug}}.md) — {{one-line summary; repos touched}}`), replace it. Otherwise append a new bullet:
+
+```
+- [<KEY>](tickets/<KEY>-<slug>.md) — <one-line summary from tracker>; <repos touched, or "TBD" if unknown>
+```
+
+Bump the `**Last updated:**` date at the top of `workspace-CONTEXT.md`.
+
+## Step 5 — log it
+
+Stage (do not yet write) a one-line addition to the working folder's `SESSION-LOG.md` for the current session entry:
+
+```
+- Pulled <KEY> — <one-line summary>
+```
+
+If `/session-end` runs later this session, this line should be folded into the session entry's "Branches/PRs/Tickets" block. If you're appending to an in-flight entry, append directly.
+
+## Step 6 — hand back
+
+Print:
+
+1. Path to the new ticket file (e.g. `tickets/LX-1234-fix-lb-path-routing.md`).
+2. First three lines of the file: key + title, tracker link, status.
+3. A reminder: "Tracker is source of truth — re-run `/pull-ticket <KEY>` if the tracker changes. This file is the local working scratchpad."
+
+Then stop. Don't propose a branch name, don't open a worktree, don't start work. The user drives next — typically by checking the kit's CONVENTIONS.md (Ticket-driven workflows section) for the branch / PR / commit shape and starting from there.

--- a/.claude/commands/refresh-context.md
+++ b/.claude/commands/refresh-context.md
@@ -1,0 +1,31 @@
+---
+description: Re-read CONTEXT.md, SESSION-LOG.md, and the current phase checklist mid-session — for picking up changes after a /close-phase or /session-end writeback, or re-anchoring on a long session. Same flow as Prompt 5 in PROMPTS.md.
+---
+
+Re-read my AI working folder so the rest of this session uses the latest state.
+
+## Files to reload
+
+1. `<working-folder>/CONTEXT.md` — project status, current phase, working rules
+2. `<working-folder>/SESSION-LOG.md` — focus on the most recent entry
+3. The current phase's checklist (`<working-folder>/phase-<N>-checklist.md`)
+
+The working-folder path comes from `reference_ai_working_folder.md` in auto-memory. If that's not set, ask before guessing.
+
+## Hand back
+
+A short delta read (≤5 bullets):
+
+- Current phase / status per CONTEXT.md right now
+- Most recent SESSION-LOG entry — date, focus, what landed
+- Any unticked items in the current phase checklist
+- Open threads / next-steps from the latest log entry
+- One sentence on what shifted since you last had this context loaded, if anything obvious — otherwise "no obvious deltas"
+
+Then wait for my next instruction. Don't propose changes yet.
+
+## Notes
+
+- Useful right after running `/close-phase` or `/session-end` — the writeback updates the docs, but the active session is still working from the pre-writeback version until told to reload.
+- The "what shifted" bullet is intentionally hedged with the fallback. Claude doesn't have perfect visibility into its own loaded context; honest framing beats false confidence.
+- For a cold session start, use `/session-start` instead — this command assumes you're already mid-session.

--- a/.claude/commands/session-end.md
+++ b/.claude/commands/session-end.md
@@ -1,0 +1,28 @@
+---
+description: End-of-session wrap-up — draft SESSION-LOG entry, suggest CONTEXT.md status updates, flag unticked checklist items, draft any new memory entries. Same flow as Prompt 3 in PROMPTS.md, packaged as a slash command.
+---
+
+We're wrapping up this session. Help me apply the end-of-session hygiene.
+Do NOT edit any files yet — draft everything, show me, and wait for my
+confirmation before writing anything.
+
+1. Draft a SESSION-LOG.md entry for today:
+   - Date (YYYY-MM-DD)
+   - 1-line focus
+   - Branches touched / PRs opened, merged, or still open (with numbers)
+   - Decisions, rule changes, or gotchas worth recording for next session
+   - Open threads ("what we'd pick up next time")
+
+2. Suggest whether CONTEXT.md's "Current Phase Status" line needs a bump,
+   based on what changed this session. If so, propose the new wording.
+
+3. Scan the current phase-<N>-checklist.md:
+   - Flag items that landed this session but aren't yet ticked
+   - Flag ticked items missing a branch or PR number
+
+4. Flag any preference or rule that came up more than once this session —
+   those are candidates for a new feedback_*.md memory file. Draft the
+   feedback entry if applicable.
+
+Show me each of these as a separate section. I'll confirm each before
+anything is written.

--- a/.claude/commands/session-start.md
+++ b/.claude/commands/session-start.md
@@ -1,0 +1,30 @@
+---
+description: Load the working folder's CONTEXT.md, SESSION-LOG.md, and current phase checklist into the session, then hand back a grounding summary. Same flow as Prompt 1 in PROMPTS.md, packaged as a slash command.
+---
+
+Before we start, read these files in my AI working folder, in order:
+
+1. `<working-folder>/CONTEXT.md` — project overview, working rules, current phase
+2. `<working-folder>/SESSION-LOG.md` — chronological session history
+3. The current phase's checklist (e.g. `<working-folder>/phase-<N>-checklist.md`)
+
+These are my persistent project context — they live outside the repo and hold scope, decisions, and current status. Don't edit them unless I ask; updates happen at session end.
+
+The working-folder path comes from `reference_ai_working_folder.md` in auto-memory. If that's not set, ask before guessing.
+
+## Hand back
+
+A 3–5 bullet summary of:
+
+- Where we are in the project (current phase + status)
+- What landed most recently (most recent SESSION-LOG entry — date, focus, PRs)
+- Any open threads / next-steps called out in the latest log entry
+- Any unticked items in the current phase checklist worth flagging
+- The likely starting point for this session, if obvious
+
+Then wait for my next instruction. Don't propose changes or start coding yet.
+
+## When to use a different command
+
+- **Resuming mid-PR with a branch in flight** → use Prompt 4 in PROMPTS.md instead. It loads the same context plus a structured branch / PR / CI assessment.
+- **Refreshing context mid-session** (after a `/close-phase` or `/session-end` writeback) → use `/refresh-context`. This command is for cold session starts.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,20 @@ Same shape as tracker, but in `memory-templates/ci/` and `tests/bootstrap_ci.bat
 
 Edit the relevant `.md` file. The `link-check.yml` workflow runs `lychee --offline` on docs PRs — broken relative links will fail CI.
 
+### Slash commands or agents
+
+The canonical sources for the kit's slash commands and agents live under `templates/.claude/commands/` and `templates/.claude/agents/` — that's what `bootstrap.sh` copies into newly-bootstrapped projects.
+
+The kit also dogfoods these files: identical copies live at `.claude/commands/` and `.claude/agents/` in the repo root so contributors can use `/session-start`, `/close-phase`, etc. while working on the kit itself. The two trees must stay byte-identical.
+
+If you edit anything under `templates/.claude/commands/` or `templates/.claude/agents/`, run:
+
+```bash
+scripts/sync-claude-dogfood.sh
+```
+
+…to update the dogfood copies. The `tests/dogfood_claude_in_sync.bats` test enforces this in CI — it'll fail with a sync hint if the trees diverge.
+
 ---
 
 ## Branch naming

--- a/scripts/sync-claude-dogfood.sh
+++ b/scripts/sync-claude-dogfood.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Sync the kit's own .claude/ slash commands and agents from the canonical
+# templates/ source.
+#
+# The kit dogfoods its own slash commands and agents, so contributors who
+# clone the repo can use /session-start, /close-phase, /session-end, etc.
+# while working on the kit itself. The canonical copy lives in
+# templates/.claude/ (which ships to bootstrapped projects via bootstrap.sh);
+# the dogfood copy in .claude/ must stay byte-identical.
+#
+# Run this after editing anything under templates/.claude/commands/ or
+# templates/.claude/agents/. CI verifies the two trees match via
+# tests/dogfood_claude_in_sync.bats.
+
+set -euo pipefail
+
+KIT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+sync_dir() {
+  local sub="$1"
+  local src="$KIT_ROOT/templates/.claude/$sub"
+  local dst="$KIT_ROOT/.claude/$sub"
+
+  if [ ! -d "$src" ]; then
+    echo "error: source missing: $src" >&2
+    exit 1
+  fi
+
+  echo "Syncing .claude/$sub/ from templates/.claude/$sub/..."
+  rm -rf "$dst"
+  mkdir -p "$dst"
+  cp -R "$src/." "$dst/"
+}
+
+sync_dir commands
+sync_dir agents
+
+echo "Done. Review the diff with 'git diff .claude/' and commit if it looks right."

--- a/tests/dogfood_claude_in_sync.bats
+++ b/tests/dogfood_claude_in_sync.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+# The kit dogfoods its own slash commands and agents — .claude/commands/ and
+# .claude/agents/ at the repo root must stay byte-identical with their
+# canonical sources under templates/.claude/. Bootstrap copies templates/ into
+# new working folders, so any drift means the kit's own copy diverges from
+# what ships to adopters.
+#
+# Sync via scripts/sync-claude-dogfood.sh after editing templates/.claude/.
+
+load 'helpers'
+
+@test "templates/.claude/commands/ matches .claude/commands/ (kit dogfoods its commands)" {
+  run diff -r "$KIT_ROOT/templates/.claude/commands" "$KIT_ROOT/.claude/commands"
+  if [ "$status" -ne 0 ]; then
+    echo "templates/.claude/commands/ and .claude/commands/ have diverged."
+    echo "Run scripts/sync-claude-dogfood.sh to bring them back in sync."
+    echo "Diff output:"
+    echo "$output"
+    return 1
+  fi
+}
+
+@test "templates/.claude/agents/ matches .claude/agents/ (kit dogfoods its agents)" {
+  run diff -r "$KIT_ROOT/templates/.claude/agents" "$KIT_ROOT/.claude/agents"
+  if [ "$status" -ne 0 ]; then
+    echo "templates/.claude/agents/ and .claude/agents/ have diverged."
+    echo "Run scripts/sync-claude-dogfood.sh to bring them back in sync."
+    echo "Diff output:"
+    echo "$output"
+    return 1
+  fi
+}


### PR DESCRIPTION
Closes #105.

## Summary

The kit's slash commands and agents (`session-start`, `close-phase`, `session-end`, `refresh-context`, `pull-ticket`, `code-reviewer`, `session-summarizer`) live canonically in `templates/.claude/` and ship to bootstrapped projects via `bootstrap.sh`. The kit's own repo didn't have them installed in `.claude/`, so contributors working on the kit couldn't use them without copying by hand.

This PR mirrors the canonical files into `.claude/commands/` and `.claude/agents/` at the repo root and adds a sync test to keep the two trees byte-identical.

## Changes

- **`.claude/commands/` and `.claude/agents/`** — new tracked dirs, byte-identical mirrors of `templates/.claude/{commands,agents}/`. Contributors get the slash commands on clone.
- **`scripts/sync-claude-dogfood.sh`** — one-command helper to re-mirror after editing `templates/.claude/`.
- **`tests/dogfood_claude_in_sync.bats`** — diffs the two trees and fails with a clear "run `scripts/sync-claude-dogfood.sh`" hint on divergence. Runs in the existing bats CI on PRs that touch `tests/`, `templates/`, etc.
- **`CONTRIBUTING.md`** — new "Slash commands or agents" subsection documenting the dogfood rule and pointing at the sync script.

The kit has a real working folder at `~/Documents/Claude/Projects/claude-project-kit/`, so the dogfooded commands actually work when invoked while contributing to the kit.

## Out of scope

- #83 (account-level `~/.claude/` install) — separate concern.
- `templates/.claude/README.md` is intentionally not mirrored — that file is the staged-templates explainer for bootstrapped projects, not for the kit's own use.
- `.claude/settings.local.json` stays per-user, not committed.

## Test plan

- [x] `bats tests/dogfood_claude_in_sync.bats` — both new tests pass against the synced trees
- [x] Drift smoke test — appended a line to `.claude/commands/session-start.md`, ran the test, confirmed it fails with the sync hint, ran the script to re-sync, test passes again
- [x] `bats tests/` full suite — 118 tests pass (no regressions in any of the existing `bootstrap_*.bats` or `pull_ticket.bats`)
- [x] `scripts/sync-claude-dogfood.sh` — runs idempotently; second run produces no git diff
- [ ] CI bats workflow runs and passes on the PR
- [ ] CI link-check runs and passes (CONTRIBUTING.md change)