### PR TITLE
docs: genericize multi-initiative workspace examples

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -296,11 +296,11 @@ When a single piece of work spans multiple repos (e.g. Terraform environment def
 Workspace mode supports two patterns at the same layout — pick the framing that matches your work:
 
 - **Single-initiative workspace** — the workspace exists for one piece of work spanning multiple repos (e.g. "ship LX-1234 across envs + modules"). Once that work ships, the workspace's lifecycle ends. Use this for short-lived, scoped multi-repo changes.
-- **Long-running multi-initiative workspace** — the workspace is a persistent program (e.g. "fdx-infrastructure", "platform observability"), hosting a sequence of initiatives over months or years. The active initiative changes over time; past initiatives are chronicled in `workspace-CONTEXT.md`'s "Past initiatives" section and `workspace-plan.md`'s "Completed initiatives" section.
+- **Long-running multi-initiative workspace** — the workspace is a persistent program (e.g. "platform-infra", "platform observability"), hosting a sequence of initiatives over months or years. The active initiative changes over time; past initiatives are chronicled in `workspace-CONTEXT.md`'s "Past initiatives" section and `workspace-plan.md`'s "Completed initiatives" section.
 
 The templates support both. For single-initiative use, fill in "Current Initiative" once and leave "Past initiatives" empty. For long-running use, update "Current Initiative" each time the active piece of work changes; old entries roll into "Past initiatives". `workspace-plan.md` mirrors per-repo `plan.md` at workspace scope — it's where initiative scope notes, planned-but-not-started work, and completed-initiative chronicles live.
 
-If a workspace's purpose drifts substantially (e.g. an "fdx-infrastructure" workspace that started for Terraform now becoming a general program), consider whether the right move is a new workspace rather than retrofitting the old one.
+If a workspace's purpose drifts substantially (e.g. a "platform-infra" workspace that started for Terraform now becoming a general program), consider whether the right move is a new workspace rather than retrofitting the old one.
 
 ### First repo in a new workspace
 

--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -55,11 +55,11 @@ Examples:
   sync-templates.sh ~/Documents/Claude/Projects/my-project
 
   # Sync workspace-level templates (workspace-CONTEXT.md, workspace-plan.md)
-  sync-templates.sh --workspace ~/Documents/Claude/Projects/fdx-infrastructure
+  sync-templates.sh --workspace ~/Documents/Claude/Projects/platform-infra
 
   # Sync a per-repo subfolder under a workspace (use default mode, point
   # at the repo subfolder, NOT --workspace)
-  sync-templates.sh ~/Documents/Claude/Projects/fdx-infrastructure/terraform-envs
+  sync-templates.sh ~/Documents/Claude/Projects/platform-infra/terraform-envs
 
   # Preview without writing
   sync-templates.sh --dry-run ~/Documents/Claude/Projects/my-project

--- a/templates/workspace/workspace-CONTEXT.md
+++ b/templates/workspace/workspace-CONTEXT.md
@@ -18,7 +18,7 @@ This file is private — never commit it to any repo.
 
 {{ONE_PARAGRAPH_DESCRIPTION — what this workspace is, the program/team/scope it represents, and why these repos belong together. Persists across initiatives — write the workspace's enduring purpose, not the current piece of work.}}
 
-- **Program / team:** {{e.g. Platform, FDX Infrastructure, Data}}
+- **Program / team:** {{e.g. Platform, Cloud Infrastructure, Data}}
 - **Stakeholders:** {{teams / leads / on-call rotations involved across initiatives}}
 - **Started:** {{YYYY-MM-DD}}
 


### PR DESCRIPTION
## Summary

Replace the placeholder example name used for the long-running multi-initiative workspace pattern with a more neutral / generic alternative across SETUP.md, the workspace-CONTEXT template, and `scripts/sync-templates.sh` help text. Also genericize the parallel example in the workspace-CONTEXT template's "Program / team" hint.

The previous placeholder reflected a real-world program; the new one is purely descriptive (`platform-infra`) and reads more naturally as a kit example. No behavior change — comment / placeholder text only.

## Test plan

- [ ] `git grep -i "<old token>"` returns no matches in tracked files (verified locally)
- [ ] `bash -n scripts/sync-templates.sh` parses cleanly
- [ ] `lychee` link-check CI passes (no link targets changed; smoke check)
- [ ] Render check on `SETUP.md` (§ Single-initiative vs. long-running workspaces) and `templates/workspace/workspace-CONTEXT.md` reads naturally with the new placeholder