### PR TITLE
feat(scripts): add sync-templates.sh for working-folder + workspace template upgrades

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -182,7 +182,7 @@ Anything that can't be derived stays as `{{PLACEHOLDER}}` so it's grep-able. The
 
 The memory files are **starters**, not commandments. Prune what doesn't apply, add your own, keep `MEMORY.md` (the index) in sync. The harness loads `MEMORY.md` into context every session, so it stays small (under ~150 lines is a reasonable target).
 
-When the kit ships new starter rules, `scripts/sync-memory.sh <memory-dir>` copies any missing templates into an existing auto-memory dir without overwriting customized files. Skips `MEMORY.md`, `project_current.md`, and `user_role.md` (user-curated). See [SETUP.md §Upgrading an existing project](SETUP.md#upgrading-an-existing-project).
+When the kit ships new starter rules, `scripts/sync-memory.sh <memory-dir>` copies any missing templates into an existing auto-memory dir without overwriting customized files. Skips `MEMORY.md`, `project_current.md`, and `user_role.md` (user-curated). The companion helper for working-folder and workspace templates is `scripts/sync-templates.sh` — same write-once shape (see [SETUP.md §Upgrading an existing project](SETUP.md#upgrading-an-existing-project)).
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -236,7 +236,15 @@ For fully filled-in references, see [`examples/widget-tracker/CONTEXT.md`](examp
 `bootstrap.sh` is deliberately **write-once** — it won't touch a working folder or auto-memory dir that's already populated. When the kit evolves, existing adopters upgrade manually:
 
 1. Check [`CHANGELOG.md`](CHANGELOG.md) to see what's landed since your bootstrap SHA (or since the last time you upgraded). Each entry has a **For existing adopters** section with specifics.
-2. **New files in `templates/`** — copy into your working folder manually:
+2. **New files in `templates/`** — easiest path is the sync helper, which copies any missing templates into a working folder without overwriting existing files (and reports any *outdated* files for you to merge by hand):
+   ```bash
+   # For a single-repo working folder (or a per-repo subfolder of a workspace)
+   <kit-dir>/scripts/sync-templates.sh <working-folder>
+
+   # For workspace-level files (workspace-CONTEXT.md, workspace-plan.md)
+   <kit-dir>/scripts/sync-templates.sh --workspace <workspace-root>
+   ```
+   Pass `--dry-run` first to preview. The helper never overwrites — when an existing file differs from the kit's current template, it reports "outdated; review and merge by hand if desired" rather than clobbering your filled-in content. To copy a single file by hand instead:
    ```bash
    cp <kit-dir>/templates/<NEW_FILE>.md <working-folder>/
    ```

--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Sync working-folder or workspace templates into an existing kit working
+# folder, write-once. Counterpart to scripts/sync-memory.sh and
+# scripts/install-commands.sh — same shape, different source/destination.
+#
+# Default mode: copies any templates/*.md file not already present in the
+# target working folder. Workspace mode (--workspace): copies any
+# templates/workspace/*.md file not already present in the target workspace
+# root.
+#
+# **Never overwrites existing files** — if a file is already present, it is
+# preserved as-is. Files that exist but differ from the kit's current
+# template are reported as "outdated; review and merge by hand if desired"
+# so the user knows there's a kit update available without auto-clobbering
+# their filled-in content.
+#
+# Idempotent — re-running is a no-op once everything is in sync.
+set -euo pipefail
+
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "error: sync-templates.sh requires bash" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KIT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+usage() {
+  cat <<EOF
+Usage: sync-templates.sh [options] <target-folder>
+
+Sync missing kit templates into <target-folder>. Never overwrites existing
+files. Reports files that exist but differ from the kit's current template
+("outdated") so you can review and merge by hand if desired.
+
+Modes:
+  Default            Sync templates/*.md from the kit into <target-folder>.
+                     Use this on a per-repo working folder (or per-repo
+                     subfolder of a workspace).
+  --workspace        Sync templates/workspace/*.md from the kit into
+                     <target-folder>. Use this on a workspace root
+                     (the directory that contains workspace-CONTEXT.md).
+
+Other options:
+  --dry-run          Print what would be copied; write nothing.
+  -h, --help         Show this help and exit.
+
+Arguments:
+  <target-folder>    Absolute path to the target. For default mode, this is
+                     a working folder (per-repo). For --workspace mode,
+                     this is the workspace root.
+
+Examples:
+  # Sync new templates into a single-repo working folder
+  sync-templates.sh ~/Documents/Claude/Projects/my-project
+
+  # Sync workspace-level templates (workspace-CONTEXT.md, workspace-plan.md)
+  sync-templates.sh --workspace ~/Documents/Claude/Projects/fdx-infrastructure
+
+  # Sync a per-repo subfolder under a workspace (use default mode, point
+  # at the repo subfolder, NOT --workspace)
+  sync-templates.sh ~/Documents/Claude/Projects/fdx-infrastructure/terraform-envs
+
+  # Preview without writing
+  sync-templates.sh --dry-run ~/Documents/Claude/Projects/my-project
+
+Notes:
+  - Default mode skips templates/.claude/ (use scripts/install-commands.sh
+    for slash commands and agents).
+  - Default mode skips templates/workspace/ (use --workspace mode for that).
+  - Memory templates have their own helper: scripts/sync-memory.sh.
+EOF
+}
+
+DRY_RUN=0
+WORKSPACE_MODE=0
+TARGET=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workspace) WORKSPACE_MODE=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --*) echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *)
+      if [ -z "$TARGET" ]; then
+        TARGET="$1"
+      else
+        echo "error: unexpected extra argument: $1" >&2
+        usage >&2
+        exit 2
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$TARGET" ]; then
+  echo "error: missing <target-folder> argument" >&2
+  usage >&2
+  exit 2
+fi
+
+case "$TARGET" in
+  "~") TARGET="$HOME" ;;
+  "~/"*) TARGET="$HOME/${TARGET#"~/"}" ;;
+esac
+
+case "$TARGET" in
+  /*) ;;
+  *) echo "error: <target-folder> must be an absolute path (got: $TARGET)" >&2; exit 2 ;;
+esac
+
+if [ ! -d "$TARGET" ]; then
+  echo "error: target folder does not exist: $TARGET" >&2
+  exit 2
+fi
+
+if [ "$WORKSPACE_MODE" -eq 1 ]; then
+  SRC_DIR="$KIT_ROOT/templates/workspace"
+  MODE_LABEL="workspace"
+else
+  SRC_DIR="$KIT_ROOT/templates"
+  MODE_LABEL="working-folder"
+fi
+
+if [ ! -d "$SRC_DIR" ]; then
+  echo "error: kit source dir not found: $SRC_DIR" >&2
+  exit 1
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "=== DRY RUN — no files will be written ==="
+fi
+echo "Mode:   $MODE_LABEL"
+echo "Source: $SRC_DIR"
+echo "Target: $TARGET"
+echo
+
+COPIED=()
+SKIPPED_IDENTICAL=()
+OUTDATED=()
+
+for src_file in "$SRC_DIR"/*.md; do
+  [ -e "$src_file" ] || continue
+  name="$(basename "$src_file")"
+
+  if [ -e "$TARGET/$name" ]; then
+    if cmp -s "$src_file" "$TARGET/$name"; then
+      SKIPPED_IDENTICAL+=("$name")
+    else
+      OUTDATED+=("$name")
+    fi
+    continue
+  fi
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "  + would copy $name"
+  else
+    cp "$src_file" "$TARGET/$name"
+    echo "  ✓ copied $name"
+  fi
+  COPIED+=("$name")
+done
+
+echo
+if [ "${#COPIED[@]}" -eq 0 ] && [ "${#OUTDATED[@]}" -eq 0 ]; then
+  echo "Already in sync — no files to copy, no outdated content."
+  exit 0
+fi
+
+if [ "${#COPIED[@]}" -gt 0 ]; then
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "Would copy ${#COPIED[@]} new file(s). Re-run without --dry-run to apply."
+  else
+    echo "Copied ${#COPIED[@]} new file(s) into $TARGET."
+  fi
+fi
+
+if [ "${#OUTDATED[@]}" -gt 0 ]; then
+  echo
+  echo "Outdated files (exist locally but differ from kit's current template):"
+  for name in "${OUTDATED[@]}"; do
+    echo "  - $name"
+  done
+  echo
+  echo "These were NOT modified — review the kit's version and merge by hand"
+  echo "if desired. Compare with:"
+  echo
+  for name in "${OUTDATED[@]}"; do
+    echo "    diff $SRC_DIR/$name $TARGET/$name"
+    break  # show one example, the user can extrapolate
+  done
+fi

--- a/tests/sync_templates.bats
+++ b/tests/sync_templates.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+# scripts/sync-templates.sh — copy missing templates/*.md (default mode) or
+# templates/workspace/*.md (--workspace) into a target folder. Write-once.
+# Reports outdated existing files; never auto-overwrites.
+
+load 'helpers'
+
+SYNC="$KIT_ROOT/scripts/sync-templates.sh"
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  TARGET="$TEST_TMP/wf"
+  mkdir -p "$TARGET"
+}
+
+teardown() {
+  [ -n "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"
+}
+
+@test "sync-templates.sh -h prints usage" {
+  run "$SYNC" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: sync-templates.sh"* ]]
+  [[ "$output" == *"--workspace"* ]]
+  [[ "$output" == *"--dry-run"* ]]
+}
+
+@test "sync-templates.sh errors when no target arg" {
+  run "$SYNC"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"missing <target-folder> argument"* ]]
+}
+
+@test "sync-templates.sh errors on relative path" {
+  run "$SYNC" relative/path
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be an absolute path"* ]]
+}
+
+@test "sync-templates.sh errors when target doesn't exist" {
+  run "$SYNC" "$TEST_TMP/nonexistent"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"target folder does not exist"* ]]
+}
+
+@test "sync-templates.sh errors on unknown flag" {
+  run "$SYNC" --bogus "$TARGET"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown option"* ]]
+}
+
+@test "default mode copies all templates/*.md into empty target" {
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+
+  for src in "$KIT_ROOT/templates/"*.md; do
+    name="$(basename "$src")"
+    [ -f "$TARGET/$name" ]
+  done
+}
+
+@test "default mode does NOT copy templates/workspace/ contents" {
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+
+  [ ! -f "$TARGET/workspace-CONTEXT.md" ]
+  [ ! -f "$TARGET/workspace-plan.md" ]
+}
+
+@test "--workspace copies templates/workspace/*.md into target" {
+  run "$SYNC" --workspace "$TARGET"
+  [ "$status" -eq 0 ]
+
+  [ -f "$TARGET/workspace-CONTEXT.md" ]
+  [ -f "$TARGET/workspace-plan.md" ]
+  # And does NOT copy single-repo templates
+  [ ! -f "$TARGET/CONTEXT.md" ]
+  [ ! -f "$TARGET/SESSION-LOG.md" ]
+}
+
+@test "sync-templates.sh never overwrites identical files" {
+  cp "$KIT_ROOT/templates/CONTEXT.md" "$TARGET/CONTEXT.md"
+
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+
+  # CONTEXT.md still matches the kit's template (unchanged)
+  cmp -s "$KIT_ROOT/templates/CONTEXT.md" "$TARGET/CONTEXT.md"
+  # Other files were copied
+  [ -f "$TARGET/SESSION-LOG.md" ]
+}
+
+@test "sync-templates.sh never overwrites customized files" {
+  echo "USER_CUSTOMIZED_CONTENT" > "$TARGET/CONTEXT.md"
+  ORIGINAL_HASH="$(md5 -q "$TARGET/CONTEXT.md" 2>/dev/null || md5sum "$TARGET/CONTEXT.md" | awk '{print $1}')"
+
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+
+  # User content preserved
+  AFTER_HASH="$(md5 -q "$TARGET/CONTEXT.md" 2>/dev/null || md5sum "$TARGET/CONTEXT.md" | awk '{print $1}')"
+  [ "$ORIGINAL_HASH" = "$AFTER_HASH" ]
+  grep -q "USER_CUSTOMIZED_CONTENT" "$TARGET/CONTEXT.md"
+}
+
+@test "sync-templates.sh reports outdated files (exist but differ from kit)" {
+  echo "USER_CUSTOMIZED_CONTENT" > "$TARGET/CONTEXT.md"
+
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Outdated files"* ]]
+  [[ "$output" == *"CONTEXT.md"* ]]
+  [[ "$output" == *"NOT modified"* ]]
+}
+
+@test "sync-templates.sh is idempotent — second run is no-op" {
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Already in sync"* ]]
+}
+
+@test "sync-templates.sh --dry-run writes nothing in default mode" {
+  run "$SYNC" --dry-run "$TARGET"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY RUN"* ]]
+  [[ "$output" == *"would copy"* ]]
+  [[ "$output" == *"Re-run without --dry-run"* ]]
+
+  # Nothing actually written
+  [ -z "$(ls -A "$TARGET" 2>/dev/null)" ]
+}
+
+@test "sync-templates.sh --dry-run writes nothing in workspace mode" {
+  run "$SYNC" --workspace --dry-run "$TARGET"
+  [ "$status" -eq 0 ]
+
+  [ -z "$(ls -A "$TARGET" 2>/dev/null)" ]
+}
+
+@test "sync-templates.sh tilde expansion works" {
+  HOME_BACKUP="$HOME"
+  export HOME="$TEST_TMP"
+  mkdir -p "$HOME/wf2"
+
+  run "$SYNC" "~/wf2"
+  [ "$status" -eq 0 ]
+  [ -f "$HOME/wf2/CONTEXT.md" ]
+
+  export HOME="$HOME_BACKUP"
+}
+
+@test "sync-templates.sh handles partially-populated target — only copies missing" {
+  cp "$KIT_ROOT/templates/CONTEXT.md" "$TARGET/CONTEXT.md"
+  cp "$KIT_ROOT/templates/SESSION-LOG.md" "$TARGET/SESSION-LOG.md"
+
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+
+  # Pre-existing files NOT mentioned as copied
+  [[ "$output" != *"copied CONTEXT.md"* ]]
+  [[ "$output" != *"copied SESSION-LOG.md"* ]]
+  # Other files DID get copied
+  [[ "$output" == *"copied plan.md"* ]] || [[ "$output" == *"copied SEED-PROMPT.md"* ]]
+}


### PR DESCRIPTION
## Summary

- New `scripts/sync-templates.sh <target-folder>` that copies any missing `templates/*.md` (default mode) or `templates/workspace/*.md` (`--workspace` mode) into an existing target without overwriting.
- **Outdated detection** — when a file exists locally but differs from the kit's current template, it reports "outdated; review and merge by hand if desired" rather than auto-clobbering filled-in user content. Same write-once invariant as `sync-memory.sh` and `install-commands.sh`, plus a one-step-better signal.
- 16 bats tests in `tests/sync_templates.bats` covering both modes, error paths, dry-run, idempotence, never-overwrite, outdated reporting, and tilde expansion.
- `SETUP.md §Upgrading an existing project` updated — step 2 now points at the new helper as the easiest path; manual `cp` stays as the alternative.
- `FEATURES.md` Auto-memory section gains a one-line cross-reference to the new helper.

Closes #36.

## Why

Surfaced during dogfood — Aaron asked how to upgrade existing kit-bootstrapped repos at work to pick up everything that shipped this session (workspace-plan.md from #138, etc.) without losing existing content. The kit had `sync-memory.sh` and `install-commands.sh` for two of three upgrade surfaces; this closes the gap on the third.

The "outdated" reporting is the new bit relative to `sync-memory.sh`'s shape. For working-folder templates, kit-shipped updates to existing files (e.g. v0.26.0 rewriting `workspace-CONTEXT.md`) are far more common than for memory files (where the user-curated content lives entirely in their additions/edits, not in the kit-shipped starters). Surfacing "this exists but the kit has a newer version" helps users notice when there's something worth reviewing.

## Test plan

- [x] `bats tests/sync_templates.bats` — 16/16 pass.
- [x] `bats tests/` — full suite 209/209 pass (no regressions).
- [x] `-h` prints usage; missing-arg / relative-path / nonexistent-target / unknown-flag all error cleanly.
- [x] Default mode copies `templates/*.md` only (skips `templates/workspace/`, `templates/.claude/`).
- [x] `--workspace` mode copies `templates/workspace/*.md` only.
- [x] Never-overwrite verified by pre-seeding identical and customized files; both preserved.
- [x] Outdated reporting verified by pre-seeding a customized version of `CONTEXT.md`.
- [x] Idempotent: second run reports "Already in sync — no files to copy, no outdated content."
- [ ] Lychee link-check passes (CI).

## Out of scope

- Auto-merging "outdated" files. The kit reports them; the user decides.
- Diff/3-way merge UX. The reporter prints the path so the user can run `diff` themselves.
- Combining sync-memory + sync-templates + install-commands into one wrapper. Each helper has a different scope and target; combining would conflate concerns.

## Related

- #36 (closes — was "design TBD"; this is the design that shipped).
- #122 (sync-memory.sh, v0.21.0) — same write-once shape.
- #131 (install-commands.sh, v0.24.0) — same write-once shape.
- Dogfood report 2026-04-30 → 2026-05-01 — surfaced as the "how do I upgrade existing repos at work" question.