### PR TITLE
feat(commands): graceful degradation when invoked outside a kit working folder

### DIFF
--- a/.claude/agents/session-summarizer.md
+++ b/.claude/agents/session-summarizer.md
@@ -4,6 +4,19 @@ description: Draft the end-of-session SESSION-LOG entry, suggest CONTEXT.md stat
 tools: Read, Bash, Glob
 ---
 
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell the user:
+   > "No kit working folder found for this project. To use this agent, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or invoke me from a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
 You are a session-end scribe for a project that uses the `claude-project-kit` pattern (working folder with `CONTEXT.md`, `SESSION-LOG.md`, `plan.md`, `phase-N-checklist.md`).
 
 ## Goal

--- a/.claude/commands/close-phase.md
+++ b/.claude/commands/close-phase.md
@@ -3,6 +3,19 @@ description: Close a project phase — tick the checklist, update plan.md status
 argument-hint: [phase-number]
 ---
 
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
+   > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
 Close phase $ARGUMENTS of this project. If no phase number was given, read `CONTEXT.md` and infer the current phase.
 
 ## Files to load

--- a/.claude/commands/pull-ticket.md
+++ b/.claude/commands/pull-ticket.md
@@ -3,6 +3,19 @@ description: Pull a tracker ticket into a per-ticket scratchpad. Reads tracker c
 argument-hint: <KEY>
 ---
 
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
+   > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
 I want to pull ticket `$ARGUMENTS` from the project's tracker into a per-ticket scratchpad. Read-only — do not push anything back to the tracker.
 
 ## Step 1 — determine tracker config

--- a/.claude/commands/refresh-context.md
+++ b/.claude/commands/refresh-context.md
@@ -2,6 +2,19 @@
 description: Re-read CONTEXT.md, SESSION-LOG.md, and the current phase checklist mid-session — for picking up changes after a /close-phase or /session-end writeback, or re-anchoring on a long session. Same flow as Prompt 5 in PROMPTS.md.
 ---
 
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
+   > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
 Re-read my AI working folder so the rest of this session uses the latest state.
 
 ## Files to reload

--- a/.claude/commands/session-end.md
+++ b/.claude/commands/session-end.md
@@ -2,6 +2,19 @@
 description: End-of-session wrap-up — draft SESSION-LOG entry, suggest CONTEXT.md status updates, flag unticked checklist items, draft any new memory entries. Same flow as Prompt 3 in PROMPTS.md, packaged as a slash command.
 ---
 
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
+   > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
 We're wrapping up this session. Help me apply the end-of-session hygiene.
 Do NOT edit any files yet — draft everything, show me, and wait for my
 confirmation before writing anything.

--- a/.claude/commands/session-handoff.md
+++ b/.claude/commands/session-handoff.md
@@ -2,6 +2,19 @@
 description: Hand off mid-session — capture everything to disk now, no confirmation gate. Use when context is at risk (window pressure, switching machines, abrupt pause). Drafts and writes immediately; review on next session start.
 ---
 
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
+   > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
 We're handing this session off NOW. Capture everything to disk in one pass —
 do **not** wait for my confirmation. Persistence over polish: I will review on
 the next `/session-start`. The kit's normal `/session-end` flow drafts and waits

--- a/.claude/commands/session-start.md
+++ b/.claude/commands/session-start.md
@@ -2,6 +2,19 @@
 description: Load the working folder's CONTEXT.md, SESSION-LOG.md, and current phase checklist into the session, then hand back a grounding summary. Same flow as Prompt 1 in PROMPTS.md, packaged as a slash command.
 ---
 
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
+   > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
 Before we start, read these files in my AI working folder, in order:
 
 1. `<working-folder>/CONTEXT.md` — project overview, working rules, current phase

--- a/templates/.claude/README.md
+++ b/templates/.claude/README.md
@@ -38,7 +38,7 @@ If you'd rather scope the install to a single repo (overriding any global copies
 
 The staged copy in your working folder stays as a stable reference either way. To copy by hand instead of running the helper, the source is `<kit-dir>/templates/.claude/{commands,agents}/` — copy into `~/.claude/` (global) or `<your-repo>/.claude/` (per-project).
 
