### PR TITLE
feat(scripts): add install-commands.sh for global/per-project slash command + agent install

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -216,11 +216,13 @@ Saves ~30 minutes of manual fill-in on a real project, and the inference markers
 
 ## Starter agents
 
-Two agents stage in `<working-folder>/.claude/agents/`. The kit doesn't modify your target repo — to activate, copy the directory in:
+Two agents stage in `<working-folder>/.claude/agents/`. **Recommended install: globally, once per machine** so they're available across every kit project:
 
 ```bash
-cp -r <working-folder>/.claude/ <your-repo>/.claude/
+<kit-dir>/scripts/install-commands.sh --global
 ```
+
+The helper is idempotent and never overwrites existing files. To scope to one repo instead, pass `--project <repo-path>`. To copy by hand, the source is `<kit-dir>/templates/.claude/agents/`.
 
 - **`code-reviewer`** — reviews diffs, branches, or files for security / correctness / performance / style. Project-agnostic; works anywhere.
 - **`session-summarizer`** — drafts SESSION-LOG entries, CONTEXT.md status bumps, checklist scans, and memory candidates from the current session's activity. Specific to projects using the kit's working-folder pattern.
@@ -231,7 +233,7 @@ These are **starters**. Edit the frontmatter (model, tool allowlist), customize 
 
 ## Starter slash commands
 
-Six slash commands stage in `<working-folder>/.claude/commands/`. Same activation pattern — copy `.claude/` into your target repo.
+Six slash commands stage in `<working-folder>/.claude/commands/`. Same install path as agents — `scripts/install-commands.sh --global` (recommended, covers every project) or `--project <repo-path>` (scope to one repo).
 
 - **`/session-start`** — packages Prompt 1 from `PROMPTS.md`. Loads `CONTEXT.md`, `SESSION-LOG.md`, and the current phase checklist; hands back a 3–5 bullet grounding summary. Use at the start of a fresh session.
 - **`/refresh-context`** — re-reads the working folder mid-session, after a `/close-phase` or `/session-end` writeback or when a long session has drifted. Hands back a delta read against the latest state.

--- a/SETUP.md
+++ b/SETUP.md
@@ -192,7 +192,13 @@ mv "<working-folder>/phase-N-checklist.md" "<working-folder>/phase-0-checklist.m
 [ -d "<framework-dir>/templates/.claude" ] && cp -R "<framework-dir>/templates/.claude" "<working-folder>/"
 ```
 
-The `.claude/` directory holds starter agents and slash commands that match the kit's session-start, session-end, session-handoff, and phase-close conventions. They're staged in the working folder; copy into your target repo's `.claude/` if you want them active. See [`templates/.claude/README.md`](templates/.claude/README.md) for the full list (two agents + six slash commands) and how to activate them.
+The `.claude/` directory holds starter agents and slash commands that match the kit's session-start, session-end, session-handoff, and phase-close conventions. **Recommended install: globally, once per machine** so they're available across every kit project:
+
+```bash
+<framework-dir>/scripts/install-commands.sh --global
+```
+
+The helper is idempotent and never overwrites existing files. To scope to one repo instead, use `--project <repo-path>`. See [`templates/.claude/README.md`](templates/.claude/README.md) for the full list (two agents + six slash commands), the kit-coupling caveat (most commands assume a kit working folder), and manual-copy alternatives.
 
 ### Seed auto-memory
 The harness expects memory at `~/.claude/projects/<sanitized-path>/memory/`. Sanitization rule: absolute repo path with `/` replaced by `-`, prefixed with `-`. Example: `/Users/you/Code/acme/foo` → `-Users-you-Code-acme-foo`.
@@ -236,9 +242,13 @@ For fully filled-in references, see [`examples/widget-tracker/CONTEXT.md`](examp
    ```bash
    cp <kit-dir>/memory-templates/<NEW_FILE>.md ~/.claude/projects/<sanitized-path>/memory/
    ```
-4. **New files in `templates/.claude/`** — copy into your working folder's `.claude/` (then re-copy into your target repo if you've activated those starters):
+4. **New files in `templates/.claude/`** — easiest path is to re-run the install helper, which adds any missing commands or agents without overwriting existing files:
    ```bash
