### PR TITLE
feat: include Next session prompt in SESSION-LOG entries on close

### DIFF
--- a/.claude/commands/close-phase.md
+++ b/.claude/commands/close-phase.md
@@ -22,9 +22,10 @@ The working-folder path comes from `reference_ai_working_folder.md` in auto-memo
 3. **Update CONTEXT.md "Current Phase Status"** block — mark the closing phase complete, set the next phase posture (often "Deferred — no active work").
 4. **Archive acceptance results** if `acceptance-test-results.md` exists and is non-empty: rename to `acceptance-test-results-phase-$ARGUMENTS.md` and update the CONTEXT.md Reference section to point at the archive.
 5. **Draft a SESSION-LOG entry** for this session covering: focus, PRs landed, key decisions, non-obvious findings, open threads.
+6. **Include a Next session prompt** as part of the SESSION-LOG entry — a short, copy-pasteable block tailored to where the next session should pick up. After phase close, this typically points at the next phase's first task: e.g. *"Phase N closed; next phase scoping is the open thread. Load context, summarize phase-(N+1) plan, propose first task."* Format as `**Next session prompt:**` followed by a fenced code block, matching `templates/SESSION-LOG.md`.
 
 ## Hand back
 
-Show each change as a diff (or as the proposed file content if it's a new file). Wait for the user's confirmation per change before writing.
+Show each change as a diff (or as the proposed file content if it's a new file). Wait for the user's confirmation per change before writing. After confirmation and writing, **echo the next-session prompt back in chat** so the user doesn't have to reopen SESSION-LOG.md to grab it.
 
 Do not invoke `git commit` or push. The user commits the working-folder updates separately when they're ready.

--- a/.claude/commands/session-end.md
+++ b/.claude/commands/session-end.md
@@ -24,5 +24,16 @@ confirmation before writing anything.
    those are candidates for a new feedback_*.md memory file. Draft the
    feedback entry if applicable.
 
+5. Draft a **Next session prompt** as part of the SESSION-LOG entry — a
+   short, copy-pasteable block tomorrow-me can grab to start the next
+   session grounded. Tailor it from this session's actual state:
+   focus phrase, current branch + open PR (if any), the top open thread.
+   If nothing is open or in flight, fall back to the short form
+   (`Load context and give me a 3-bullet summary of where we are.`).
+   Format the field exactly as `templates/SESSION-LOG.md` shows it —
+   `**Next session prompt:**` followed by a fenced code block.
+
 Show me each of these as a separate section. I'll confirm each before
-anything is written.
+anything is written. After I confirm and you write everything, **echo
+the next-session prompt back to me in chat** so I don't have to reopen
+SESSION-LOG.md to grab it.

--- a/.claude/commands/session-handoff.md
+++ b/.claude/commands/session-handoff.md
@@ -29,9 +29,18 @@ for review; this command exists for moments when waiting risks losing work.
    AND add a one-line entry to `MEMORY.md`. Better to write a draft I edit
    later than to lose the rule.
 
+5. Include a **Next session prompt** as part of the SESSION-LOG entry —
+   a short, copy-pasteable block to start the next session grounded.
+   Tailor it from this session's state: focus phrase, current branch +
+   open PR (if any), top open thread. If nothing is in flight, use the
+   short form (`Load context and give me a 3-bullet summary of where we
+   are.`). Format exactly as `templates/SESSION-LOG.md` shows:
+   `**Next session prompt:**` followed by a fenced code block.
+
 After writing, print a one-paragraph summary of what you wrote — what entries,
-what status changes, what new memory. That's the read-on-next-session
-checkpoint.
+what status changes, what new memory. **Then echo the next-session prompt
+back in chat** so I can grab it without reopening SESSION-LOG.md. That's the
+read-on-next-session checkpoint.
 
 ## When to use this vs. `/session-end`
 

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -115,8 +115,18 @@ confirmation before writing anything.
    those are candidates for a new feedback_*.md memory file. Draft the
    feedback entry if applicable.
 
+5. Draft a **Next session prompt** as part of the SESSION-LOG entry — a
+   short, copy-pasteable block I can grab tomorrow to start the next
+   session grounded. Tailor it from this session's actual state: focus
+   phrase, current branch + open PR (if any), top open thread. If
+   nothing is in flight, fall back to "Load context and give me a
+   3-bullet summary of where we are." Format the field as
+   `**Next session prompt:**` followed by a fenced code block, matching
+   the entry-format example at the top of `SESSION-LOG.md`.
+
 Show me each of these as a separate section. I'll confirm each before
-anything is written.
+anything is written. After writing, echo the next-session prompt back
+in chat so I can grab it without reopening SESSION-LOG.md.
 ```
 
 **Notes:**

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -329,7 +329,13 @@ write_initial_session_log_entry() {
     if [ "$WORKSPACE_MODE" -eq 1 ]; then
       printf -- '- For each sibling repo in this workspace, re-run `bootstrap.sh --workspace %s` from that repo.\n' "$WORKSPACE_DIR"
     fi
-    printf -- '- Fill `[CLAUDE-INFERRED]` / `[HUMAN-CONFIRM]` markers in `CONTEXT.md` once SEED-PROMPT runs.\n'
+    printf -- '- Fill `[CLAUDE-INFERRED]` / `[HUMAN-CONFIRM]` markers in `CONTEXT.md` once SEED-PROMPT runs.\n\n'
+    printf '**Next session prompt:**\n\n'
+    printf '```\n'
+    printf 'Load context and give me a 3-bullet summary of where we are.\n'
+    printf 'Last session was the kit bootstrap — running the SEED-PROMPT to fill\n'
+    printf 'the working-folder templates is the next step. Pick up there.\n'
+    printf '```\n'
     printf '\n---\n'
   } >> "$target"
 }

