### PR TITLE
feat: durable bootstrap session via SESSION-LOG entry + /session-handoff

### DIFF
--- a/.claude/commands/session-handoff.md
+++ b/.claude/commands/session-handoff.md
@@ -1,0 +1,46 @@
+---
+description: Hand off mid-session — capture everything to disk now, no confirmation gate. Use when context is at risk (window pressure, switching machines, abrupt pause). Drafts and writes immediately; review on next session start.
+---
+
+We're handing this session off NOW. Capture everything to disk in one pass —
+do **not** wait for my confirmation. Persistence over polish: I will review on
+the next `/session-start`. The kit's normal `/session-end` flow drafts and waits
+for review; this command exists for moments when waiting risks losing work.
+
+1. Append a SESSION-LOG.md entry for today, using this shape:
+   - Date (YYYY-MM-DD)
+   - 1-line focus
+   - Branches touched / PRs opened, merged, or still open (with numbers)
+   - Decisions, rule changes, or gotchas worth recording for next session
+   - Open threads ("what we'd pick up next time")
+   Write the entry directly. If anything is uncertain, write your best guess
+   and mark it `[CLAUDE-INFERRED]` so I can correct on next session start.
+
+2. If `CONTEXT.md`'s "Current Phase Status" line is clearly out of date based
+   on what changed this session, update it. Mark the line `[CLAUDE-INFERRED]`
+   if the call was a judgment.
+
+3. Tick any items in `phase-<N>-checklist.md` that landed this session. If a
+   ticked item is missing a branch or PR number, leave a note in the SESSION-LOG
+   entry rather than guessing.
+
+4. If a preference or rule came up more than once this session, draft a
+   `feedback_*.md` memory file for it under the project's auto-memory dir
+   AND add a one-line entry to `MEMORY.md`. Better to write a draft I edit
+   later than to lose the rule.
+
+After writing, print a one-paragraph summary of what you wrote — what entries,
+what status changes, what new memory. That's the read-on-next-session
+checkpoint.
+
+## When to use this vs. `/session-end`
+
+- **`/session-end`** — stable end of a working session, you have time to review
+  drafts before they land. Default to this.
+- **`/session-handoff`** — hand-off interrupt: switching to Claude desktop,
+  context window pressure, abrupt pause, anything where waiting risks losing
+  work. Persistence > review.
+
+The trade-off is real: handoff occasionally writes something slightly off, which
+gets corrected on the next `/session-start` read. Strictly better than losing
+the session entirely.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -31,6 +31,10 @@ A feature-by-feature reference. For setup steps, see [SETUP.md](SETUP.md). For t
 - `--force` — override the working-folder check (auto-memory is **still** protected; existing memory files are never overwritten).
 - `--skip-memory` — seed the working folder only, leave `~/.claude/projects/<sanitized-path>/memory/` alone.
 
+### Initial SESSION-LOG entry
+
+Every successful run appends a factual "Bootstrap" entry to `<working-folder>/SESSION-LOG.md` capturing the date, mode (single-repo / workspace), working folder, repo path, tracker, CI, auto-memory location, kit version, and next-step pointers. Deterministic write — no LLM in the loop, no confirmation gate. The bootstrap-time state stays durable even if the user hands off before running `/session-end`. Pairs with `/session-handoff` to make the entire bootstrap-and-seed-prompt session resilient to interrupts.
+
 ```bash
 bootstrap.sh ~/Documents/Claude/Projects/foo --dry-run
 ```
@@ -227,12 +231,13 @@ These are **starters**. Edit the frontmatter (model, tool allowlist), customize 
 
 ## Starter slash commands
 
-Five slash commands stage in `<working-folder>/.claude/commands/`. Same activation pattern — copy `.claude/` into your target repo.
+Six slash commands stage in `<working-folder>/.claude/commands/`. Same activation pattern — copy `.claude/` into your target repo.
 
 - **`/session-start`** — packages Prompt 1 from `PROMPTS.md`. Loads `CONTEXT.md`, `SESSION-LOG.md`, and the current phase checklist; hands back a 3–5 bullet grounding summary. Use at the start of a fresh session.
 - **`/refresh-context`** — re-reads the working folder mid-session, after a `/close-phase` or `/session-end` writeback or when a long session has drifted. Hands back a delta read against the latest state.
 - **`/close-phase`** — runs the phase-close writeback (checklist tick, `plan.md` status bump, `CONTEXT.md` update, optional acceptance-results archive). Takes a phase number or infers from `CONTEXT.md`.
 - **`/session-end`** — packages Prompt 3 from `PROMPTS.md`. Drafts the four end-of-session updates (SESSION-LOG entry, CONTEXT bump, checklist scan, memory candidates) and waits for confirmation before writing.