-**Caveat — kit-coupling.** All slash commands except `code-reviewer` (which is universal) assume a kit-bootstrapped project (CONTEXT.md / SESSION-LOG.md / phase-N-checklist.md). They will error in non-kit projects until [kit issue #82](https://github.com/IamMrCupp/claude-project-kit/issues/82) (graceful degradation) lands. Installing globally is still the right call if every project you work on is kit-bootstrapped.
+**On kit-coupling.** All slash commands and the `session-summarizer` agent expect a kit-bootstrapped project (CONTEXT.md / SESSION-LOG.md / phase-N-checklist.md / `reference_ai_working_folder.md` in auto-memory). When invoked in a project that isn't bootstrapped, each one **probes for the working folder up front** and bails with a friendly one-liner pointing at `bootstrap.sh` rather than crashing or doing partial work. Safe to install globally — they'll politely no-op outside kit projects. The `code-reviewer` agent is universal and works anywhere with no precheck.
 
 ## Customizing
 

--- a/templates/.claude/agents/session-summarizer.md
+++ b/templates/.claude/agents/session-summarizer.md
@@ -4,6 +4,19 @@ description: Draft the end-of-session SESSION-LOG entry, suggest CONTEXT.md stat
 tools: Read, Bash, Glob
 ---
 
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell the user:
+   > "No kit working folder found for this project. To use this agent, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or invoke me from a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
 You are a session-end scribe for a project that uses the `claude-project-kit` pattern (working folder with `CONTEXT.md`, `SESSION-LOG.md`, `plan.md`, `phase-N-checklist.md`).
 
 ## Goal

--- a/templates/.claude/commands/close-phase.md
+++ b/templates/.claude/commands/close-phase.md
@@ -3,6 +3,19 @@ description: Close a project phase — tick the checklist, update plan.md status
 argument-hint: [phase-number]
 ---
 
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
+   > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
 Close phase $ARGUMENTS of this project. If no phase number was given, read `CONTEXT.md` and infer the current phase.
 
 ## Files to load

--- a/templates/.claude/commands/pull-ticket.md
+++ b/templates/.claude/commands/pull-ticket.md
@@ -3,6 +3,19 @@ description: Pull a tracker ticket into a per-ticket scratchpad. Reads tracker c
 argument-hint: <KEY>
 ---
 
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
+   > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
 I want to pull ticket `$ARGUMENTS` from the project's tracker into a per-ticket scratchpad. Read-only — do not push anything back to the tracker.
 
 ## Step 1 — determine tracker config

--- a/templates/.claude/commands/refresh-context.md
+++ b/templates/.claude/commands/refresh-context.md
@@ -2,6 +2,19 @@
 description: Re-read CONTEXT.md, SESSION-LOG.md, and the current phase checklist mid-session — for picking up changes after a /close-phase or /session-end writeback, or re-anchoring on a long session. Same flow as Prompt 5 in PROMPTS.md.
 ---
 
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
+   > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
 Re-read my AI working folder so the rest of this session uses the latest state.
 
 ## Files to reload

--- a/templates/.claude/commands/session-end.md
+++ b/templates/.claude/commands/session-end.md
@@ -2,6 +2,19 @@
 description: End-of-session wrap-up — draft SESSION-LOG entry, suggest CONTEXT.md status updates, flag unticked checklist items, draft any new memory entries. Same flow as Prompt 3 in PROMPTS.md, packaged as a slash command.
 ---
 
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
+   > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
 We're wrapping up this session. Help me apply the end-of-session hygiene.
 Do NOT edit any files yet — draft everything, show me, and wait for my
 confirmation before writing anything.

--- a/templates/.claude/commands/session-handoff.md
+++ b/templates/.claude/commands/session-handoff.md
@@ -2,6 +2,19 @@
 description: Hand off mid-session — capture everything to disk now, no confirmation gate. Use when context is at risk (window pressure, switching machines, abrupt pause). Drafts and writes immediately; review on next session start.
 ---
 
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
+   > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
 We're handing this session off NOW. Capture everything to disk in one pass —
 do **not** wait for my confirmation. Persistence over polish: I will review on
 the next `/session-start`. The kit's normal `/session-end` flow drafts and waits

--- a/templates/.claude/commands/session-start.md
+++ b/templates/.claude/commands/session-start.md
@@ -2,6 +2,19 @@
 description: Load the working folder's CONTEXT.md, SESSION-LOG.md, and current phase checklist into the session, then hand back a grounding summary. Same flow as Prompt 1 in PROMPTS.md, packaged as a slash command.
 ---
 
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
+   > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
 Before we start, read these files in my AI working folder, in order:
 
 1. `<working-folder>/CONTEXT.md` — project overview, working rules, current phase

--- a/tests/precheck_in_commands.bats
+++ b/tests/precheck_in_commands.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+# Regression check — every kit-coupled slash command and the session-summarizer
+# agent must include a "Precheck — is this a kit project?" block instructing
+# Claude to bail with a friendly message when invoked outside a kit working
+# folder. Closes #82's "graceful degradation" requirement.
+
+load 'helpers'
+
+# Slash commands that read/write kit files (everything except code-reviewer
+# is kit-coupled).
+KIT_COUPLED_COMMANDS=(
+  templates/.claude/commands/session-start.md
+  templates/.claude/commands/session-end.md
+  templates/.claude/commands/session-handoff.md
+  templates/.claude/commands/refresh-context.md
+  templates/.claude/commands/close-phase.md
+  templates/.claude/commands/pull-ticket.md
+)
+
+# Kit-coupled agents (code-reviewer is universal — no kit dependency).
+KIT_COUPLED_AGENTS=(
+  templates/.claude/agents/session-summarizer.md
+)
+
+@test "every kit-coupled slash command includes a Precheck block" {
+  for cmd in "${KIT_COUPLED_COMMANDS[@]}"; do
+    f="$KIT_ROOT/$cmd"
+    [ -f "$f" ]
+    if ! grep -q "^## Precheck — is this a kit project?$" "$f"; then
+      echo "missing Precheck block: $cmd"
+      return 1
+    fi
+  done
+}
+
+@test "every kit-coupled command Precheck mentions reference_ai_working_folder.md" {
+  for cmd in "${KIT_COUPLED_COMMANDS[@]}"; do
+    f="$KIT_ROOT/$cmd"
+    if ! grep -q 'reference_ai_working_folder\.md' "$f"; then
+      echo "missing reference_ai_working_folder.md probe in: $cmd"
+      return 1
+    fi
+  done
+}
+
+@test "every kit-coupled command Precheck has a friendly bail message" {
+  for cmd in "${KIT_COUPLED_COMMANDS[@]}"; do
+    f="$KIT_ROOT/$cmd"
+    if ! grep -q 'No kit working folder found for this project' "$f"; then
+      echo "missing bail message in: $cmd"
+      return 1
+    fi
+  done
+}
+
+@test "kit-coupled agents include a Precheck block" {
+  for agent in "${KIT_COUPLED_AGENTS[@]}"; do
+    f="$KIT_ROOT/$agent"
+    [ -f "$f" ]
+    if ! grep -q "^## Precheck — is this a kit project?$" "$f"; then
+      echo "missing Precheck block: $agent"
+      return 1
+    fi
+  done
+}
+
+@test "code-reviewer agent does NOT include the kit Precheck (universal agent)" {
+  f="$KIT_ROOT/templates/.claude/agents/code-reviewer.md"
+  [ -f "$f" ]
+  ! grep -q "Precheck — is this a kit project" "$f"
+}


### PR DESCRIPTION
## Summary

Every kit-coupled slash command (`/session-start`, `/session-end`, `/session-handoff`, `/refresh-context`, `/close-phase`, `/pull-ticket`) and the kit-coupled `session-summarizer` agent gain a **"Precheck — is this a kit project?"** block at the top of their instructions. When invoked in a project that has not been bootstrapped with the kit, each one now bails with a friendly one-liner pointing at `bootstrap.sh` instead of crashing on missing `CONTEXT.md` reads.

The `code-reviewer` agent stays universal — no precheck, works anywhere.

Closes #82.

## Why

Surfaced as the lingering caveat from #102 / [#131](https://github.com/IamMrCupp/claude-project-kit/pull/131) (`install-commands.sh --global`). Once kit slash commands are installed at user level (`~/.claude/commands/`), they're available in every project on the machine — including non-kit ones. Without a precheck, invoking `/session-end` in a non-kit repo produced a confusing "file not found" cascade as Claude tried to read `CONTEXT.md` etc. that didn't exist. The precheck flips this to a single line of friendly guidance.

The kit-coupling caveat in `templates/.claude/README.md` is also reframed — installing globally is now unambiguously safe.

## Test plan

- [x] `bats tests/precheck_in_commands.bats` — 5/5 pass: regression checks asserting every kit-coupled command + agent has the precheck block, the `reference_ai_working_folder.md` probe, and the bail message; and that `code-reviewer` does NOT have the precheck (universal).
- [x] `bats tests/` — full suite 177/177 pass (no regressions).
- [x] Kit dogfood `.claude/` synced via `scripts/sync-claude-dogfood.sh`; `tests/dogfood_claude_in_sync.bats` still passes.
- [x] Eyeballed each updated command/agent — precheck block reads cleanly and lands before the existing instructions.
- [ ] Lychee link-check passes (CI).

## Out of scope

Per #82:
- Auto-bootstrapping from inside a slash command (the user runs `bootstrap.sh` explicitly).
- Detecting partial-bootstrap states (e.g. `CONTEXT.md` exists but `SESSION-LOG.md` doesn't) — the precheck is binary on `CONTEXT.md` presence; partial states are rare.

## Related

- #82 (closes).
- #102 / [#131](https://github.com/IamMrCupp/claude-project-kit/pull/131) — global install of slash commands. This PR removes the kit-coupling caveat that landed alongside #131.
- Dogfood report 2026-04-30 — third of three follow-on issues queued for tonight.