### PR TITLE
fix(bootstrap): surface per-repo bootstrap requirement in workspace mode

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -231,6 +231,8 @@ If a future change is *not* backwards-compatible (rare for a docs-only kit — o
 
 ## Workspace mode (multi-repo initiatives)
 
+> **Run `bootstrap.sh --workspace` once from EACH repo's root.** Both the per-repo subfolder and auto-memory are keyed to each repo's path (auto-memory at `~/.claude/projects/<sanitized-repo-path>/memory/`), so every repo participating in the workspace needs its own bootstrap. The first run creates the workspace folder + `workspace-CONTEXT.md`; subsequent runs add new per-repo subfolders without recreating workspace-level files. Skip this step on a sibling repo and `/session-start` will fail there — the repo won't have `reference_ai_working_folder.md` in auto-memory.
+
 When a single piece of work spans multiple repos (e.g. Terraform environment definitions in one repo and modules in another), use `--workspace` so bootstrap creates a workspace folder above per-repo subfolders. The model is documented in [ADR-0001](docs/adr/0001-multi-repo-folder-model.md); summary:
 
 ```

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -616,11 +616,13 @@ fi
 
 mkdir -p "$WORKING_FOLDER"
 
+WORKSPACE_FIRST_REPO=0
 if [ "$WORKSPACE_MODE" -eq 1 ]; then
   mkdir -p "$WORKSPACE_DIR/tickets/archive"
   if [ ! -f "$WORKSPACE_DIR/workspace-CONTEXT.md" ]; then
     cp "$KIT_ROOT/templates/workspace/workspace-CONTEXT.md" "$WORKSPACE_DIR/"
     echo "  ✓ Created workspace at $WORKSPACE_DIR (workspace-CONTEXT.md, tickets/archive/)"
+    WORKSPACE_FIRST_REPO=1
   else
     echo "  ✓ Existing workspace at $WORKSPACE_DIR — adding repo subfolder $WORKSPACE_REPO_NAME"
   fi
@@ -713,6 +715,27 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
 else
   echo "  3. Memory was skipped (--skip-memory). See SETUP.md §Manual alternative"
   echo "     if you want to seed it by hand later."
+fi
+
+if [ "$WORKSPACE_MODE" -eq 1 ]; then
+  echo
+  echo "  ⚠ Workspace mode — per-repo bootstrap required:"
+  echo
+  echo "    The per-repo subfolder and auto-memory are keyed to each repo's"
+  echo "    path, so this run only set them up for $REPO_ROOT."
+  if [ "$WORKSPACE_FIRST_REPO" -eq 1 ]; then
+    echo "    Every additional repo participating in this workspace needs its"
+    echo "    own bootstrap. For each sibling repo:"
+  else
+    echo "    Repeat for any other sibling repos that haven't been added yet:"
+  fi
+  echo
+  echo "        cd <sibling-repo>"
+  echo "        $SCRIPT_DIR/bootstrap.sh --workspace $WORKSPACE_DIR"
+  echo
+  echo "    Without that step, /session-start and other kit commands will fail"
+  echo "    in the sibling repo because reference_ai_working_folder.md won't"
+  echo "    be in its auto-memory. See SETUP.md §Workspace mode."
 fi
 echo
 echo "Prefer to fill the templates manually instead? See SETUP.md §3."

--- a/tests/bootstrap_workspace.bats
+++ b/tests/bootstrap_workspace.bats
@@ -177,6 +177,42 @@ teardown() { bootstrap_teardown; }
   grep -q '^- \*\*Project / team key:\*\* LX$' "$WS/$REPO_NAME/CONTEXT.md"
 }
 
+@test "--workspace first-repo run prints per-repo bootstrap guidance" {
+  WS="$TEST_TMP/lx-platform"
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Workspace mode — per-repo bootstrap required"* ]]
+  [[ "$output" == *"Every additional repo"* ]]
+  [[ "$output" == *"bootstrap.sh --workspace $WS"* ]]
+  [[ "$output" == *"reference_ai_working_folder.md"* ]]
+}
+
+@test "--workspace second-repo run prints per-repo guidance with reuse framing" {
+  WS="$TEST_TMP/lx-platform"
+
+  # First run — establishes workspace
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -eq 0 ]
+
+  # Sibling repo
+  REPO2="$TEST_TMP/repo2"
+  mkdir -p "$REPO2"
+  git -C "$REPO2" init -q
+  cd "$REPO2"
+
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Workspace mode — per-repo bootstrap required"* ]]
+  [[ "$output" == *"Repeat for any other sibling repos"* ]]
+  [[ "$output" != *"Every additional repo"* ]]
+}
+
+@test "single-repo bootstrap does NOT print workspace per-repo guidance" {
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Workspace mode — per-repo bootstrap required"* ]]
+}
+
 @test "--workspace re-run against existing workspace does not re-substitute tracker config" {
   WS="$TEST_TMP/lx-platform"
 


### PR DESCRIPTION
## Summary

- Workspace bootstraps now print an explicit, hard-to-miss callout in the post-success "Next steps" output explaining that auto-memory is keyed per repo and bootstrap must be re-run from each sibling repo's root. Includes a copy-pasteable invocation.
- First-repo runs and additional-repo runs get distinct framing ("Every additional repo …" vs "Repeat for any other sibling repos …").
- Promotes the requirement to a top-of-section callout in `SETUP.md` §Workspace mode so the requirement is visible before the user runs anything.

Closes #116.

## Why

Surfaced during a real dogfood at work — single workspace bootstrap, opened Claude Code in the second repo without re-bootstrapping, `/session-start` failed because that repo's auto-memory was empty. ~2 days lost re-deriving state. The requirement was already documented in `bootstrap.sh -h` and buried deep in `SETUP.md`, but never surfaced where a user actually sees it (post-bootstrap output, top of the workspace section).

Scope kept tight: output + docs only. The complementary "make `/session-start` degrade gracefully when the memory file is missing" idea overlaps with #82 and stays there.

## Test plan

- [x] `bats tests/` — full suite passes (121/121, +3 new tests in `bootstrap_workspace.bats`).
  - [x] `--workspace first-repo run prints per-repo bootstrap guidance` — verifies callout text + copy-pasteable command + reference to `reference_ai_working_folder.md`.
  - [x] `--workspace second-repo run prints per-repo guidance with reuse framing` — verifies the additional-repo wording differs from first-repo wording.
  - [x] `single-repo bootstrap does NOT print workspace per-repo guidance` — regression check.
- [x] Eyeballed actual workspace bootstrap output in a temp dir; callout reads cleanly with `--skip-memory` and with full memory seeding.
- [ ] Lychee link-check passes (CI runs on push; not installed locally).

## Out of scope

- Graceful degradation in `/session-start` when `reference_ai_working_folder.md` is missing — separate concern, tracked in #82.
- Auto-detecting sibling repos from the workspace root — would require a way to enumerate the user's repo paths, which is over-design for a docs-shaped kit.