+- **`/session-handoff`** — same drafting work as `/session-end`, but **writes immediately** without a confirmation gate. Use when waiting risks losing work: switching to Claude desktop, context-window pressure, abrupt pause. Persistence > polish; review on the next `/session-start`. Pairs with `bootstrap.sh`'s automatic Bootstrap entry — between the two, the bootstrap-and-seed-prompt session is durable end-to-end even if the user pauses without a clean wrap-up.
 - **`/pull-ticket <KEY>`** — packages Prompt 6 from `PROMPTS.md`. Fetches a tracker ticket (JIRA / GitHub Issues / Linear / GitLab / Shortcut) via the relevant MCP, creates `tickets/<KEY>-<slug>.md` from the kit's ticket template, updates `workspace-CONTEXT.md` "Active tickets" list, stages a `SESSION-LOG.md` line. Read-only against the tracker. See [Per-ticket scratchpads](#per-ticket-scratchpads) for the full flow.
 
 ---

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -123,6 +123,7 @@ anything is written.
 - If `reference_ai_working_folder.md` is set up in auto-memory, Claude already knows where the working folder lives. Otherwise prefix with: *"Working folder is `<path>`."*
 - The "draft first, don't write" guard is load-bearing — session-end updates are easy to get wrong (overzealous status bumps, hallucinated PR numbers), and reviewing is faster than undoing.
 - For a bare-minimum wrap-up (no checklist or memory review), the one-liner *"Draft a SESSION-LOG.md entry for today and show it to me"* is usually enough.
+- **For mid-session handoffs** (switching to Claude desktop, context-window pressure, abrupt pause), use `/session-handoff` instead — same drafting work but writes immediately without the confirmation gate. The trade-off is real (occasionally writes something slightly off, corrected on the next `/session-start`) and strictly better than losing the session entirely.
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -174,7 +174,9 @@ Every working session should end with:
 
 The habit that makes this work: the **last thing you do** before quitting is update these docs. It takes two minutes and rescues the next session from "where was I?"
 
-For a scaffolded version of this pass, paste **Prompt 3 ("Wrapping up a session")** from [PROMPTS.md](PROMPTS.md). It has Claude draft all four items and stop for your review before writing anything — easier than remembering each piece by hand.
+For a scaffolded version of this pass, paste **Prompt 3 ("Wrapping up a session")** from [PROMPTS.md](PROMPTS.md), or run the **`/session-end`** slash command. Both draft all four items and stop for your review before writing anything — easier than remembering each piece by hand.
+
+**For interrupted sessions** (switching to Claude desktop, abrupt pause, context-window pressure), use **`/session-handoff`** instead — same drafting work but writes immediately, no confirmation gate. Persistence over polish; review on the next `/session-start`. Pairs with `bootstrap.sh`'s automatic Bootstrap entry — between the two, even an aborted bootstrap-and-seed-prompt session leaves a durable record on disk.
 
 ---
 