-   cp -R <kit-dir>/templates/.claude/<NEW_FILE> <working-folder>/.claude/
+   <kit-dir>/scripts/install-commands.sh --global   # or --project <repo-path>
+   ```
+   To copy a single file by hand instead:
+   ```bash
+   cp <kit-dir>/templates/.claude/<commands_or_agents>/<NEW_FILE>.md ~/.claude/<commands_or_agents>/
    ```
 5. **Changed prose in kit-level files** (e.g. `CONVENTIONS.md`, `SETUP.md`, `README.md`) — re-read them. Your local copies of working-folder templates and memory files are yours; they don't auto-upgrade.
 6. **New `bootstrap.sh` flags or behavior** — apply only to *new* projects you bootstrap going forward. Already-bootstrapped projects keep their current state.

--- a/scripts/install-commands.sh
+++ b/scripts/install-commands.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Install the kit's starter slash commands and agents at user-level
+# (~/.claude/{commands,agents}/) or per-project level (<repo>/.claude/{commands,agents}/).
+#
+# Slash commands and agents shipped in templates/.claude/ are workflow-shaped
+# (session-start / session-end / session-handoff / refresh-context / close-phase /
+# pull-ticket; code-reviewer + session-summarizer). They're not project-specific —
+# installing once at user level makes them available across every project. This
+# script does that opt-in install with the same write-once invariant bootstrap.sh
+# follows: never overwrite an existing file. Idempotent.
+#
+# See FEATURES.md "Starter slash commands" / "Starter agents" for what each
+# command does. See templates/.claude/README.md for the kit-coupling caveat —
+# most commands assume a kit working folder exists; they error gracefully in
+# non-kit projects.
+set -euo pipefail
+
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "error: install-commands.sh requires bash" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KIT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SRC_DIR="$KIT_ROOT/templates/.claude"
+
+usage() {
+  cat <<EOF
+Usage: install-commands.sh [options]
+
+Install the kit's starter slash commands and agents into Claude Code's
+recognized locations. Never overwrites existing files.
+
+You must pick a destination:
+  --global               Install to ~/.claude/commands/ and ~/.claude/agents/.
+                         Recommended for kit users with multiple projects;
+                         one install covers every project on this machine.
+  --project <repo-path>  Install to <repo-path>/.claude/commands/ and
+                         <repo-path>/.claude/agents/. Use when you want the
+                         starters scoped to a single repo (or want to
+                         override globals for that repo).
+
+Other options:
+  --dry-run              Print what would be copied; write nothing.
+  -h, --help             Show this help and exit.
+
+Examples:
+  # Install globally (one-time per machine, covers every kit project)
+  install-commands.sh --global
+
+  # Install scoped to a single repo
+  install-commands.sh --project ~/Code/my-project
+
+  # Preview without writing
+  install-commands.sh --global --dry-run
+
+Behavior:
+  - Idempotent — files already present in the target are skipped, never
+    overwritten. Safe to re-run.
+  - Source of truth is templates/.claude/ in the kit checkout; if the kit
+    ships new commands or agents later, re-run to pick them up.
+  - The kit's slash commands assume a kit working folder exists in the
+    project (CONTEXT.md / SESSION-LOG.md / phase-N-checklist.md). They
+    will error in non-kit projects — see kit issue #82 for graceful
+    degradation, in flight.
+EOF
+}
+
+DRY_RUN=0
+MODE=""
+PROJECT_PATH=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --global)
+      if [ -n "$MODE" ]; then
+        echo "error: --global and --project are mutually exclusive" >&2
+        exit 2
+      fi
+      MODE="global"
+      shift
+      ;;
+    --project)
+      if [ -n "$MODE" ]; then
+        echo "error: --global and --project are mutually exclusive" >&2
+        exit 2
+      fi
+      if [ $# -lt 2 ]; then
+        echo "error: --project requires a path argument" >&2
+        usage >&2
+        exit 2
+      fi
+      MODE="project"
+      PROJECT_PATH="$2"
+      shift 2
+      ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --*) echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *) echo "error: unexpected argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$MODE" ]; then
+  echo "error: must specify --global or --project <repo-path>" >&2
+  usage >&2
+  exit 2
+fi
+
+if [ "$MODE" = "project" ]; then
+  case "$PROJECT_PATH" in
+    "~") PROJECT_PATH="$HOME" ;;
+    "~/"*) PROJECT_PATH="$HOME/${PROJECT_PATH#"~/"}" ;;
+  esac
+  case "$PROJECT_PATH" in
+    /*) ;;
+    *) echo "error: --project path must be absolute (got: $PROJECT_PATH)" >&2; exit 2 ;;
+  esac
+  if [ ! -d "$PROJECT_PATH" ]; then
+    echo "error: --project path does not exist: $PROJECT_PATH" >&2
+    exit 2
+  fi
+  TARGET_BASE="$PROJECT_PATH/.claude"
+else
+  TARGET_BASE="$HOME/.claude"
+fi
+
+if [ ! -d "$SRC_DIR/commands" ] || [ ! -d "$SRC_DIR/agents" ]; then
+  echo "error: kit source missing — expected $SRC_DIR/commands and $SRC_DIR/agents" >&2
+  exit 1
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "=== DRY RUN — no files will be written ==="
+fi
+echo "Source: $SRC_DIR"
+echo "Target: $TARGET_BASE"
+echo
+
+COPIED=()
+SKIPPED_EXISTING=()
+
+install_dir() {
+  # args: subdir_name (commands or agents)
+  local sub="$1"
+  local src="$SRC_DIR/$sub"
+  local dst="$TARGET_BASE/$sub"
+  local f name
+  for src_file in "$src"/*.md; do
+    [ -e "$src_file" ] || continue
+    name="$(basename "$src_file")"
+    if [ -e "$dst/$name" ]; then
+      SKIPPED_EXISTING+=("$sub/$name")
+      continue
+    fi
+    if [ "$DRY_RUN" -eq 1 ]; then
+      echo "  + would install $sub/$name → $dst/$name"
+    else
+      mkdir -p "$dst"
+      cp "$src_file" "$dst/$name"
+      echo "  ✓ installed $sub/$name"
+    fi
+    COPIED+=("$sub/$name")
+  done
+}
+
+install_dir commands
+install_dir agents
+
+echo
+if [ "${#COPIED[@]}" -eq 0 ]; then
+  echo "Already installed — no files to copy."
+  if [ "${#SKIPPED_EXISTING[@]}" -gt 0 ]; then
+    echo "Skipped (already present): ${#SKIPPED_EXISTING[@]} file(s)."
+  fi
+  exit 0
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "Would install ${#COPIED[@]} file(s). Re-run without --dry-run to apply."
+else
+  echo "Installed ${#COPIED[@]} file(s) into $TARGET_BASE."
+  if [ "${#SKIPPED_EXISTING[@]}" -gt 0 ]; then
+    echo "Skipped ${#SKIPPED_EXISTING[@]} file(s) already present (never overwritten)."
+  fi
+  echo
+  if [ "$MODE" = "global" ]; then
+    echo "Slash commands and agents are now available in every project on this"
+    echo "machine. Restart Claude Code if it was already running."
+  else
+    echo "Slash commands and agents are scoped to $PROJECT_PATH."
+    echo "Open Claude Code in that repo to use them."
+  fi
+fi

--- a/templates/.claude/README.md
+++ b/templates/.claude/README.md
@@ -20,13 +20,25 @@ Two agents and six slash commands that follow the kit's session-start, session-e
 
 ## How to activate them
 
-These are **staged in your working folder, not in your target repo.** The kit doesn't modify the target repo — that's the kit's invariant. To activate the agents and commands, copy the directory into your target repo:
+These commands and agents are **workflow-shaped**, not project-shaped — every kit project uses them the same way. Recommended install: **once, globally** at user level so they're available across every project on the machine. Use the kit's helper:
 
 ```bash
