### PR TITLE
docs: document one-time additionalDirectories setup for working folder

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -263,6 +263,7 @@ Every step has a manual alternative — see [SETUP.md §Manual alternative](SETU
 ## What the kit does NOT do
 
 - **Doesn't modify your target repo.** Templates land in the working folder; memory lands in the harness path. Your repo stays clean.
+- **Doesn't write to `~/.claude/settings.json`.** That file is global, cross-project; the kit shouldn't silently mutate it. To stop the per-read permission prompts on the working folder, add its parent directory to `permissions.additionalDirectories` once by hand — see [SETUP.md §1](SETUP.md#1-pick-a-working-folder-location) for the exact JSON.
 - **Doesn't make network calls.** No telemetry, no auto-update check, no remote dependencies at runtime.
 - **Doesn't manage your tracker / CI.** It seeds memory so Claude knows the conventions; it doesn't create JIRA projects, push GitHub Actions workflows, or open issues for you. Tracker integration (`/pull-ticket`, `pull-ticket.sh`) is **one-way read** — fetches summary / AC / status, never creates / edits / transitions / comments. See [ADR-0001 §D3](docs/adr/0001-multi-repo-folder-model.md).
 - **Doesn't replace `CLAUDE.md`.** They're complementary — the kit handles cross-session state and preferences; `CLAUDE.md` handles in-repo guidance Claude reads automatically.

--- a/SETUP.md
+++ b/SETUP.md
@@ -27,6 +27,20 @@ Avoid:
 
 Whatever you pick, the **repo stays the repo; the working folder stays separate**. Never commit it.
 
+> **One-time: tell Claude Code to trust the working-folder root.** Because the working folder lives outside any repo, Claude Code prompts for permission every time it reads or writes `CONTEXT.md` / `SESSION-LOG.md` / phase checklists. Add the **parent directory** of your working folders to `permissions.additionalDirectories` in `~/.claude/settings.json` once and the prompts stop — for every kit project that lives under that root, on both the macOS desktop app and the CLI.
+>
+> ```json
+> {
+>   "permissions": {
+>     "additionalDirectories": [
+>       "~/Documents/Claude/Projects/"
+>     ]
+>   }
+> }
+> ```
+>
+> Adjust the path to match wherever you keep your working folders (`~/claude-projects/`, a synced drive, etc.). One entry covers every project underneath it. The kit doesn't write this for you — `~/.claude/settings.json` is global, and a per-project bootstrap shouldn't silently mutate cross-project state.
+
 > Throughout this guide, `<framework-dir>` means wherever you've cloned/extracted this kit (e.g. `~/Code/claude-project-kit`), and `<working-folder>` means the path you just picked above.
 
 ---


### PR DESCRIPTION
## Summary

Closes #109. Adds a one-time setup callout to SETUP.md §1 explaining how to allowlist the working-folder parent directory via `permissions.additionalDirectories` in `~/.claude/settings.json`, and a complementary note in FEATURES.md "What the kit does NOT do" clarifying why the kit doesn't write that setting itself.

The kit pushes users to put working folders *outside* any repo (e.g. `~/Documents/Claude/Projects/<project>/`), but the Claude Code permission model treats those reads/writes as out-of-scope and prompts every time. One entry under `additionalDirectories` covers every kit project under that root, on both the desktop app and the CLI.

## Why doc-only, not bootstrap

`~/.claude/settings.json` is global, cross-project state. A per-project bootstrap silently mutating it would violate the kit's existing safety stance ("never override the harness without the user knowing"). The right pattern is one-time human config covering the parent directory.

## Test plan

- [x] [SETUP.md §1](https://github.com/IamMrCupp/claude-project-kit/blob/docs/trust-working-folder-setup/SETUP.md#1-pick-a-working-folder-location) renders the new callout block correctly with the JSON snippet.
- [x] [FEATURES.md "What the kit does NOT do"](https://github.com/IamMrCupp/claude-project-kit/blob/docs/trust-working-folder-setup/FEATURES.md#what-the-kit-does-not-do) cross-link to SETUP §1 anchor resolves.
- [x] No section renumbering — verified existing references in README.md and PROMPTS.md to "SETUP.md step 2" / "§7" are still correct.
- [x] `lychee` link-check CI passes (the new internal anchor `#1-pick-a-working-folder-location` already exists; the addition is content-only).