### PR TITLE
feat(workspace): scaffold multi-initiative shape (current initiative + workspace-plan.md)

### DIFF
--- a/.claude/commands/session-start.md
+++ b/.claude/commands/session-start.md
@@ -4,9 +4,10 @@ description: Load the working folder's CONTEXT.md, SESSION-LOG.md, and current p
 
 Before we start, read these files in my AI working folder, in order:
 
-1. `<working-folder>/CONTEXT.md` — project overview, working rules, current phase
-2. `<working-folder>/SESSION-LOG.md` — chronological session history
-3. The current phase's checklist (e.g. `<working-folder>/phase-<N>-checklist.md`)
+1. **In workspace mode only** — if `<working-folder>/../workspace-CONTEXT.md` exists, read it FIRST. It tells you the current initiative so the per-repo load below makes sense in context. Also read `<working-folder>/../workspace-plan.md` if it exists for the broader initiative arc.
+2. `<working-folder>/CONTEXT.md` — project overview, working rules, current phase
+3. `<working-folder>/SESSION-LOG.md` — chronological session history
+4. The current phase's checklist (e.g. `<working-folder>/phase-<N>-checklist.md`)
 
 These are my persistent project context — they live outside the repo and hold scope, decisions, and current status. Don't edit them unless I ask; updates happen at session end.
 

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -41,6 +41,7 @@ landed most recently, and any open threads. Then wait for my next instruction.
 - Replace `<working-folder>` with the actual path (e.g. `~/Documents/Claude/Projects/my-project/`).
 - If you're resuming mid-PR, use [Prompt 4](#4-resuming-mid-pr) instead of either form above — it loads the same context but adds a structured branch + PR + CI assessment.
 - The `/session-start` slash command (in `templates/.claude/commands/`) runs the verbose flow as a one-step invocation. Copy it into your repo's `.claude/commands/` to enable.