--- a/examples/lx-platform/terraform-envs/SESSION-LOG.md
+++ b/examples/lx-platform/terraform-envs/SESSION-LOG.md
@@ -46,6 +46,15 @@ Chronological record of Claude working sessions in the `terraform-envs` repo. **
 - Once Atlantis applies, update LX-1234's `Status` in this scratchpad to `Done` and stage the archive note.
 - Carry over: `prod-dr/` is still on `lighthouse-vpc@v1.0.0` (pre-CIDR-fix). Open follow-up ticket whenever DR drift becomes load-bearing.
 
+**Next session prompt:**
+
+```
+Load context and give me a 3-bullet summary of where we are.
+Last session: LX-1234 prod-bump PR opened (#501, draft, awaiting soak end
+17:00 UTC 2026-04-25). Top open thread: mark PR #501 ready and merge
+once soak completes, then archive LX-1234. Pick up there.
+```
+
 ---
 
 ## Session: 2026-04-14 — LX-1100 dev migration

--- a/examples/widget-tracker/SESSION-LOG.md
+++ b/examples/widget-tracker/SESSION-LOG.md
@@ -73,4 +73,13 @@ Chronological record of Claude working sessions. Each entry captures what was do
 - Start thinking about Section C's in-memory → SQLite swap. Not urgent; Section B first.
 - Open Question #4 still unresolved; try to resolve before Section C so README docs can be authoritative.
 
+**Next session prompt:**
+
+```
+Load context and give me a 3-bullet summary of where we are.
+Last session: `add` shipped, `list` started. Branch `feat/list-command`
+is open with PR #7; B.2 filter flags (AND vs OR) is the top open thread.
+Pick up there.
+```
+
 ---

--- a/templates/.claude/commands/close-phase.md
+++ b/templates/.claude/commands/close-phase.md
@@ -22,9 +22,10 @@ The working-folder path comes from `reference_ai_working_folder.md` in auto-memo
 3. **Update CONTEXT.md "Current Phase Status"** block — mark the closing phase complete, set the next phase posture (often "Deferred — no active work").
 4. **Archive acceptance results** if `acceptance-test-results.md` exists and is non-empty: rename to `acceptance-test-results-phase-$ARGUMENTS.md` and update the CONTEXT.md Reference section to point at the archive.
 5. **Draft a SESSION-LOG entry** for this session covering: focus, PRs landed, key decisions, non-obvious findings, open threads.
+6. **Include a Next session prompt** as part of the SESSION-LOG entry — a short, copy-pasteable block tailored to where the next session should pick up. After phase close, this typically points at the next phase's first task: e.g. *"Phase N closed; next phase scoping is the open thread. Load context, summarize phase-(N+1) plan, propose first task."* Format as `**Next session prompt:**` followed by a fenced code block, matching `templates/SESSION-LOG.md`.
 
 ## Hand back
 
