### PR TITLE
feat(scripts): add rename-workspace.sh helper

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -313,6 +313,31 @@ Once a workspace is set up with tracker config (`--tracker jira --jira-project L
 
 Idempotence: both refuse to overwrite an existing scratchpad with the same `<KEY>-` prefix (active or archived). Re-pull by removing or archiving the old file first, or do it from Claude (the slash command can re-pull if you confirm).
 
+### Renaming a workspace
+
+A naive `mv` of the workspace folder works for the directory tree, but **leaves stale references** in per-repo auto-memory at `~/.claude/projects/<sanitized-repo-path>/memory/reference_ai_working_folder.md` (which pins the workspace path baked in at bootstrap time). Use the rename helper instead:
+
+```bash
+<framework-dir>/scripts/rename-workspace.sh \
+  ~/Documents/Claude/Projects/<old-name>/ \
+  ~/Documents/Claude/Projects/<new-name>/
+```
+
+The helper:
+
+1. `mv`s the workspace directory.
+2. Rewrites every auto-memory file across `~/.claude/projects/*/memory/*.md` that referenced the old path.
+3. Backs each rewritten memory file up to `<file>.bak.<timestamp>` first.
+4. Reports any old-path references **inside** the workspace tree (in `workspace-CONTEXT.md`, per-repo `CONTEXT.md`, etc.) — these are NOT auto-rewritten because prose may legitimately reference history. Review and edit by hand if appropriate.
+
+Pass `--dry-run` to preview before committing:
+
+```bash
+<framework-dir>/scripts/rename-workspace.sh --dry-run \
+  ~/Documents/Claude/Projects/<old-name>/ \
+  ~/Documents/Claude/Projects/<new-name>/
+```
+
 ### What `--workspace` does NOT do (yet)
 
 - **Interactive workspace prompt** — `--workspace` requires the explicit flag. Interactive mode still defaults to single-repo. Use the flag-based form above for workspace bootstraps.

--- a/scripts/rename-workspace.sh
+++ b/scripts/rename-workspace.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Rename a kit workspace folder: mv the workspace tree AND fix up the
+# per-repo auto-memory files that pin the old path.
+#
+# Why this exists: per-repo auto-memory at
+# ~/.claude/projects/<sanitized-repo-path>/memory/reference_ai_working_folder.md
+# contains the workspace-relative {{WORKING_FOLDER}} path baked in at bootstrap
+# time. The memory directory is keyed off the *repo* path (not the workspace
+# path), so a naive `mv` of the workspace directory leaves stale path references
+# in those memory files. This helper does the mv and the memory rewrite atomically.
+#
+# Prose inside the workspace tree itself (workspace-CONTEXT.md, per-repo
+# CONTEXT.md, SESSION-LOG.md, etc.) is NOT auto-rewritten — those files may
+# legitimately reference the old path in historical entries. The helper greps
+# and reports matches so the user can review and edit by hand if appropriate.
+set -euo pipefail
+
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "error: rename-workspace.sh requires bash" >&2
+  exit 1
+fi
+
+usage() {
+  cat <<EOF
+Usage: rename-workspace.sh [options] <old-workspace-path> <new-workspace-path>
+
+Rename a kit workspace folder. Both paths must be absolute. The old path must
+exist and contain workspace-CONTEXT.md (i.e. it must have been bootstrapped
+with --workspace). The new path must NOT already exist.
+
+What happens:
+  1. mv <old-workspace-path> <new-workspace-path>
+  2. Rewrite per-repo auto-memory files (~/.claude/projects/.../memory/*.md)
+     that contained <old-workspace-path>, replacing it with <new-workspace-path>.
+  3. Grep the moved workspace tree for any remaining <old-workspace-path>
+     string matches (in workspace-CONTEXT.md, per-repo CONTEXT.md, etc.) and
+     REPORT them — these are NOT auto-rewritten since prose may legitimately
+     reference history.
+
+Options:
+  --dry-run     Show what would change. No mv, no memory edits.
+  -h, --help    Show this help and exit.
+
+Examples:
+  # Rename ~/Documents/Claude/Projects/old-name to ...new-name
+  rename-workspace.sh \\
+    ~/Documents/Claude/Projects/old-name \\
+    ~/Documents/Claude/Projects/new-name
+
+  # Preview without writing
+  rename-workspace.sh --dry-run \\
+    ~/Documents/Claude/Projects/old-name \\
+    ~/Documents/Claude/Projects/new-name
+EOF
+}
+
+DRY_RUN=0
+OLD=""
+NEW=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --*) echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *)
+      if [ -z "$OLD" ]; then
+        OLD="$1"
+      elif [ -z "$NEW" ]; then
+        NEW="$1"
+      else
+        echo "error: unexpected extra argument: $1" >&2
+        usage >&2
+        exit 2
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$OLD" ] || [ -z "$NEW" ]; then
+  echo "error: both <old-workspace-path> and <new-workspace-path> are required" >&2
+  usage >&2
+  exit 2
+fi
+
+# Tilde expansion (in case argument was literal "~/...")
+case "$OLD" in
+  "~") OLD="$HOME" ;;
+  "~/"*) OLD="$HOME/${OLD#"~/"}" ;;
+esac
+case "$NEW" in
+  "~") NEW="$HOME" ;;
+  "~/"*) NEW="$HOME/${NEW#"~/"}" ;;
+esac
+
+case "$OLD" in /*) ;; *) echo "error: old path must be absolute (got: $OLD)" >&2; exit 2 ;; esac
+case "$NEW" in /*) ;; *) echo "error: new path must be absolute (got: $NEW)" >&2; exit 2 ;; esac
+
+# Strip trailing slashes for consistent string-replacement
+OLD="${OLD%/}"
+NEW="${NEW%/}"
+
+if [ "$OLD" = "$NEW" ]; then
+  echo "error: old and new paths are identical" >&2
+  exit 2
+fi
+
+if [ ! -d "$OLD" ]; then
+  echo "error: old workspace path does not exist or is not a directory: $OLD" >&2
+  exit 2
+fi
+
+if [ ! -f "$OLD/workspace-CONTEXT.md" ]; then
+  echo "error: $OLD does not look like a kit workspace (no workspace-CONTEXT.md)" >&2
+  exit 2
+fi
+
+if [ -e "$NEW" ]; then
+  echo "error: new workspace path already exists: $NEW" >&2
+  echo "       Refusing to overwrite. Choose a different new path." >&2
+  exit 2
+fi
+
+# Find auto-memory files that contain the old workspace path. The memory dir
+# layout (per Claude harness): ~/.claude/projects/<sanitized-repo-path>/memory/*.md.
+MEMORY_ROOT="$HOME/.claude/projects"
+AFFECTED_MEMORY_FILES=()
+if [ -d "$MEMORY_ROOT" ]; then
+  while IFS= read -r f; do
+    [ -n "$f" ] && AFFECTED_MEMORY_FILES+=("$f")
+  done < <(grep -rl -F "$OLD" "$MEMORY_ROOT" 2>/dev/null || true)
+fi
+
+echo "Workspace rename plan"
+echo "  Old: $OLD"
+echo "  New: $NEW"
+echo
+
+if [ "${#AFFECTED_MEMORY_FILES[@]}" -eq 0 ]; then
+  echo "  No auto-memory files reference the old path."
+else
+  echo "  Auto-memory files that will be rewritten (${#AFFECTED_MEMORY_FILES[@]}):"
+  for f in "${AFFECTED_MEMORY_FILES[@]}"; do
+    echo "    - $f"
+  done
+fi
+echo
+
+# Grep workspace tree for old-path matches (these are reported, not rewritten).
+WORKSPACE_TREE_MATCHES=()
+while IFS= read -r line; do
+  [ -n "$line" ] && WORKSPACE_TREE_MATCHES+=("$line")
+done < <(grep -rn -F "$OLD" "$OLD" --include='*.md' 2>/dev/null || true)
+
+if [ "${#WORKSPACE_TREE_MATCHES[@]}" -eq 0 ]; then
+  echo "  No old-path references inside the workspace tree."
+else
+  echo "  Old-path references INSIDE the workspace tree (NOT auto-rewritten — review by hand):"
+  for line in "${WORKSPACE_TREE_MATCHES[@]}"; do
+    echo "    $line"
+  done
+fi
+echo
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "=== DRY RUN — no changes made ==="
+  echo "Re-run without --dry-run to apply."
+  exit 0
+fi
+
+# Perform the rename. mv first; if mv fails, abort before touching memory.
+echo "Renaming workspace directory..."
+mv "$OLD" "$NEW"
+echo "  ✓ moved $OLD → $NEW"
+
+# Rewrite memory files. If anything fails here, the workspace dir stays at NEW
+# (it can be reverted by hand: mv "$NEW" "$OLD" + un-edited memory).
+if [ "${#AFFECTED_MEMORY_FILES[@]}" -gt 0 ]; then
+  echo "Rewriting auto-memory references..."
+  for f in "${AFFECTED_MEMORY_FILES[@]}"; do
+    # Use a delimiter unlikely to appear in paths (we use | and rely on no |
+    # in HOME-rooted paths). Backup created with .bak.<timestamp> suffix.
+    BAK="$f.bak.$(date +%Y%m%d-%H%M%S)"
+    cp "$f" "$BAK"
+    # macOS sed and GNU sed differ on -i; use a portable pattern.
+    if sed --version >/dev/null 2>&1; then
+      sed -i "s|$OLD|$NEW|g" "$f"
+    else
+      sed -i '' "s|$OLD|$NEW|g" "$f"
+    fi
+    echo "  ✓ rewrote $f (backup: $BAK)"
+  done
+fi
+
+echo
+echo "Workspace rename complete."
+if [ "${#WORKSPACE_TREE_MATCHES[@]}" -gt 0 ]; then
+  echo
+  echo "Reminder — the workspace tree itself still has old-path references"
+  echo "in prose (listed above). Review and edit by hand if those should change."
+fi

--- a/tests/rename_workspace.bats
+++ b/tests/rename_workspace.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+# scripts/rename-workspace.sh — rename a kit workspace folder + fix up the
+# per-repo auto-memory files that pin the old path. Workspace-tree prose is
+# reported, not auto-rewritten.
+
+load 'helpers'
+
+RENAME="$KIT_ROOT/scripts/rename-workspace.sh"
+
+setup() { bootstrap_setup; }
+teardown() { bootstrap_teardown; }
+
+# Set up a workspace + bootstrap one repo into it. Returns nothing; sets
+# OLD_WS, NEW_WS, MEM_FILE globals for the test to use.
+setup_workspace_with_one_repo() {
+  OLD_WS="$TEST_TMP/old-workspace"
+  NEW_WS="$TEST_TMP/new-workspace"
+  run "$BOOTSTRAP" --workspace "$OLD_WS"
+  [ "$status" -eq 0 ]
+  MEM_FILE="$(memory_dir)/reference_ai_working_folder.md"
+  [ -f "$MEM_FILE" ]
+  # The memory file should reference the OLD path
+  grep -qF "$OLD_WS" "$MEM_FILE"
+}
+
+@test "rename-workspace.sh -h prints usage" {
+  run "$RENAME" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: rename-workspace.sh"* ]]
+  [[ "$output" == *"<old-workspace-path>"* ]]
+  [[ "$output" == *"<new-workspace-path>"* ]]
+}
+
+@test "rename-workspace.sh errors when args missing" {
+  run "$RENAME"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"both <old-workspace-path> and <new-workspace-path> are required"* ]]
+}
+
+@test "rename-workspace.sh errors on relative paths" {
+  run "$RENAME" relative/old absolute/new
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be absolute"* ]]
+}
+
+@test "rename-workspace.sh errors when old and new are the same" {
+  WS="$TEST_TMP/foo"
+  mkdir -p "$WS"
+  touch "$WS/workspace-CONTEXT.md"
+  run "$RENAME" "$WS" "$WS"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"identical"* ]]
+}
+
+@test "rename-workspace.sh errors when old workspace doesn't exist" {
+  run "$RENAME" "$TEST_TMP/nonexistent" "$TEST_TMP/new"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not exist"* ]]
+}
+
+@test "rename-workspace.sh errors when old path is not a kit workspace" {
+  WS="$TEST_TMP/notakitws"
+  mkdir -p "$WS"
+  echo "hi" > "$WS/random.md"
+  run "$RENAME" "$WS" "$TEST_TMP/new"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"workspace-CONTEXT.md"* ]]
+}
+
+@test "rename-workspace.sh errors when new path already exists" {
+  setup_workspace_with_one_repo
+  mkdir -p "$NEW_WS"
+  run "$RENAME" "$OLD_WS" "$NEW_WS"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"already exists"* ]]
+}
+
+@test "rename-workspace.sh --dry-run shows plan and writes nothing" {
+  setup_workspace_with_one_repo
+
+  run "$RENAME" --dry-run "$OLD_WS" "$NEW_WS"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY RUN"* ]]
+  [[ "$output" == *"will be rewritten"* ]] || [[ "$output" == *"No auto-memory files"* ]]
+
+  # Workspace dir not moved
+  [ -d "$OLD_WS" ]
+  [ ! -d "$NEW_WS" ]
+  # Memory file unchanged
+  grep -qF "$OLD_WS" "$MEM_FILE"
+  ! grep -qF "$NEW_WS" "$MEM_FILE"
+}
+
+@test "rename-workspace.sh moves the workspace dir" {
+  setup_workspace_with_one_repo
+
+  run "$RENAME" "$OLD_WS" "$NEW_WS"
+  [ "$status" -eq 0 ]
+
+  [ ! -d "$OLD_WS" ]
+  [ -d "$NEW_WS" ]
+  [ -f "$NEW_WS/workspace-CONTEXT.md" ]
+}
+
+@test "rename-workspace.sh rewrites auto-memory reference_ai_working_folder.md" {
+  setup_workspace_with_one_repo
+
+  run "$RENAME" "$OLD_WS" "$NEW_WS"
+  [ "$status" -eq 0 ]
+
+  # Memory file now references new path, not old
+  grep -qF "$NEW_WS" "$MEM_FILE"
+  ! grep -qF "$OLD_WS" "$MEM_FILE"
+}
+
+@test "rename-workspace.sh creates a backup of memory files before rewriting" {
+  setup_workspace_with_one_repo
+
+  run "$RENAME" "$OLD_WS" "$NEW_WS"
+  [ "$status" -eq 0 ]
+
+  # At least one .bak.<timestamp> file exists alongside the rewritten memory
+  ls "$MEM_FILE".bak.* >/dev/null 2>&1
+  # The backup contains the OLD path
+  BAK="$(ls "$MEM_FILE".bak.* | head -1)"
+  grep -qF "$OLD_WS" "$BAK"
+}
+
+@test "rename-workspace.sh reports workspace-tree matches without rewriting them" {
+  setup_workspace_with_one_repo
+
+  # Inject an old-path reference into a per-repo file inside the workspace
+  REPO_NAME="$(basename "$TEST_REPO")"
+  echo "Reference to $OLD_WS in prose" >> "$OLD_WS/$REPO_NAME/CONTEXT.md"
+
+  run "$RENAME" --dry-run "$OLD_WS" "$NEW_WS"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"NOT auto-rewritten"* ]]
+  [[ "$output" == *"$REPO_NAME/CONTEXT.md"* ]]
+}
+
+@test "rename-workspace.sh handles no-memory case gracefully" {
+  # Set up a workspace WITHOUT auto-memory (--skip-memory)
+  OLD_WS="$TEST_TMP/old-ws"
+  NEW_WS="$TEST_TMP/new-ws"
+  run "$BOOTSTRAP" --workspace "$OLD_WS" --skip-memory
+  [ "$status" -eq 0 ]
+
+  run "$RENAME" "$OLD_WS" "$NEW_WS"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No auto-memory files"* ]]
+  [ -d "$NEW_WS" ]
+}
+
+@test "rename-workspace.sh handles tilde expansion" {
+  HOME_BACKUP="$HOME"
+  export HOME="$TEST_TMP/home2"
+  mkdir -p "$HOME"
+
+  # Bootstrap a workspace under the new HOME
+  cd "$TEST_REPO"
+  run "$BOOTSTRAP" --workspace "$HOME/old-ws" --skip-memory
+  [ "$status" -eq 0 ]
+
+  run "$RENAME" "~/old-ws" "~/new-ws"
+  [ "$status" -eq 0 ]
+  [ -d "$HOME/new-ws" ]
+  [ ! -d "$HOME/old-ws" ]
+
+  export HOME="$HOME_BACKUP"
+}


### PR DESCRIPTION
## Summary

- New `scripts/rename-workspace.sh <old-path> <new-path>` that renames a kit workspace folder AND fixes up the per-repo auto-memory references that pin the old workspace path.
- Backs up each rewritten memory file to `<file>.bak.<timestamp>` first.
- Reports old-path references *inside* the workspace tree (in `workspace-CONTEXT.md`, per-repo `CONTEXT.md`, etc.) but does NOT auto-rewrite them — prose may legitimately reference history; user reviews and edits by hand if appropriate.
- `--dry-run` previews the plan; `-h` shows usage.
- 14 bats tests in `tests/rename_workspace.bats` covering all error paths, dry-run, mv + memory rewrite, backups, no-memory case, and tilde expansion.
- `SETUP.md` §Workspace mode gains a "Renaming a workspace" subsection so the helper is discoverable.

Closes #115.

## Why

Surfaced during dogfood — user wanted to know whether rename was supported before committing to the workspace name `platform-infra`, with the intent to rename later as the workspace evolves. A naive `mv` of the workspace dir leaves stale path references in `~/.claude/projects/<sanitized-repo-path>/memory/reference_ai_working_folder.md` files (which pin the workspace-relative path baked in at bootstrap time). The rename helper does the mv and the memory rewrite atomically, with backups, and surfaces in-workspace prose references for human review.

## Test plan

- [x] `bats tests/rename_workspace.bats` — 14/14 pass.
- [x] `bats tests/` — full suite 186/186 pass (no regressions).
- [x] `-h` prints usage; missing-args / relative-path / nonexistent-old / non-kit-old / existing-new all error cleanly.
- [x] `--dry-run` reports plan + workspace-tree matches without writing.
- [x] Real run: workspace dir moved, memory files rewritten, backups created.
- [x] No-memory edge case (`--skip-memory` workspace) handled cleanly.
- [x] Tilde expansion works for both `<old>` and `<new>` arguments.
- [ ] Lychee link-check passes (CI).

## Out of scope

Per #115:
- Updating user shell aliases / shortcuts pointing at the workspace (kit can't see those).
- Changing the per-repo memory dir location (it's keyed on repo path by design — only the *contents* get rewritten, not the location).
- Auto-rewriting prose inside the workspace tree (workspace-CONTEXT.md historical entries, per-repo SESSION-LOG.md notes referencing the old path) — these are reported, not rewritten.

## Related

- #115 (closes).
- #133 / [#138](https://github.com/IamMrCupp/claude-project-kit/pull/138) (multi-initiative workspace scaffold) — adjacent; ships independently.
- `scripts/sync-memory.sh`, `scripts/install-commands.sh`, `scripts/sync-claude-dogfood.sh` — same write-once-no-overwrite pattern.