@@ -190,7 +192,7 @@ mv "<working-folder>/phase-N-checklist.md" "<working-folder>/phase-0-checklist.m
 [ -d "<framework-dir>/templates/.claude" ] && cp -R "<framework-dir>/templates/.claude" "<working-folder>/"
 ```
 
-The `.claude/` directory holds starter agents and slash commands that match the kit's session-start, session-end, and phase-close conventions. They're staged in the working folder; copy into your target repo's `.claude/` if you want them active. See [`templates/.claude/README.md`](templates/.claude/README.md) for the full list (two agents + four slash commands) and how to activate them.
+The `.claude/` directory holds starter agents and slash commands that match the kit's session-start, session-end, session-handoff, and phase-close conventions. They're staged in the working folder; copy into your target repo's `.claude/` if you want them active. See [`templates/.claude/README.md`](templates/.claude/README.md) for the full list (two agents + six slash commands) and how to activate them.
 
 ### Seed auto-memory
 The harness expects memory at `~/.claude/projects/<sanitized-path>/memory/`. Sanitization rule: absolute repo path with `/` replaced by `-`, prefixed with `-`. Example: `/Users/you/Code/acme/foo` → `-Users-you-Code-acme-foo`.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -242,6 +242,87 @@ substitute_tracker_placeholders_in_dir() {
   printf '%s' "$count"
 }
 
+kit_version() {
+  # Best-effort kit version string — git describe if the kit is a checkout,
+  # else "unknown". Never errors.
+  local v
+  if v="$(git -C "$KIT_ROOT" describe --tags --always --dirty 2>/dev/null)"; then
+    printf '%s' "$v"
+  else
+    printf 'unknown'
+  fi
+}
+
+write_initial_session_log_entry() {
+  # Append a factual Bootstrap entry to <working-folder>/SESSION-LOG.md so the
+  # bootstrap session is durable even if a hand-off interrupts before
+  # /session-end runs. Reads globals: WORKING_FOLDER, REPO_ROOT, MEMORY_DIR,
+  # WORKSPACE_MODE, WORKSPACE_DIR, WORKSPACE_REPO_NAME, WORKSPACE_FIRST_REPO,
+  # TRACKER, JIRA_PROJECT_KEY, LINEAR_TEAM_KEY, CI_TOOL, SKIP_MEMORY.
+  local target="$WORKING_FOLDER/SESSION-LOG.md"
+  [ -f "$target" ] || return 0
+
+  local today; today="$(date +%Y-%m-%d)"
+  local mode_label="single-repo"
+  if [ "$WORKSPACE_MODE" -eq 1 ]; then
+    if [ "$WORKSPACE_FIRST_REPO" -eq 1 ]; then
+      mode_label="workspace (new — first repo)"
+    else
+      mode_label="workspace (added repo to existing workspace)"
+    fi
+  fi
+
+  local tracker_line="(none)"
+  case "$TRACKER" in
+    jira)     tracker_line="jira (project: $JIRA_PROJECT_KEY)" ;;
+    linear)   tracker_line="linear (team: $LINEAR_TEAM_KEY)" ;;
+    github|gitlab|shortcut|other) tracker_line="$TRACKER" ;;
+  esac
+
+  local ci_line="(none)"
+  if [ -n "$CI_TOOL" ] && [ "$CI_TOOL" != "none" ]; then
+    ci_line="$CI_TOOL"
+  fi
+
+  local memory_line
+  if [ "$SKIP_MEMORY" -eq 1 ]; then
+    memory_line="skipped (--skip-memory)"
+  else
+    memory_line="$MEMORY_DIR"
+  fi
+
+  {
+    printf '\n## Session: %s — Bootstrap\n\n' "$today"
+    printf '**Focus:** Initial bootstrap of the working folder%s.\n\n' \
+      "$( [ "$SKIP_MEMORY" -eq 0 ] && printf ' + auto-memory' )"
+    printf '**Bootstrap config:**\n'
+    printf -- '- Mode: %s\n' "$mode_label"
+    if [ "$WORKSPACE_MODE" -eq 1 ]; then
+      printf -- '- Workspace: `%s`\n' "$WORKSPACE_DIR"
+      printf -- '- Repo subfolder: `%s` (full path: `%s`)\n' \
+        "$WORKSPACE_REPO_NAME" "$WORKING_FOLDER"
+    else
+      printf -- '- Working folder: `%s`\n' "$WORKING_FOLDER"
+    fi
+    printf -- '- Repo: `%s`\n' "$REPO_ROOT"
+    printf -- '- Tracker: %s\n' "$tracker_line"
+    printf -- '- CI: %s\n' "$ci_line"
+    printf -- '- Auto-memory: %s\n' "$memory_line"
+    printf -- '- Kit version: %s\n\n' "$(kit_version)"
+    printf '**Open threads / next steps:**\n'
+    printf -- '- Run the seed prompt: `Follow the instructions in %s/SEED-PROMPT.md.`\n' \
+      "$WORKING_FOLDER"
+    if [ "$SKIP_MEMORY" -eq 0 ]; then
+      printf -- '- Tune auto-memory at `%s` — prune what does not apply, customize feedback files.\n' "$MEMORY_DIR"
+    fi
+    if [ "$WORKSPACE_MODE" -eq 1 ]; then
+      printf -- '- For each sibling repo in this workspace, re-run `bootstrap.sh --workspace %s` from that repo.\n' "$WORKSPACE_DIR"
+    fi
+    printf -- '- Fill `[CLAUDE-INFERRED]` / `[HUMAN-CONFIRM]` markers in `CONTEXT.md` once SEED-PROMPT runs.\n'
+    printf '\n---\n'
+  } >> "$target"
+}
+
 SKIP_MEMORY=0
 FORCE=0
 DRY_RUN=0
@@ -683,6 +764,9 @@ if [ "$SKIP_MEMORY" -eq 0 ]; then
     echo "    (no git remote 'origin' found — {{REPO_SLUG}} left for manual fill)"
   fi
 fi
+
+write_initial_session_log_entry
+echo "  ✓ Wrote initial Bootstrap entry to $WORKING_FOLDER/SESSION-LOG.md"
 
 echo
 echo "Bootstrap complete."

--- a/templates/.claude/README.md
+++ b/templates/.claude/README.md
@@ -1,6 +1,6 @@
 # `.claude/` starters
 
-Two agents and four slash commands that follow the kit's session-start, session-end, and phase-close conventions. Staged here in your working folder; copy into your target repo's `.claude/` if you want them.
+Two agents and six slash commands that follow the kit's session-start, session-end, session-handoff, and phase-close conventions. Staged here in your working folder; copy into your target repo's `.claude/` if you want them.
 
 ## What's here
 
@@ -15,6 +15,7 @@ Two agents and four slash commands that follow the kit's session-start, session-
 - **`/refresh-context`** — re-reads the working folder mid-session (after a `/close-phase` or `/session-end` writeback, or when a long session has drifted). Hands back a delta summary. Same flow as Prompt 5 in `PROMPTS.md`.
 - **`/close-phase`** — runs the phase-close writeback (checklist tick, `plan.md` status, `CONTEXT.md`, `SESSION-LOG.md`, optional acceptance-results archive). Takes a phase number or infers from `CONTEXT.md`.
 - **`/session-end`** — Prompt 3 from `PROMPTS.md` packaged as a slash command. Drafts the end-of-session updates, waits for confirmation before writing.
+- **`/session-handoff`** — same drafting work as `/session-end`, but **writes immediately** without a confirmation gate. Use when waiting risks losing the session: switching to Claude desktop, context-window pressure, abrupt pause. Persistence > polish; review on the next `/session-start`.
 - **`/pull-ticket <KEY>`** — pull a tracker ticket (JIRA / GitHub Issues / Linear / GitLab / Shortcut) into a per-ticket scratchpad at `tickets/<KEY>-<slug>.md`. Reads tracker config from `CONTEXT.md` (or `../workspace-CONTEXT.md` in workspace mode), fetches via the relevant MCP, fills the kit's ticket template. Updates `workspace-CONTEXT.md` and stages a `SESSION-LOG.md` line. **Read-only against the tracker** — never creates, edits, transitions, or comments. Same flow as Prompt 6 in `PROMPTS.md`. For terminal-driven use without Claude, see `pull-ticket.sh` at the kit root.
 
 ## How to activate them

--- a/templates/.claude/commands/session-handoff.md
+++ b/templates/.claude/commands/session-handoff.md
@@ -1,0 +1,46 @@
+---
+description: Hand off mid-session — capture everything to disk now, no confirmation gate. Use when context is at risk (window pressure, switching machines, abrupt pause). Drafts and writes immediately; review on next session start.
+---
+
+We're handing this session off NOW. Capture everything to disk in one pass —
+do **not** wait for my confirmation. Persistence over polish: I will review on
+the next `/session-start`. The kit's normal `/session-end` flow drafts and waits
+for review; this command exists for moments when waiting risks losing work.
+
+1. Append a SESSION-LOG.md entry for today, using this shape:
+   - Date (YYYY-MM-DD)
+   - 1-line focus
+   - Branches touched / PRs opened, merged, or still open (with numbers)
+   - Decisions, rule changes, or gotchas worth recording for next session
+   - Open threads ("what we'd pick up next time")
+   Write the entry directly. If anything is uncertain, write your best guess
+   and mark it `[CLAUDE-INFERRED]` so I can correct on next session start.
+
+2. If `CONTEXT.md`'s "Current Phase Status" line is clearly out of date based
+   on what changed this session, update it. Mark the line `[CLAUDE-INFERRED]`
+   if the call was a judgment.
+
+3. Tick any items in `phase-<N>-checklist.md` that landed this session. If a
+   ticked item is missing a branch or PR number, leave a note in the SESSION-LOG
+   entry rather than guessing.
+
+4. If a preference or rule came up more than once this session, draft a
+   `feedback_*.md` memory file for it under the project's auto-memory dir
+   AND add a one-line entry to `MEMORY.md`. Better to write a draft I edit
+   later than to lose the rule.
+
+After writing, print a one-paragraph summary of what you wrote — what entries,
+what status changes, what new memory. That's the read-on-next-session
+checkpoint.
+
+## When to use this vs. `/session-end`
+
+- **`/session-end`** — stable end of a working session, you have time to review
+  drafts before they land. Default to this.
+- **`/session-handoff`** — hand-off interrupt: switching to Claude desktop,
+  context window pressure, abrupt pause, anything where waiting risks losing
+  work. Persistence > review.
+
+The trade-off is real: handoff occasionally writes something slightly off, which
+gets corrected on the next `/session-start` read. Strictly better than losing
+the session entirely.

--- a/templates/SEED-PROMPT.md
+++ b/templates/SEED-PROMPT.md
@@ -167,6 +167,7 @@ Output a summary in this exact shape:
 Once the user answers your questions and confirms inferences:
 
 1. Replace the `[CLAUDE-INFERRED]` and `[HUMAN-CONFIRM]` markers with the confirmed values in `CONTEXT.md` and `research.md`.
-2. Ask whether to proceed to Phase 0/1 scoping (populate `plan.md` phases, create `phase-N-checklist.md`) or stop here for the user to drive.
+2. Run `/session-handoff` (or fall back to drafting the equivalent and writing immediately) to append a SESSION-LOG entry capturing what got derived during this seed-prompt run — architecture decisions, key inferences, anything non-obvious that future sessions will want. `bootstrap.sh` already wrote a factual "Bootstrap" entry; this one captures everything Claude derived on top of those facts. Persisting now means the seed-prompt session is durable even if the user pauses without running `/session-end`.
+3. Ask whether to proceed to Phase 0/1 scoping (populate `plan.md` phases, create `phase-N-checklist.md`) or stop here for the user to drive.
 
-Do not presume the next move. The seed prompt's job ends at "working folder is filled and confirmed." Anything after that is the user's call.
+Do not presume the next move beyond the writeback above. The seed prompt's job ends at "working folder is filled, confirmed, and captured in SESSION-LOG." Anything after that is the user's call.

--- a/templates/SESSION-LOG.md
+++ b/templates/SESSION-LOG.md
@@ -38,19 +38,10 @@ Use this shape for every session entry. Keep prose tight — future-you will sca
 
 ---
 
-## Session: {{YYYY-MM-DD}} — Initial setup
-
-**Focus:** Bootstrap working folder, seed planning docs, establish conventions.
-
-**Outputs:**
-- Created `CONTEXT.md`, `plan.md`, `implementation.md`, `research.md` (skeletons)
-- Created `phase-0-checklist.md` for initial setup work
-
-**Key decisions:**
-- Working folder location: `{{WORKING_FOLDER}}`
-- Adopted conventions from `~/Documents/Claude/Framework/CONVENTIONS.md` (with modifications: {{list any}})
-
-**Open threads:**
-- {{…}}
-
----
+<!--
+Session entries go below. `bootstrap.sh` appends a factual "Bootstrap" entry
+on first run capturing the date, working-folder path, repo path, tracker /
+CI config, and kit version — so the bootstrap session is durable even if
+hand-off interrupts before /session-end runs. Subsequent sessions append
+their own entries here using the format above.
+-->

--- a/tests/bootstrap_session_log.bats
+++ b/tests/bootstrap_session_log.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+# bootstrap.sh appends a factual "Bootstrap" entry to <working-folder>/SESSION-LOG.md
+# so the bootstrap session is durable even if a hand-off interrupts before
+# /session-end runs.
+
+load 'helpers'
+
+setup() { bootstrap_setup; }
+teardown() { bootstrap_teardown; }
+
+@test "bootstrap appends a Bootstrap entry to SESSION-LOG.md" {
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+
+  [ -f "$TEST_WF/SESSION-LOG.md" ]
+  grep -qE '^## Session: [0-9]{4}-[0-9]{2}-[0-9]{2} — Bootstrap$' "$TEST_WF/SESSION-LOG.md"
+  grep -q '\*\*Focus:\*\* Initial bootstrap' "$TEST_WF/SESSION-LOG.md"
+  grep -q '\*\*Bootstrap config:\*\*' "$TEST_WF/SESSION-LOG.md"
+  grep -q '\*\*Open threads / next steps:\*\*' "$TEST_WF/SESSION-LOG.md"
+}
+
+@test "Bootstrap entry records single-repo mode by default" {
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  grep -q '^- Mode: single-repo$' "$TEST_WF/SESSION-LOG.md"
+  grep -q "^- Working folder: \`$TEST_WF\`$" "$TEST_WF/SESSION-LOG.md"
+  grep -q "^- Repo: \`$TEST_REPO\`$" "$TEST_WF/SESSION-LOG.md"
+}
+
+@test "Bootstrap entry records tracker config when set" {
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory --tracker jira --jira-project INFRA
+  [ "$status" -eq 0 ]
+  grep -q '^- Tracker: jira (project: INFRA)$' "$TEST_WF/SESSION-LOG.md"
+}
+
+@test "Bootstrap entry records linear tracker key" {
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory --tracker linear --linear-team ENG
+  [ "$status" -eq 0 ]
+  grep -q '^- Tracker: linear (team: ENG)$' "$TEST_WF/SESSION-LOG.md"
+}
+
+@test "Bootstrap entry records CI tool when set" {
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory --ci github-actions
+  [ "$status" -eq 0 ]
+  grep -q '^- CI: github-actions$' "$TEST_WF/SESSION-LOG.md"
+}
+
+@test "Bootstrap entry records 'none' tracker and CI when not set" {
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  grep -q '^- Tracker: (none)$' "$TEST_WF/SESSION-LOG.md"
+  grep -q '^- CI: (none)$' "$TEST_WF/SESSION-LOG.md"
+}
+
+@test "Bootstrap entry records skipped memory when --skip-memory" {
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  grep -q '^- Auto-memory: skipped (--skip-memory)$' "$TEST_WF/SESSION-LOG.md"
+  # Memory tuning step should NOT appear when skipped
+  ! grep -q 'Tune auto-memory' "$TEST_WF/SESSION-LOG.md"
+}
+
+@test "Bootstrap entry records auto-memory path when seeded" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+  MEM="$(memory_dir)"
+  grep -q "^- Auto-memory: $MEM$" "$TEST_WF/SESSION-LOG.md"
+  grep -q 'Tune auto-memory' "$TEST_WF/SESSION-LOG.md"
+}
+
+@test "Bootstrap entry includes a kit-version line" {
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  grep -qE '^- Kit version: ' "$TEST_WF/SESSION-LOG.md"
+}
+
+@test "Bootstrap entry includes seed-prompt next step" {
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  grep -q "Follow the instructions in $TEST_WF/SEED-PROMPT.md" "$TEST_WF/SESSION-LOG.md"
+}
+
+@test "workspace first-repo bootstrap entry records workspace mode + sibling-repo step" {
+  WS="$TEST_TMP/lx-platform"
+  REPO_NAME="$(basename "$TEST_REPO")"
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -eq 0 ]
+
+  PER_REPO="$WS/$REPO_NAME"
+  grep -q '^- Mode: workspace (new — first repo)$' "$PER_REPO/SESSION-LOG.md"
+  grep -q "^- Workspace: \`$WS\`$" "$PER_REPO/SESSION-LOG.md"
+  grep -q "^- Repo subfolder: \`$REPO_NAME\`" "$PER_REPO/SESSION-LOG.md"
+  grep -q "re-run \`bootstrap.sh --workspace $WS\`" "$PER_REPO/SESSION-LOG.md"
+}
+
+@test "workspace second-repo bootstrap entry records added-repo mode" {
+  WS="$TEST_TMP/lx-platform"
+
+  # First run establishes workspace
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -eq 0 ]
+
+  # Sibling repo
+  REPO2="$TEST_TMP/repo2"
+  mkdir -p "$REPO2"
+  git -C "$REPO2" init -q
+  cd "$REPO2"
+
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -eq 0 ]
+
+  grep -q '^- Mode: workspace (added repo to existing workspace)$' "$WS/repo2/SESSION-LOG.md"
+}
+
+@test "--dry-run does NOT write a Bootstrap entry" {
+  run "$BOOTSTRAP" --dry-run "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  [ ! -d "$TEST_WF" ]
+}
+
+@test "templates/SESSION-LOG.md no longer contains the placeholder Initial setup entry" {
+  # The kit's own SESSION-LOG.md template should not ship an unfilled
+  # "Initial setup" entry — that's bootstrap's job to write factually.
+  ! grep -q '## Session: {{YYYY-MM-DD}} — Initial setup' "$KIT_ROOT/templates/SESSION-LOG.md"
+}


### PR DESCRIPTION
## Summary

Closes #118.

**Fix A — `bootstrap.sh` writes its own SESSION-LOG entry.**
Every successful bootstrap (single-repo or workspace, with or without `--skip-memory`) appends a factual "Bootstrap" entry to `<working-folder>/SESSION-LOG.md` capturing date, mode, paths, tracker, CI, auto-memory location, kit version, and next-step pointers. Deterministic write — no LLM in the loop, no confirmation gate. The bootstrap-time state is durable even if the user pauses before running `/session-end`. `templates/SESSION-LOG.md` no longer ships an unfilled "Initial setup" placeholder block (it had `{{YYYY-MM-DD}}` / `{{WORKING_FOLDER}}` placeholders that bootstrap never substituted).

**Fix B — new `/session-handoff` slash command.**
Same drafting work as `/session-end`, but writes immediately without a confirmation gate. Frame: persistence over polish; review on the next `/session-start`. Pairs with Fix A so the entire bootstrap-and-seed-prompt session is durable end-to-end even if the user hands off mid-flow. Synced to `.claude/commands/session-handoff.md` per the dogfood pattern.

**Bonus — `templates/SEED-PROMPT.md` final step.**
The seed prompt now ends by running `/session-handoff` (or equivalent) so the SEED-PROMPT-derived inferences (architecture, decisions, `[CLAUDE-INFERRED]` resolutions) are captured before the session ends. Closes the gap between "bootstrap.sh wrote a factual entry" and "the user has reviewed inferences" — both endpoints are now durable.

## Why

Surfaced during dogfood at work — the user spent a full session bootstrapping a dual-repo workspace, handed off to Claude desktop without running `/session-end`, and lost ~2 days of derived context. Three orthogonal mechanisms close the hole: (A) bootstrap writes what it knows for free, (B) the user has a write-now command for interrupts, and (C) the SEED-PROMPT itself runs the writeback at its natural endpoint. Each is small; together they make every common interruption point durable.

## Test plan

- [x] `bats tests/` — full suite 148/148 pass (+14 new tests in `tests/bootstrap_session_log.bats`).
  - Single-repo + workspace (first-repo + additional-repo) entry shapes
  - Tracker (jira/linear/github/none) and CI variants captured
  - Memory skipped vs. seeded recorded correctly
  - Kit-version line present
  - Next-step lines (seed prompt, sibling repos, memory tuning) appear / don't appear correctly
  - `--dry-run` writes no entry
  - Regression: `templates/SESSION-LOG.md` no longer contains the unfilled `Initial setup` placeholder block
- [x] Eyeballed actual SESSION-LOG.md output across single-repo + workspace + skip-memory + tracker variants — formatting reads cleanly.
- [x] `/session-handoff` synced into `.claude/commands/` (kit dogfoods it); `tests/dogfood_claude_in_sync.bats` still passes.
- [x] Lychee link-check passes (CI; not installed locally).

## Out of scope

- Auto-running `/session-end` from `bootstrap.sh`. `bootstrap.sh` runs *before* Claude is engaged in a session — there's nothing to wrap up. The factual write (Fix A) is the bash-side equivalent.
- Auto-handoff on detected context-window pressure. Out of scope for the kit; user-driven only.
- `~/.claude/settings.json` `additionalDirectories` opt-in prompt during bootstrap — separate concern, tracked in #126.

## Related

- #116 / #119 — workspace per-repo bootstrap requirement (same dogfood report).
- #117 / #124 — `.claude/settings.local.json` docs (same dogfood report).
- #121 / #122 — sync-memory helper (same dogfood report).
- #126 — opt-in prompt to add working-folder root to `~/.claude/settings.json` (filed alongside this work).