-Show each change as a diff (or as the proposed file content if it's a new file). Wait for the user's confirmation per change before writing.
+Show each change as a diff (or as the proposed file content if it's a new file). Wait for the user's confirmation per change before writing. After confirmation and writing, **echo the next-session prompt back in chat** so the user doesn't have to reopen SESSION-LOG.md to grab it.
 
 Do not invoke `git commit` or push. The user commits the working-folder updates separately when they're ready.

--- a/templates/.claude/commands/session-end.md
+++ b/templates/.claude/commands/session-end.md
@@ -24,5 +24,16 @@ confirmation before writing anything.
    those are candidates for a new feedback_*.md memory file. Draft the
    feedback entry if applicable.
 
+5. Draft a **Next session prompt** as part of the SESSION-LOG entry — a
+   short, copy-pasteable block tomorrow-me can grab to start the next
+   session grounded. Tailor it from this session's actual state:
+   focus phrase, current branch + open PR (if any), the top open thread.
+   If nothing is open or in flight, fall back to the short form
+   (`Load context and give me a 3-bullet summary of where we are.`).
+   Format the field exactly as `templates/SESSION-LOG.md` shows it —
+   `**Next session prompt:**` followed by a fenced code block.
+
 Show me each of these as a separate section. I'll confirm each before
-anything is written.
+anything is written. After I confirm and you write everything, **echo
+the next-session prompt back to me in chat** so I don't have to reopen
+SESSION-LOG.md to grab it.

--- a/templates/.claude/commands/session-handoff.md
+++ b/templates/.claude/commands/session-handoff.md
@@ -29,9 +29,18 @@ for review; this command exists for moments when waiting risks losing work.
    AND add a one-line entry to `MEMORY.md`. Better to write a draft I edit
    later than to lose the rule.
 
+5. Include a **Next session prompt** as part of the SESSION-LOG entry —
+   a short, copy-pasteable block to start the next session grounded.
+   Tailor it from this session's state: focus phrase, current branch +
+   open PR (if any), top open thread. If nothing is in flight, use the
+   short form (`Load context and give me a 3-bullet summary of where we
+   are.`). Format exactly as `templates/SESSION-LOG.md` shows:
+   `**Next session prompt:**` followed by a fenced code block.
+
 After writing, print a one-paragraph summary of what you wrote — what entries,
-what status changes, what new memory. That's the read-on-next-session
-checkpoint.
+what status changes, what new memory. **Then echo the next-session prompt
+back in chat** so I can grab it without reopening SESSION-LOG.md. That's the
+read-on-next-session checkpoint.
 
 ## When to use this vs. `/session-end`
 

--- a/templates/SESSION-LOG.md
+++ b/templates/SESSION-LOG.md
@@ -34,7 +34,17 @@ Use this shape for every session entry. Keep prose tight — future-you will sca
 
 **Open threads / next steps:**
 - {{…}}
+
+**Next session prompt:**
+
 ```
+Load context and give me a 3-bullet summary of where we are.
+Last session: {{focus phrase}}. Branch `{{branch}}` is open with PR #{{N}};
+top open thread: {{one-line thread}}. Pick up from there.
+```
+```
+
+The "Next session prompt" block is filled by `/session-end` (and `/session-handoff`, `/close-phase`) so future-you can scroll back, copy the latest entry's prompt, and paste it into a fresh Claude session with everything Claude needs to resume. If no branch is open or no threads are pending, simplify the prompt to just the short form (`Load context and give me a 3-bullet summary of where we are.`).
 
 ---
 

--- a/tests/bootstrap_session_log.bats
+++ b/tests/bootstrap_session_log.bats
@@ -74,6 +74,14 @@ teardown() { bootstrap_teardown; }
   grep -qE '^- Kit version: ' "$TEST_WF/SESSION-LOG.md"
 }
 
+@test "Bootstrap entry includes a Next session prompt block" {
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory
+  [ "$status" -eq 0 ]
+  grep -qF '**Next session prompt:**' "$TEST_WF/SESSION-LOG.md"
+  grep -q 'Load context and give me a 3-bullet summary' "$TEST_WF/SESSION-LOG.md"
+  grep -q 'running the SEED-PROMPT' "$TEST_WF/SESSION-LOG.md"
+}
+
 @test "Bootstrap entry includes seed-prompt next step" {
   run "$BOOTSTRAP" "$TEST_WF" --skip-memory
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

- Adds a **`Next session prompt:`** field to the SESSION-LOG entry format. Each entry now ends with a fenced code block holding a copy-pasteable Prompt-1-style invocation tailored to where the session left off (focus phrase, current branch + open PR, top open thread).
- `/session-end`, `/session-handoff`, and `/close-phase` all draft the field as part of the entry, then **echo the prompt back in chat** after writing so the user can grab it without reopening SESSION-LOG.md.
- `bootstrap.sh`'s factual "Bootstrap" entry includes the field too — even the very first session has a copy-pasteable next-session prompt on disk.
- `PROMPTS.md` Prompt 3 + the entry-format example in `templates/SESSION-LOG.md` documenting the field.
- Two example SESSION-LOG entries (widget-tracker + acme-platform terraform-envs) updated to demonstrate the new field in filled-in form.

Closes #135.

## Why

Surfaced during dogfood — user explicitly asked for a polished resumption-ready prompt to be kicked out at session close so it's "easier to look back and grab and post for the next day/session". The current short-form Prompt 1 (`Load context and give me a 3-bullet summary of where we are.`) is generic; the new field captures **specific state** (branch, PR, open thread) so the next session starts grounded with no manual prompt-crafting.

## Test plan

- [x] `bats tests/` — full suite 172/172 pass (+1 new test in `tests/bootstrap_session_log.bats` asserting the field appears in the bootstrap entry).
- [x] Eyeballed actual bootstrap output — `**Next session prompt:**` block appears at the bottom of the entry with proper fenced code block.
- [x] Kit dogfood `.claude/` synced via `scripts/sync-claude-dogfood.sh`; `tests/dogfood_claude_in_sync.bats` still passes.
- [x] Updated examples render correctly in markdown.
- [x] Lychee link-check passes (CI; not installed locally).

## Out of scope

- Auto-launching a new session with the prompt pre-filled. Kit doesn't drive Claude Code UI.
- Multiple prompt variants per session (mid-PR, scoping, cleanup). One prompt per entry; user can edit before pasting.

## Related

- Dogfood report 2026-04-30 (this session) — sixth follow-on after the original four (#116, #117, #118, #102) and adjacent (#121, #126).
- #118 / #127 — durable bootstrap session via SESSION-LOG entry. This builds on that infrastructure.