-cp -r <working-folder>/.claude/ <your-repo>/.claude/
+# Recommended: install at user level (~/.claude/{commands,agents}/).
+# One install, every kit project on this machine.
+<kit-dir>/scripts/install-commands.sh --global
 ```
 
-Then commit the target's `.claude/` (or `.gitignore` it) to taste — the kit doesn't have an opinion. Both agents and slash commands work the same way whether they're committed or not.
+The helper is **idempotent and write-once** — files already present in the target are skipped, never overwritten. Re-run after pulling kit updates to pick up new commands.
+
+If you'd rather scope the install to a single repo (overriding any global copies for that repo, or keeping the kit's footprint visible per-project), use:
+
+```bash
+<kit-dir>/scripts/install-commands.sh --project <repo-path>
+```
+
+The staged copy in your working folder stays as a stable reference either way. To copy by hand instead of running the helper, the source is `<kit-dir>/templates/.claude/{commands,agents}/` — copy into `~/.claude/` (global) or `<your-repo>/.claude/` (per-project).
+
+**Caveat — kit-coupling.** All slash commands except `code-reviewer` (which is universal) assume a kit-bootstrapped project (CONTEXT.md / SESSION-LOG.md / phase-N-checklist.md). They will error in non-kit projects until [kit issue #82](https://github.com/IamMrCupp/claude-project-kit/issues/82) (graceful degradation) lands. Installing globally is still the right call if every project you work on is kit-bootstrapped.
 
 ## Customizing
 

--- a/tests/install_commands.bats
+++ b/tests/install_commands.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+# scripts/install-commands.sh — install kit slash commands + agents to user
+# (~/.claude/) or per-project (.claude/) location. Never overwrites existing
+# files. Idempotent.
+
+load 'helpers'
+
+INSTALL="$KIT_ROOT/scripts/install-commands.sh"
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  TEST_HOME="$TEST_TMP/home"
+  TEST_PROJECT="$TEST_TMP/project"
+  mkdir -p "$TEST_HOME" "$TEST_PROJECT"
+  export HOME="$TEST_HOME"
+}
+
+teardown() {
+  [ -n "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"
+}
+
+@test "install-commands.sh -h prints usage" {
+  run "$INSTALL" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: install-commands.sh"* ]]
+  [[ "$output" == *"--global"* ]]
+  [[ "$output" == *"--project"* ]]
+}
+
+@test "install-commands.sh errors when no destination is specified" {
+  run "$INSTALL"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must specify --global or --project"* ]]
+}
+
+@test "install-commands.sh errors when --global and --project both passed" {
+  run "$INSTALL" --global --project "$TEST_PROJECT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"mutually exclusive"* ]]
+}
+
+@test "install-commands.sh errors on unknown flag" {
+  run "$INSTALL" --bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown option"* ]]
+}
+
+@test "install-commands.sh --project errors on relative path" {
+  run "$INSTALL" --project relative/path
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be absolute"* ]]
+}
+
+@test "install-commands.sh --project errors when path doesn't exist" {
+  run "$INSTALL" --project "$TEST_TMP/nonexistent"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not exist"* ]]
+}
+
+@test "install-commands.sh --global installs all commands and agents" {
+  run "$INSTALL" --global
+  [ "$status" -eq 0 ]
+
+  for f in "$KIT_ROOT/templates/.claude/commands"/*.md; do
+    name="$(basename "$f")"
+    [ -f "$TEST_HOME/.claude/commands/$name" ]
+  done
+  for f in "$KIT_ROOT/templates/.claude/agents"/*.md; do
+    name="$(basename "$f")"
+    [ -f "$TEST_HOME/.claude/agents/$name" ]
+  done
+}
+
+@test "install-commands.sh --project installs to <project>/.claude/" {
+  run "$INSTALL" --project "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+
+  [ -f "$TEST_PROJECT/.claude/commands/session-start.md" ]
+  [ -f "$TEST_PROJECT/.claude/agents/code-reviewer.md" ]
+  # And NOT global
+  [ ! -d "$TEST_HOME/.claude" ]
+}
+
+@test "install-commands.sh never overwrites existing files" {
+  mkdir -p "$TEST_HOME/.claude/commands"
+  echo "USER_CUSTOMIZED" > "$TEST_HOME/.claude/commands/session-start.md"
+
+  run "$INSTALL" --global
+  [ "$status" -eq 0 ]
+
+  # File was preserved, not overwritten
+  grep -q "USER_CUSTOMIZED" "$TEST_HOME/.claude/commands/session-start.md"
+  # Other files still installed
+  [ -f "$TEST_HOME/.claude/commands/session-end.md" ]
+}
+
+@test "install-commands.sh is idempotent — second run is no-op" {
+  run "$INSTALL" --global
+  [ "$status" -eq 0 ]
+
+  run "$INSTALL" --global
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Already installed"* ]]
+}
+
+@test "install-commands.sh --dry-run writes nothing" {
+  run "$INSTALL" --global --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY RUN"* ]]
+  [[ "$output" == *"would install"* ]]
+  [[ "$output" == *"Re-run without --dry-run"* ]]
+
+  [ ! -d "$TEST_HOME/.claude" ]
+}
+
+@test "install-commands.sh --project --dry-run writes nothing" {
+  run "$INSTALL" --project "$TEST_PROJECT" --dry-run
+  [ "$status" -eq 0 ]
+  [ ! -d "$TEST_PROJECT/.claude" ]
+}
+
+@test "install-commands.sh handles tilde expansion for --project" {
+  mkdir -p "$TEST_HOME/myrepo"
+
+  run "$INSTALL" --project "~/myrepo"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_HOME/myrepo/.claude/commands/session-start.md" ]
+}
+
+@test "install-commands.sh installs the new session-handoff command" {
+  run "$INSTALL" --global
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_HOME/.claude/commands/session-handoff.md" ]
+}


### PR DESCRIPTION
## Summary

- New `scripts/install-commands.sh` helper that installs the kit's six slash commands and two agents into Claude Code's recognized locations:
  - `--global` → `~/.claude/{commands,agents}/` (recommended; one install covers every project on the machine)
  - `--project <repo-path>` → `<repo-path>/.claude/{commands,agents}/` (scope to one repo or override globals)
  - `--dry-run` previews; `-h` shows usage
- **Idempotent + write-once** — files already present in the target are skipped, never overwritten. Safe to re-run.
- 14 bats tests in `tests/install_commands.bats` covering every flag, both install modes, idempotence, dry-run, never-overwrite, tilde expansion, and the new `/session-handoff` command.
- **Docs flip to global-as-default** — `templates/.claude/README.md`, `SETUP.md`, and `FEATURES.md` updated to recommend `install-commands.sh --global` as the primary path. Manual `cp -R` still documented as the alternative.

Closes #102.

## Why

Surfaced during dogfood — the previous activation flow ("copy `.claude/` into your target repo") was wrong by default. The slash commands (`/session-start`, `/session-end`, `/session-handoff`, `/refresh-context`, `/close-phase`, `/pull-ticket`) are **workflow-shaped, not project-shaped** — they apply to every kit project the same way. Repeating the per-repo copy is busywork; one global install does it for every project on the machine.

The kit's invariant ("don't modify the user's target repo") stays intact: this script only writes to `~/.claude/` (when `--global`) or to a path the user explicitly specifies (when `--project`). Same write-once-no-overwrite shape as `bootstrap.sh` and the recently-shipped `sync-memory.sh`.

## Test plan

- [x] `bats tests/install_commands.bats` — 14/14 pass.
- [x] `bats tests/` — full suite 162/162 pass (no regressions).
- [x] `--help` lists both install modes; missing-destination errors cleanly; `--global` + `--project` mutual-exclusion errors cleanly; relative `--project` path errors cleanly.
- [x] Idempotent: second run reports "Already installed".
- [x] Never-overwrite verified by pre-seeding a customized `session-start.md` and re-running — file preserved.
- [x] Both modes verified to copy all six commands + both agents into the right destination.
- [ ] Lychee link-check passes (CI).

## Out of scope

- **Graceful degradation when commands run in non-kit projects** — the slash commands assume kit working-folder shape. Tracked separately in #82. The README + this PR call out the caveat explicitly so users opting in globally know what to expect.
- **Auto-running install at end of bootstrap.** That'd cross the kit's "no silent global mutation" invariant. The user runs the install once per machine; bootstrap stays scoped to per-project working-folder + auto-memory.
- **Versioning / upgrade detection.** Re-running `install-commands.sh` is the upgrade path — same write-once-no-overwrite contract, so existing customizations are safe.

## Related

- #122 (sync-memory.sh, v0.21.0) — same dogfood-sync pattern this script follows.
- #119 (workspace per-repo bootstrap), #124 (settings.local.json docs), #127 (durable bootstrap session), #129 (trust-working-folder-root) — siblings from the same dogfood report.
- #82 (graceful-degradation in commands) — would let `session-summarizer` and the slash commands fail cleanly in non-kit projects, removing the kit-coupling caveat.