### PR TITLE
feat(scripts): add sync-memory.sh helper for kit-on-kit memory drift

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -178,6 +178,8 @@ Anything that can't be derived stays as `{{PLACEHOLDER}}` so it's grep-able. The
 
 The memory files are **starters**, not commandments. Prune what doesn't apply, add your own, keep `MEMORY.md` (the index) in sync. The harness loads `MEMORY.md` into context every session, so it stays small (under ~150 lines is a reasonable target).
 
+When the kit ships new starter rules, `scripts/sync-memory.sh <memory-dir>` copies any missing templates into an existing auto-memory dir without overwriting customized files. Skips `MEMORY.md`, `project_current.md`, and `user_role.md` (user-curated). See [SETUP.md §Upgrading an existing project](SETUP.md#upgrading-an-existing-project).
+
 ---
 
 ## Phase-based planning docs

--- a/SETUP.md
+++ b/SETUP.md
@@ -213,7 +213,11 @@ For fully filled-in references, see [`examples/widget-tracker/CONTEXT.md`](examp
    ```bash
    cp <kit-dir>/templates/<NEW_FILE>.md <working-folder>/
    ```
-3. **New files in `memory-templates/`** — copy into your auto-memory dir:
+3. **New files in `memory-templates/`** — easiest path is the sync helper, which copies any missing templates into your auto-memory without overwriting existing files:
+   ```bash
+   <kit-dir>/scripts/sync-memory.sh ~/.claude/projects/<sanitized-path>/memory
+   ```
+   Pass `--dry-run` first to preview. The helper skips `MEMORY.md`, `project_current.md`, and `user_role.md` (user-curated) and prints suggested `MEMORY.md` index lines for the new entries — paste the ones you want into your `MEMORY.md` by hand. To copy a single template by hand instead:
    ```bash
    cp <kit-dir>/memory-templates/<NEW_FILE>.md ~/.claude/projects/<sanitized-path>/memory/
    ```

--- a/scripts/sync-memory.sh
+++ b/scripts/sync-memory.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Sync missing memory-templates/*.md into a target auto-memory directory.
+#
+# Bootstrap seeds memory at first-run only. When the kit ships new starter
+# memory files, existing adopters (and the kit's own dogfood memory) drift
+# behind. This helper copies any template not already present in the target
+# memory dir, never overwrites existing files, and never touches user-curated
+# files (MEMORY.md, project_current.md, user_role.md).
+#
+# Run after pulling kit updates if you want to absorb new starter rules.
+# Idempotent — re-running is a no-op once everything is in sync.
+set -euo pipefail
+
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "error: sync-memory.sh requires bash" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KIT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATES_DIR="$KIT_ROOT/memory-templates"
+
+# Files in memory-templates/ that are user-customized scaffolds (not generic
+# rules) and must NEVER be auto-synced — overwriting them would clobber the
+# user's project notes / role profile / curated index.
+SKIP_FILES=(MEMORY.md project_current.md user_role.md)
+
+usage() {
+  cat <<EOF
+Usage: sync-memory.sh [options] <memory-dir>
+
+Sync missing memory-templates/*.md into <memory-dir>. Never overwrites
+existing files. Never touches MEMORY.md, project_current.md, or
+user_role.md (those are user-customized).
+
+Arguments:
+  <memory-dir>   Absolute path to an auto-memory directory.
+                 Typically ~/.claude/projects/<sanitized-repo-path>/memory/.
+
+Options:
+  --dry-run      Print what would be copied; write nothing.
+  -h, --help     Show this help and exit.
+
+Examples:
+  # Sync the kit's own dogfood memory after pulling kit updates
+  sync-memory.sh ~/.claude/projects/-Users-you-Code-claude-project-kit/memory
+
+  # Preview without writing
+  sync-memory.sh --dry-run ~/.claude/projects/.../memory
+
+After files copy, the script prints suggested MEMORY.md index lines for
+the new entries — paste the ones you want into your MEMORY.md. The
+script never edits MEMORY.md directly.
+EOF
+}
+
+is_skipped() {
+  local name="$1"
+  local skip
+  for skip in "${SKIP_FILES[@]}"; do
+    [ "$name" = "$skip" ] && return 0
+  done
+  return 1
+}
+
+# Extract the matching MEMORY.md index line for a memory file, if any.
+# Reads memory-templates/MEMORY.md and returns the line that links to the
+# file (e.g. "- [Title](feedback_foo.md) — hook"). Empty string if not found.
+suggested_index_line() {
+  local name="$1"
+  local index_src="$TEMPLATES_DIR/MEMORY.md"
+  [ -f "$index_src" ] || return 0
+  grep -F "($name)" "$index_src" || true
+}
+
+DRY_RUN=0
+TARGET=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --*) echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *)
+      if [ -z "$TARGET" ]; then
+        TARGET="$1"
+      else
+        echo "error: unexpected extra argument: $1" >&2
+        usage >&2
+        exit 2
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$TARGET" ]; then
+  echo "error: missing <memory-dir> argument" >&2
+  usage >&2
+  exit 2
+fi
+
+case "$TARGET" in
+  "~") TARGET="$HOME" ;;
+  "~/"*) TARGET="$HOME/${TARGET#"~/"}" ;;
+esac
+
+case "$TARGET" in
+  /*) ;;
+  *) echo "error: <memory-dir> must be an absolute path (got: $TARGET)" >&2; exit 2 ;;
+esac
+
+if [ ! -d "$TEMPLATES_DIR" ]; then
+  echo "error: kit memory-templates/ not found at $TEMPLATES_DIR" >&2
+  exit 1
+fi
+
+if [ ! -d "$TARGET" ]; then
+  echo "error: target memory dir does not exist: $TARGET" >&2
+  echo "       Run bootstrap.sh first to seed initial memory." >&2
+  exit 1
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "=== DRY RUN — no files will be written ==="
+fi
+echo "Source:  $TEMPLATES_DIR"
+echo "Target:  $TARGET"
+echo
+
+COPIED=()
+SKIPPED_EXISTING=()
+SKIPPED_RESERVED=()
+
+for src in "$TEMPLATES_DIR"/*.md; do
+  [ -e "$src" ] || continue
+  name="$(basename "$src")"
+
+  if is_skipped "$name"; then
+    SKIPPED_RESERVED+=("$name")
+    continue
+  fi
+
+  if [ -e "$TARGET/$name" ]; then
+    SKIPPED_EXISTING+=("$name")
+    continue
+  fi
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "  + would copy $name"
+  else
+    cp "$src" "$TARGET/$name"
+    echo "  ✓ copied $name"
+  fi
+  COPIED+=("$name")
+done
+
+echo
+if [ "${#COPIED[@]}" -eq 0 ]; then
+  echo "Already in sync — no files to copy."
+  if [ "${#SKIPPED_RESERVED[@]}" -gt 0 ]; then
+    echo "Skipped (user-customized, never auto-synced): ${SKIPPED_RESERVED[*]}"
+  fi
+  exit 0
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "Would copy ${#COPIED[@]} file(s). Re-run without --dry-run to apply."
+else
+  echo "Copied ${#COPIED[@]} file(s) into $TARGET."
+fi
+
+echo
+echo "Suggested MEMORY.md additions (paste the ones you want):"
+echo
+for name in "${COPIED[@]}"; do
+  line="$(suggested_index_line "$name")"
+  if [ -n "$line" ]; then
+    echo "  $line"
+  else
+    echo "  - [TITLE]($name) — TODO: write a one-line hook"
+  fi
+done
+echo
+echo "MEMORY.md is user-curated; this script does not edit it directly."

--- a/tests/sync_memory.bats
+++ b/tests/sync_memory.bats
@@ -1,0 +1,147 @@
+#!/usr/bin/env bats
+# scripts/sync-memory.sh — copy missing memory templates into a target
+# auto-memory dir without overwriting existing files. Closes the dogfood-drift
+# class of bug (kit ships new starter rules; existing adopters' memory
+# silently falls behind).
+
+load 'helpers'
+
+SYNC="$KIT_ROOT/scripts/sync-memory.sh"
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  TARGET="$TEST_TMP/memory"
+  mkdir -p "$TARGET"
+}
+
+teardown() {
+  [ -n "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"
+}
+
+@test "sync-memory.sh -h prints usage" {
+  run "$SYNC" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: sync-memory.sh"* ]]
+  [[ "$output" == *"--dry-run"* ]]
+}
+
+@test "sync-memory.sh errors when no memory-dir arg" {
+  run "$SYNC"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"missing <memory-dir> argument"* ]]
+}
+
+@test "sync-memory.sh errors on unknown flag" {
+  run "$SYNC" --bogus "$TARGET"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown option"* ]]
+}
+
+@test "sync-memory.sh errors on relative path" {
+  run "$SYNC" relative/path
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be an absolute path"* ]]
+}
+
+@test "sync-memory.sh errors when target dir does not exist" {
+  run "$SYNC" "$TEST_TMP/does-not-exist"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"target memory dir does not exist"* ]]
+}
+
+@test "sync-memory.sh copies all generic templates into empty target" {
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+
+  # Every shipped template (except user-customized) should land in the target
+  for src in "$KIT_ROOT/memory-templates/"*.md; do
+    name="$(basename "$src")"
+    case "$name" in
+      MEMORY.md|project_current.md|user_role.md) continue ;;
+    esac
+    [ -f "$TARGET/$name" ]
+  done
+}
+
+@test "sync-memory.sh skips MEMORY.md, project_current.md, user_role.md" {
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+
+  [ ! -f "$TARGET/MEMORY.md" ]
+  [ ! -f "$TARGET/project_current.md" ]
+  [ ! -f "$TARGET/user_role.md" ]
+}
+
+@test "sync-memory.sh never overwrites an existing file" {
+  # Pre-seed target with a customized version of a known template
+  cat > "$TARGET/feedback_commit_format.md" <<'EOF'
+---
+name: customized
+---
+USER_EDITED_CONTENT
+EOF
+  ORIGINAL_HASH="$(md5 -q "$TARGET/feedback_commit_format.md" 2>/dev/null || md5sum "$TARGET/feedback_commit_format.md" | awk '{print $1}')"
+
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+
+  # File contents preserved
+  AFTER_HASH="$(md5 -q "$TARGET/feedback_commit_format.md" 2>/dev/null || md5sum "$TARGET/feedback_commit_format.md" | awk '{print $1}')"
+  [ "$ORIGINAL_HASH" = "$AFTER_HASH" ]
+  grep -q "USER_EDITED_CONTENT" "$TARGET/feedback_commit_format.md"
+}
+
+@test "sync-memory.sh is idempotent — second run is a no-op" {
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Already in sync"* ]]
+}
+
+@test "sync-memory.sh --dry-run writes nothing" {
+  run "$SYNC" --dry-run "$TARGET"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY RUN"* ]]
+  [[ "$output" == *"would copy"* ]]
+  [[ "$output" == *"Re-run without --dry-run"* ]]
+
+  # Nothing actually written
+  [ -z "$(ls -A "$TARGET" 2>/dev/null)" ]
+}
+
+@test "sync-memory.sh prints suggested MEMORY.md additions for copied files" {
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Suggested MEMORY.md additions"* ]]
+  # Index lines come from memory-templates/MEMORY.md, e.g. push_branches
+  [[ "$output" == *"feedback_push_branches.md"* ]]
+  [[ "$output" == *"MEMORY.md is user-curated"* ]]
+}
+
+@test "sync-memory.sh tilde expansion works" {
+  HOME_BACKUP="$HOME"
+  export HOME="$TEST_TMP"
+  mkdir -p "$HOME/mem"
+
+  run "$SYNC" "~/mem"
+  [ "$status" -eq 0 ]
+  [ -f "$HOME/mem/feedback_commit_format.md" ]
+
+  export HOME="$HOME_BACKUP"
+}
+
+@test "sync-memory.sh against a partially-populated target only copies missing" {
+  cp "$KIT_ROOT/memory-templates/feedback_commit_format.md" "$TARGET/"
+  cp "$KIT_ROOT/memory-templates/feedback_merge_strategy.md" "$TARGET/"
+
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+
+  # Pre-existing files NOT mentioned as copied
+  [[ "$output" != *"copied feedback_commit_format.md"* ]]
+  [[ "$output" != *"copied feedback_merge_strategy.md"* ]]
+  # Other files DID get copied
+  [[ "$output" == *"copied feedback_push_branches.md"* ]]
+}


### PR DESCRIPTION
## Summary

- New `scripts/sync-memory.sh <memory-dir>` copies any `memory-templates/*.md` not already present in a target auto-memory dir. Same write-once invariant as `bootstrap.sh` — never overwrites existing files.
- Skips user-customized files (`MEMORY.md`, `project_current.md`, `user_role.md`).
- Prints suggested `MEMORY.md` index lines for copied files (sourced from `memory-templates/MEMORY.md`); never edits the user's `MEMORY.md` directly.
- `--dry-run` and `-h/--help` flags. 13 bats tests covering all paths.
- Surfaces the script in `SETUP.md` §Upgrading and `FEATURES.md` Auto-memory.

Closes #121.

## Why

Same root cause as #116 — the kit's own dogfood isn't enforced. The kit's auto-memory was missing 5 of the 14 starter feedback files the kit currently ships (commit format, merge strategy, push branches, PR test plans, tick-on-pass, docs in sync). Result: I wrote a multi-line commit message because the rule wasn't loaded into context, and the user had to correct me explicitly.

The fix doesn't try to enforce parity automatically — that would require Claude-side logic and would fight the user's right to customize. It just makes the manual upgrade flow that's already documented in SETUP.md scriptable, testable, and idempotent so drift becomes a one-line fix rather than a manual `cp` chase.

## Test plan

- [x] `bats tests/sync_memory.bats` — 13/13 pass.
- [x] `bats tests/` — full suite 134/134 pass (no regressions).
- [x] Ran sync against the kit's own auto-memory after manual backfill: reports "Already in sync — no files to copy."
- [x] Ran `--dry-run` against an empty target dir: lists everything, writes nothing.
- [x] `-h` prints usage; missing arg / relative path / nonexistent target all error cleanly.
- [x] Lychee link-check passes (CI).

## Out of scope (deliberate)

- **Auto-detecting renamed files.** The script uses filename as the canonical identity. Same rule under a different filename will be flagged as missing. This surfaced once during this session (`feedback_no_claude_coauthor.md` → `feedback_no_ai_coauthor.md`) and was reconciled by hand. Worth tracking if it recurs but not worth automating now.
- **Auto-merging MEMORY.md.** Index is user-curated text. Suggested-additions output gives the user the lines to paste; safer than overwriting.
- **Working-folder template sync.** Same drift class could affect `templates/*.md` → working folder. `bootstrap.sh` is the canonical seed there and the upgrade docs already cover the manual `cp`. Defer until felt.

## Related

- #116 ([#119](https://github.com/IamMrCupp/claude-project-kit/pull/119)) — workspace per-repo bootstrap requirement (same kit-dogfood-not-enforced pattern).
- `scripts/sync-claude-dogfood.sh` + `tests/dogfood_claude_in_sync.bats` — the precedent this script copies in shape.