### PR TITLE
docs: clarify additionalDirectories setup is per-machine

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -263,7 +263,7 @@ Every step has a manual alternative — see [SETUP.md §Manual alternative](SETU
 ## What the kit does NOT do
 
 - **Doesn't modify your target repo.** Templates land in the working folder; memory lands in the harness path. Your repo stays clean.
-- **Doesn't write to `~/.claude/settings.json`.** That file is global, cross-project; the kit shouldn't silently mutate it. To stop the per-read permission prompts on the working folder, add its parent directory to `permissions.additionalDirectories` once by hand — see [SETUP.md §1](SETUP.md#1-pick-a-working-folder-location) for the exact JSON.
+- **Doesn't write to `~/.claude/settings.json`.** That file is global, cross-project, and per-user-per-machine; the kit shouldn't silently mutate it, and it's not synced from the kit repo. To stop the per-read permission prompts on the working folder, add its parent directory to `permissions.additionalDirectories` once by hand on each machine you work from — see [SETUP.md §1](SETUP.md#1-pick-a-working-folder-location) for the exact JSON.
 - **Doesn't make network calls.** No telemetry, no auto-update check, no remote dependencies at runtime.
 - **Doesn't manage your tracker / CI.** It seeds memory so Claude knows the conventions; it doesn't create JIRA projects, push GitHub Actions workflows, or open issues for you. Tracker integration (`/pull-ticket`, `pull-ticket.sh`) is **one-way read** — fetches summary / AC / status, never creates / edits / transitions / comments. See [ADR-0001 §D3](docs/adr/0001-multi-repo-folder-model.md).
 - **Doesn't replace `CLAUDE.md`.** They're complementary — the kit handles cross-session state and preferences; `CLAUDE.md` handles in-repo guidance Claude reads automatically.

--- a/SETUP.md
+++ b/SETUP.md
@@ -27,7 +27,7 @@ Avoid:
 
 Whatever you pick, the **repo stays the repo; the working folder stays separate**. Never commit it.
 
-> **One-time: tell Claude Code to trust the working-folder root.** Because the working folder lives outside any repo, Claude Code prompts for permission every time it reads or writes `CONTEXT.md` / `SESSION-LOG.md` / phase checklists. Add the **parent directory** of your working folders to `permissions.additionalDirectories` in `~/.claude/settings.json` once and the prompts stop — for every kit project that lives under that root, on both the macOS desktop app and the CLI.
+> **One-time, per machine: tell Claude Code to trust the working-folder root.** Because the working folder lives outside any repo, Claude Code prompts for permission every time it reads or writes `CONTEXT.md` / `SESSION-LOG.md` / phase checklists. Add the **parent directory** of your working folders to `permissions.additionalDirectories` in `~/.claude/settings.json` once and the prompts stop — for every kit project that lives under that root, on both the macOS desktop app and the CLI.
 >
 > ```json
 > {
@@ -40,6 +40,8 @@ Whatever you pick, the **repo stays the repo; the working folder stays separate*
 > ```
 >
 > Adjust the path to match wherever you keep your working folders (`~/claude-projects/`, a synced drive, etc.). One entry covers every project underneath it. The kit doesn't write this for you — `~/.claude/settings.json` is global, and a per-project bootstrap shouldn't silently mutate cross-project state.
+>
+> **If you use the kit on more than one machine** (work laptop + personal desktop, etc.), repeat the edit on each. `~/.claude/settings.json` is local user config, not part of the kit repo, so cloning the kit on a new machine won't bring it along.
 
 > Throughout this guide, `<framework-dir>` means wherever you've cloned/extracted this kit (e.g. `~/Code/claude-project-kit`), and `<working-folder>` means the path you just picked above.
 


### PR DESCRIPTION
## Summary

Closes #112. Tightens the language added in PR #110 to make the multi-machine implication explicit.

- **SETUP.md §1** — opens the callout with "**One-time, per machine:**" and adds a closing paragraph noting that `~/.claude/settings.json` is local user config and won't follow you when you clone the kit onto a second machine.
- **FEATURES.md "What the kit does NOT do"** — the existing `~/.claude/settings.json` bullet now names "per-user-per-machine" and "not synced from the kit repo" explicitly, plus "on each machine you work from" in the action sentence.

## Why

A user (me) realized after applying the setting on a personal laptop that the work laptop tomorrow morning would still prompt — because the file is per-machine and the kit doesn't (and shouldn't) ship it. Existing wording said "one-time" but didn't disambiguate one-time-per-account vs one-time-per-machine. Two small word additions make the right behavior unambiguous without bloating the callout.

## Test plan

- [x] [SETUP.md §1](https://github.com/IamMrCupp/claude-project-kit/blob/docs/per-machine-trust-setup-clarification/SETUP.md#1-pick-a-working-folder-location) renders the callout cleanly with the new "per machine" header and closing paragraph.
- [x] [FEATURES.md "What the kit does NOT do"](https://github.com/IamMrCupp/claude-project-kit/blob/docs/per-machine-trust-setup-clarification/FEATURES.md#what-the-kit-does-not-do) bullet still cross-links to SETUP.md §1; new framing is "on each machine you work from."
- [x] No section renumbering, no anchor changes — pure wording tweak.
- [x] `lychee` link-check CI passes.