### PR TITLE
docs(readme): catch up on v0.21-v0.29 helpers + /session-handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ That kicks off interactive mode: it asks for the working-folder path, project na
 - **Phase-based planning docs** — `plan.md` + per-phase checklist + `implementation.md` give Claude scoped, numbered tasks instead of a wall of intent.
 - **SEED-PROMPT auto-fill** — point Claude at one file and it deep-reads your repo, fills `CONTEXT.md`, drafts `research.md`, flags inferences, and stops for your review.
 - **Starter agents** — `code-reviewer` (universal) and `session-summarizer` (kit-aware), staged in the working folder; copy into your repo to activate.
-- **Starter slash commands** — `/session-start`, `/refresh-context`, `/close-phase`, `/session-end`, `/pull-ticket`.
+- **Starter slash commands** — `/session-start`, `/refresh-context`, `/close-phase`, `/session-end`, `/session-handoff`, `/pull-ticket`. Install once globally with `scripts/install-commands.sh --global` (recommended) or per-repo with `--project <path>`.
+- **Upgrade helpers** — `scripts/sync-memory.sh`, `scripts/sync-templates.sh`, and `scripts/rename-workspace.sh` keep auto-memory, working-folder templates, and workspace paths in sync with the latest kit release without overwriting your filled-in content. See [SETUP.md §Upgrading](SETUP.md#upgrading-an-existing-project).
 - **Worked examples** — `examples/widget-tracker/` (fictional Go CLI, single-repo, mid-Phase 1) and `examples/lx-platform/` (fictional Terraform multi-repo workspace, JIRA-driven, with active + archived ticket scratchpads).
 - **Conventions baseline** — Conventional Commits, merge-only PRs, ticket-driven branch / PR / commit shape, test-plan format, etc. Read once, drop or keep per project.
 - **No surprises** — MIT licensed, no telemetry, no network calls, kit never modifies your target repo.
@@ -85,7 +86,7 @@ See [FEATURES.md](FEATURES.md) for one-paragraph-per-feature detail with example
 
 ## What this is / isn't
 
-- **Is:** a workflow scaffold layered on top of Claude Code — templates, memory starters, conventions, two starter agents, five starter slash commands.
+- **Is:** a workflow scaffold layered on top of Claude Code — templates, memory starters, conventions, two starter agents, six starter slash commands.
 - **Isn't:** a Claude Code plugin, a replacement for `CLAUDE.md`, or a project tracker. It complements all three.
 
 ## Why this works
@@ -151,6 +152,11 @@ Works the same for greenfield repos and ones you're adopting it on mid-stream �
 ├── LICENSE
 ├── bootstrap.sh             ← one-command setup (see SETUP.md step 2)
 ├── pull-ticket.sh           ← terminal-driven /pull-ticket equivalent (read-only)
+├── scripts/                 ← post-bootstrap helpers (idempotent, write-once by default)
+│   ├── install-commands.sh  ← install slash commands + agents (--global | --project)
+│   ├── sync-memory.sh       ← copy any newly-shipped memory templates into existing auto-memory
+│   ├── sync-templates.sh    ← refresh working-folder / workspace templates without clobbering edits
+│   └── rename-workspace.sh  ← rename a workspace folder + rewrite path refs across auto-memory
 ├── docs/adr/                ← Architecture Decision Records (see README inside)
 ├── templates/               ← copied into a new working folder
 │   ├── SEED-PROMPT.md       ← instructions for Claude to auto-fill the rest
@@ -166,7 +172,7 @@ Works the same for greenfield repos and ones you're adopting it on mid-stream �
 │   │   └── ticket.md              ← per-ticket scratchpad shape
 │   └── .claude/             ← starter agents + slash commands (staged in WF)
 │       ├── agents/          ← code-reviewer, session-summarizer
-│       ├── commands/        ← /session-start, /refresh-context, /close-phase, /session-end, /pull-ticket
+│       ├── commands/        ← /session-start, /refresh-context, /close-phase, /session-end, /session-handoff, /pull-ticket
 │       └── README.md        ← how to copy into your target repo
 ├── examples/                ← filled-in reference — read, don't copy
 │   ├── widget-tracker/      ← fictional Go CLI, single-repo, mid-Phase-1 snapshot


### PR DESCRIPTION
## Summary

The 11-PR sweep across v0.20.3 → v0.29.0 updated `SETUP.md` and `FEATURES.md` as each PR shipped, but the front-door `README.md` fell behind. This catches it up.

- Slash-commands list now shows all six (`/session-handoff` was missing) and points at `scripts/install-commands.sh --global` as the recommended install path. "five starter slash commands" → "six" in the What this is/isn't bullet.
- New Features bullet for the upgrade-helper script set: `sync-memory.sh`, `sync-templates.sh`, `rename-workspace.sh`. These were previously only discoverable via `SETUP.md §Upgrading`.
- File tree gains a `scripts/` block listing the four user-facing helpers (deliberately omits `sync-claude-dogfood.sh`, which is contributor-only).

Out of scope (deliberately): `--trust-working-folder-root` flag (covered well in `SETUP.md` / `FEATURES.md` already), the new `**Next session prompt:**` SESSION-LOG field (lives in `PROMPTS.md`), and CHANGELOG entries (release-please owns those).

## Test plan

- [x] 1. ✅ `README.md` renders cleanly on GitHub PR view — no broken markdown, file-tree code block intact, no rogue table-of-contents drift. **Evidence:** diff confirms the new `scripts/` block sits inside the existing fenced code block; new Features bullets follow existing `- **Bold** — text` shape; no headings or anchors changed.
- [x] 2. ✅ Slash-commands list parity with `FEATURES.md`. **Evidence:** `grep -n "session-handoff" README.md FEATURES.md` returns 2 hits in README (line 79 bullet + line 175 file tree) and 2 hits in FEATURES.md (line 36 cross-ref + line 242 dedicated bullet). Canonical order `/session-start, /refresh-context, /close-phase, /session-end, /session-handoff, /pull-ticket` matches in both files.
- [x] 3. ✅ Every helper script in `scripts/` (excluding the contributor-only `sync-claude-dogfood.sh`) appears in either the README Features list or the file tree. **Evidence:** `ls scripts/` shows 5 scripts; the 4 user-facing ones (`install-commands.sh`, `sync-memory.sh`, `sync-templates.sh`, `rename-workspace.sh`) all appear in the new file-tree block AND in either the new Upgrade-helpers Features bullet or the updated Slash-commands bullet. `sync-claude-dogfood.sh` deliberately omitted.
- [x] 4. ✅ Link-check CI passes. **Evidence:** `gh pr checks 146` → `Check internal markdown links	pass	6s` ([run 25206925997](https://github.com/IamMrCupp/claude-project-kit/actions/runs/25206925997/job/73909202543)). The new `SETUP.md#upgrading-an-existing-project` anchor resolves (verified `## Upgrading an existing project` exists at SETUP.md:234).