+- **In workspace mode** (the working folder is a per-repo subfolder under a workspace dir), Claude should read `../workspace-CONTEXT.md` *first*, **before** the per-repo files — it identifies the **current initiative** so the per-repo load makes sense in context. Then read `../workspace-plan.md` if available for the broader initiative arc. Then load `<working-folder>/CONTEXT.md` etc. as normal. The verbose form's file list still works at the per-repo level; the workspace-level reads are additive.
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -271,8 +271,9 @@ If a future change is *not* backwards-compatible (rare for a docs-only kit — o
 When a single piece of work spans multiple repos (e.g. Terraform environment definitions in one repo and modules in another), use `--workspace` so bootstrap creates a workspace folder above per-repo subfolders. The model is documented in [ADR-0001](docs/adr/0001-multi-repo-folder-model.md); summary:
 
 ```
-~/<projects-root>/<initiative>/
-├── workspace-CONTEXT.md      ← cross-repo overview
+~/<projects-root>/<workspace-name>/
+├── workspace-CONTEXT.md      ← cross-repo overview + current initiative
+├── workspace-plan.md         ← initiative list (current, planned, completed)
 ├── tickets/                  ← per-ticket scratchpads
 │   ├── <KEY>-<slug>.md
 │   └── archive/
@@ -281,6 +282,17 @@ When a single piece of work spans multiple repos (e.g. Terraform environment def
 └── <repo-b>/
     └── ...
 ```
+
+### Single-initiative vs. long-running workspaces
+
+Workspace mode supports two patterns at the same layout — pick the framing that matches your work:
+
+- **Single-initiative workspace** — the workspace exists for one piece of work spanning multiple repos (e.g. "ship LX-1234 across envs + modules"). Once that work ships, the workspace's lifecycle ends. Use this for short-lived, scoped multi-repo changes.
+- **Long-running multi-initiative workspace** — the workspace is a persistent program (e.g. "fdx-infrastructure", "platform observability"), hosting a sequence of initiatives over months or years. The active initiative changes over time; past initiatives are chronicled in `workspace-CONTEXT.md`'s "Past initiatives" section and `workspace-plan.md`'s "Completed initiatives" section.
+
+The templates support both. For single-initiative use, fill in "Current Initiative" once and leave "Past initiatives" empty. For long-running use, update "Current Initiative" each time the active piece of work changes; old entries roll into "Past initiatives". `workspace-plan.md` mirrors per-repo `plan.md` at workspace scope — it's where initiative scope notes, planned-but-not-started work, and completed-initiative chronicles live.
+
+If a workspace's purpose drifts substantially (e.g. an "fdx-infrastructure" workspace that started for Terraform now becoming a general program), consider whether the right move is a new workspace rather than retrofitting the old one.
 
 ### First repo in a new workspace
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -788,6 +788,7 @@ if [ "$DRY_RUN" -eq 1 ]; then
     else
       echo "  + create workspace dir + tickets/archive/"
       echo "  + copy $KIT_ROOT/templates/workspace/workspace-CONTEXT.md → workspace-CONTEXT.md"
+      echo "  + copy $KIT_ROOT/templates/workspace/workspace-plan.md → workspace-plan.md"
     fi
     echo
   fi
@@ -882,7 +883,8 @@ if [ "$WORKSPACE_MODE" -eq 1 ]; then
   mkdir -p "$WORKSPACE_DIR/tickets/archive"
   if [ ! -f "$WORKSPACE_DIR/workspace-CONTEXT.md" ]; then
     cp "$KIT_ROOT/templates/workspace/workspace-CONTEXT.md" "$WORKSPACE_DIR/"
-    echo "  ✓ Created workspace at $WORKSPACE_DIR (workspace-CONTEXT.md, tickets/archive/)"
+    cp "$KIT_ROOT/templates/workspace/workspace-plan.md" "$WORKSPACE_DIR/"
+    echo "  ✓ Created workspace at $WORKSPACE_DIR (workspace-CONTEXT.md, workspace-plan.md, tickets/archive/)"
     WORKSPACE_FIRST_REPO=1
   else
     echo "  ✓ Existing workspace at $WORKSPACE_DIR — adding repo subfolder $WORKSPACE_REPO_NAME"

--- a/templates/.claude/commands/session-start.md
+++ b/templates/.claude/commands/session-start.md
@@ -4,9 +4,10 @@ description: Load the working folder's CONTEXT.md, SESSION-LOG.md, and current p
 
 Before we start, read these files in my AI working folder, in order:
 
-1. `<working-folder>/CONTEXT.md` — project overview, working rules, current phase
-2. `<working-folder>/SESSION-LOG.md` — chronological session history
-3. The current phase's checklist (e.g. `<working-folder>/phase-<N>-checklist.md`)
+1. **In workspace mode only** — if `<working-folder>/../workspace-CONTEXT.md` exists, read it FIRST. It tells you the current initiative so the per-repo load below makes sense in context. Also read `<working-folder>/../workspace-plan.md` if it exists for the broader initiative arc.
+2. `<working-folder>/CONTEXT.md` — project overview, working rules, current phase
+3. `<working-folder>/SESSION-LOG.md` — chronological session history
+4. The current phase's checklist (e.g. `<working-folder>/phase-<N>-checklist.md`)
 
 These are my persistent project context — they live outside the repo and hold scope, decisions, and current status. Don't edit them unless I ask; updates happen at session end.
 

--- a/templates/workspace/workspace-CONTEXT.md
+++ b/templates/workspace/workspace-CONTEXT.md
@@ -1,4 +1,4 @@
-# Workspace — {{INITIATIVE_NAME}}
+# Workspace — {{WORKSPACE_NAME}}
 **Last updated:** {{YYYY-MM-DD}}
 
 ---
@@ -8,24 +8,50 @@
 At the start of any session that spans multiple repos in this workspace, say:
 > "Read workspace-CONTEXT.md before we start."
 
-Per-repo context (`<repo>/CONTEXT.md`, `<repo>/SESSION-LOG.md`) lives in each repo's subfolder; load that for the specific repo when work narrows to that repo. Per-ticket scratchpads live at `tickets/<KEY>-<slug>.md` (active) and `tickets/archive/` (closed).
+Read this file **first** in workspace mode — it tells Claude the *current initiative* so per-repo context loads make sense. Per-repo context (`<repo>/CONTEXT.md`, `<repo>/SESSION-LOG.md`) lives in each repo's subfolder; load that for the specific repo when work narrows to that repo. Per-ticket scratchpads live at `tickets/<KEY>-<slug>.md` (active) and `tickets/archive/` (closed).
 
 This file is private — never commit it to any repo.
 
 ---
 
-## Initiative Overview
+## Workspace Overview
 
-{{ONE_PARAGRAPH_DESCRIPTION — what this initiative is, why it spans these repos, what done looks like}}
+{{ONE_PARAGRAPH_DESCRIPTION — what this workspace is, the program/team/scope it represents, and why these repos belong together. Persists across initiatives — write the workspace's enduring purpose, not the current piece of work.}}
 
-- **Initiative key (if applicable):** {{e.g. epic key, OKR ID, project codename}}
-- **Status:** {{active | paused | wrapping up | done}}
+- **Program / team:** {{e.g. Platform, FDX Infrastructure, Data}}
+- **Stakeholders:** {{teams / leads / on-call rotations involved across initiatives}}
+- **Started:** {{YYYY-MM-DD}}
+
+---
+
+## Current Initiative
+
+The active initiative this workspace is focused on. **Update this section when initiatives change** (`/close-phase` style — close out the previous initiative below in "Past initiatives", then bump this section).
+
+- **Initiative:** {{e.g. Terraform foundation, Helm migration, Observability stack rollout}}
+- **Initiative key (if applicable):** {{epic / OKR ID / project codename}}
+- **Status:** {{kicking off | active | wrapping up | done}}
+- **Started:** {{YYYY-MM-DD}}
+- **Target completion:** {{YYYY-MM-DD or "open-ended"}}
+- **Why this initiative now:** {{one sentence — the driver or trigger}}
+- **Repos primarily touched:** {{<repo-a>, <repo-b>}}
+
+**Plan** — see [`workspace-plan.md`](workspace-plan.md) for the full initiative list and per-initiative plans.
+
+---
+
+## Past initiatives
+
+Chronicle of completed initiatives in this workspace. Keep entries to one or two lines so the file stays scannable; deeper history lives in `workspace-plan.md` and the per-repo `SESSION-LOG.md` files.
+
+- {{YYYY-MM-DD}} — **{{initiative name}}** — {{one-line summary; key outcome / cross-reference (PR, archived ticket, plan section)}}
+- …
 
 ---
 
 ## Tracker Configuration
 
-Shared tracker config for the initiative. If a single tracker covers all repos, capture it here once instead of duplicating in each `<repo>/CONTEXT.md`.
+Shared tracker config for the workspace. If a single tracker covers all repos, capture it here once instead of duplicating in each `<repo>/CONTEXT.md`.
 
 - **Tracker type:** {{TRACKER_TYPE}}
 - **Project / team key:** {{TRACKER_KEY}}
@@ -50,10 +76,10 @@ See `CONVENTIONS.md` (kit-level — `## Ticket-driven workflows`) for the branch
 Active per-ticket scratchpads live under `tickets/<KEY>-<slug>.md`. Closed ticket files move to `tickets/archive/`.
 
 **Active:**
-- [{{KEY}}](tickets/{{KEY}}-{{slug}}.md) — {{one-line summary; repos touched}}
+- [{{KEY}}](tickets/{{KEY}}-{{slug}}.md) — {{one-line summary; repos touched; initiative}}
 
 **Recently archived:**
-- [{{KEY}}](tickets/archive/{{KEY}}-{{slug}}.md) — {{one-line "what shipped"}}
+- [{{KEY}}](tickets/archive/{{KEY}}-{{slug}}.md) — {{one-line "what shipped"; initiative}}
 
 ---
 
@@ -65,6 +91,7 @@ Active per-ticket scratchpads live under `tickets/<KEY>-<slug>.md`. Closed ticke
 
 ## Reference
 
+- [`workspace-plan.md`](workspace-plan.md) — initiative list, current + past + planned, with per-initiative scope notes
 - `tickets/` — per-ticket scratchpads (per [`docs/adr/0001-multi-repo-folder-model.md`](https://github.com/IamMrCupp/claude-project-kit/blob/main/docs/adr/0001-multi-repo-folder-model.md) in the kit)
 - `<repo>/CONTEXT.md` — per-repo context (one per repo subfolder)
 - `<repo>/SESSION-LOG.md` — per-repo session history

--- a/templates/workspace/workspace-plan.md
+++ b/templates/workspace/workspace-plan.md
@@ -1,0 +1,66 @@
+# Workspace Plan — {{WORKSPACE_NAME}}
+
+The persistent plan for this workspace. Tracks initiatives over time — current, planned, completed. Per-repo phase plans live in each repo's `plan.md`; this file sits one level up and chronicles the program-level arc.
+
+**Update cadence:**
+- When a new initiative kicks off — add it under "Active initiative" and move the prior one (if any) to "Completed initiatives".
+- When scope of the active initiative changes meaningfully — edit in place, note the date.
+- When new initiatives appear on the horizon — add to "Planned / on deck" with whatever certainty you have.
+
+This file is the workspace counterpart to a per-repo `plan.md`. Keep it scannable; deeper detail belongs in per-repo planning docs or per-ticket scratchpads.
+
+---
+
+## Active initiative
+
+### {{Initiative name}} — {{kicking off | active | wrapping up}}
+
+**Started:** {{YYYY-MM-DD}}
+**Target completion:** {{YYYY-MM-DD or "open-ended"}}
+**Initiative key:** {{epic / OKR / codename}}
+**Repos primarily touched:** {{<repo-a>, <repo-b>}}
+
+**Goal:** {{one paragraph — what done looks like}}
+
+**Scope (what's in):**
+- {{…}}
+- {{…}}
+
+**Out of scope (deliberate):**
+- {{…}}
+
+**Open questions / risks:**
+- {{…}}
+
+**Cross-references:**
+- Per-repo plan sections: {{<repo-a>/plan.md#section, <repo-b>/plan.md#section}}
+- Tracker epic / parent: {{key + link if applicable}}
+
+---
+
+## Planned / on deck
+
+Initiatives the workspace expects to take on but isn't actively working yet. Order = rough priority. Move to "Active initiative" when work starts.
+
+- **{{Initiative name}}** — {{one-paragraph scope; trigger that starts it}}
+- **{{Initiative name}}** — {{…}}
+
+---
+
+## Completed initiatives
+
+Chronicle of what this workspace has shipped, most recent first. Each entry is one paragraph max plus cross-references — anything more detailed lives in per-repo `SESSION-LOG.md` entries and archived ticket scratchpads.
+
+### {{YYYY-MM-DD}} — {{Initiative name}}
+
+**Outcome:** {{one or two sentences — what shipped, the impact}}
+
+**Key cross-references:**
+- {{archived tickets, key PRs, ADRs spawned}}
+
+---
+
+## Notes
+
+- The workspace itself is long-running; initiatives come and go. If the workspace's purpose drifts substantially, consider whether you actually want a *new* workspace rather than retrofitting this one.
+- For converting a single-repo working folder into a workspace, see [SETUP.md §Upgrading a single-repo working folder to a workspace](https://github.com/IamMrCupp/claude-project-kit/blob/main/SETUP.md#upgrading-a-single-repo-working-folder-to-a-workspace) in the kit.

--- a/tests/bootstrap_workspace.bats
+++ b/tests/bootstrap_workspace.bats
@@ -36,6 +36,25 @@ teardown() { bootstrap_teardown; }
   grep -q "Workspace —" "$WS/workspace-CONTEXT.md"
 }
 
+@test "--workspace copies workspace-plan.md to workspace root" {
+  WS="$TEST_TMP/lx-platform"
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -eq 0 ]
+
+  [ -f "$WS/workspace-plan.md" ]
+  grep -q "Workspace Plan —" "$WS/workspace-plan.md"
+  grep -q "Active initiative" "$WS/workspace-plan.md"
+}
+
+@test "--workspace workspace-CONTEXT.md has Current Initiative + Past initiatives sections" {
+  WS="$TEST_TMP/lx-platform"
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -eq 0 ]
+
+  grep -q "^## Current Initiative$" "$WS/workspace-CONTEXT.md"
+  grep -q "^## Past initiatives$" "$WS/workspace-CONTEXT.md"
+}
+
 @test "--workspace populates per-repo subfolder with standard templates" {
   WS="$TEST_TMP/lx-platform"
   run "$BOOTSTRAP" --workspace "$WS" --skip-memory


### PR DESCRIPTION
## Summary

Lightweight first cut at multi-initiative workspace mode for #133, scoped specifically to support tonight's `platform-infra` dogfood without locking in heavier design choices that benefit from real-use signal.

**What ships in this PR:**
- `templates/workspace/workspace-CONTEXT.md` rewritten — the previous "Initiative Overview" (single-initiative shape) is replaced with **"Workspace Overview" + "Current Initiative" + "Past initiatives"**. The workspace is now framed as the long-running container; initiatives flow through it.
- New `templates/workspace/workspace-plan.md` — counterpart to per-repo `plan.md` at workspace scope. Tracks **active / planned / completed** initiatives, with per-initiative scope notes.
- `bootstrap.sh --workspace` first-repo run now copies BOTH workspace files (and lists them in `--dry-run` preview).
- `SETUP.md §Workspace mode` gains a "Single-initiative vs. long-running workspaces" subsection explaining when each pattern fits and how the templates support both.
- `PROMPTS.md` Prompt 1 + the `/session-start` slash command pick up an instruction to read `../workspace-CONTEXT.md` (and `../workspace-plan.md` if present) **before** per-repo files in workspace mode — the current initiative is what makes the per-repo load make sense.
- 2 new bats tests confirm the new file copies + that workspace-CONTEXT.md has the right section headers.

**What's deferred (PR 2+, after dogfood):**
- `workspace-phase-N-checklist.md` template — wait to see whether you actually want phases at workspace scope or whether per-initiative phase tracking inside per-repo checklists is enough.
- Updated `examples/acme-platform/` exemplar showing multi-initiative shape — best built from the actual platform-infra dogfood structure.
- Dedicated session-start prompt variant for multi-initiative workspaces — wait to see what hand-back is most useful.
- Formal ADR for workspace-scale phase/initiative tracking — write after the design is validated by use, not before.

Partial-progress against #133. The remaining acceptance criteria stay open on that issue and get worked once you've used the new shape for a session or two and have signal on what hurts.

## Why ship now (lightweight scope)

[#133 itself](https://github.com/IamMrCupp/claude-project-kit/issues/133) flags this: *"This is the first real test; friction points should be captured fast and feed this issue's design."* Shipping the full design before tonight's dogfood would lock in choices that should be informed by real use. The lightweight scope here gives `platform-infra` the right shape from the start (current-initiative tracking, workspace plan) without over-committing.

## Test plan

- [x] `bats tests/` — full suite 174/174 pass (+2 new tests in `tests/bootstrap_workspace.bats` for the new file + section headers).
- [x] Eyeballed `--workspace --dry-run` output — `workspace-plan.md` appears in the planned-creates list.
- [x] Eyeballed actual `--workspace` first-repo run — both files land at workspace root with substituted tracker config.
- [x] Existing `--workspace` re-run idempotency tests still pass (workspace files preserved on additional-repo bootstraps).
- [x] Kit dogfood `.claude/` synced via `scripts/sync-claude-dogfood.sh`; `tests/dogfood_claude_in_sync.bats` still passes.
- [ ] Lychee link-check passes (CI).

## Out of scope

Listed in #133 — explicitly:
- Workspace rename (#115 — separate work)
- Cross-workspace operations
- Tracker integration changes (existing flow already works at workspace scope)

## Related

- #133 — partial progress; remaining ACs stay open for post-dogfood follow-up.
- #115 (workspace rename) — adjacent; up next.
- Tonight's dogfood (`platform-infra`) — drives validation.
