### PR TITLE
feat: enforce acceptance tests as a mandatory phase exit criterion

### DIFF
--- a/.claude/commands/close-phase.md
+++ b/.claude/commands/close-phase.md
@@ -28,6 +28,22 @@ Close phase $ARGUMENTS of this project. If no phase number was given, read `CONT
 
 The working-folder path comes from `reference_ai_working_folder.md` in auto-memory. If that's not set, ask the user before guessing.
 
+## Enforcement — acceptance tests must exist
+
+Before any of the "What to do" steps, verify the convention from `CONVENTIONS.md` → "Acceptance tests at phase boundaries". This is enforcement, not a suggestion — refuse and stop if either check fails.
+
+1. **`## Acceptance testing` section present in the closing phase's checklist.** Grep `phase-$ARGUMENTS-checklist.md` (or current `phase-N-checklist.md`) for a line matching `^## Acceptance testing`. If absent, refuse:
+   > "Phase checklist is missing the `## Acceptance testing` section. The kit requires every phase to declare acceptance tests — see CONVENTIONS.md → 'Acceptance tests at phase boundaries'. Restore the section from `templates/phase-N-checklist.md` and re-run /close-phase."
+
+2. **Results recorded OR skip explicitly documented.** Exactly one of these must be true:
+   - `acceptance-test-results.md` (or `acceptance-test-results-phase-$ARGUMENTS.md` if already archived) exists in the working folder AND is non-empty (more than the unfilled template — at least one Test section has its Result field set to `✅ PASS` or `❌ FAIL`, not `⏳ Pending`), OR
+   - the phase checklist's `## Phase exit` block contains a single line matching the literal pattern `Acceptance tests intentionally skipped — rationale: <something>`.
+
+   If neither is true, refuse:
+   > "Cannot close phase $ARGUMENTS: no acceptance test results found and no explicit skip-rationale recorded. Either fill in `acceptance-test-results.md` and re-run, or — if this phase legitimately has nothing to acceptance-test — add a single line to the checklist's `## Phase exit` block reading `Acceptance tests intentionally skipped — rationale: <one sentence>`. See CONVENTIONS.md → 'Acceptance tests at phase boundaries' for the rule."
+
+3. **If a skip-rationale line is present**, capture the rationale verbatim and surface it in the SESSION-LOG entry drafted in Step 5 below, under "Key decisions" as: `Acceptance tests intentionally skipped — <rationale>`. Do not silently elide it.
+
 ## What to do
 
 1. **Tick remaining unchecked items** in the phase checklist. For each, find the matching merged PR (`gh pr list --state merged`) and add the PR number + merge date. If no PR exists for an item, flag it for human review rather than ticking blindly.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -78,6 +78,18 @@ When working against an external tracker (JIRA, GitHub Issues, Linear, etc.), th
 - **End every session with a `SESSION-LOG.md` entry.** Append-only. Date, focus, branches/PRs, decisions, anything non-obvious for future-you.
 - **`CONTEXT.md` is the "read first" doc.** Keep it ≤300 lines. If it grows beyond that, the content belongs in one of the other docs and `CONTEXT.md` should link to it.
 
+## Acceptance tests at phase boundaries
+
+Acceptance tests verify *user-visible behavior* of a phase's slice. Green CI alone only proves code correctness, not feature correctness — the two diverge often enough that the kit treats acceptance tests as load-bearing, not aspirational.
+
+- **Every phase MUST have a non-empty `acceptance-test-results.md`** (or archived `acceptance-test-results-phase-N.md`) before the phase can close. The phase checklist's `## Acceptance testing` section lists the tests; the results file records Goal / Setup / Steps / Expected / Actual / Result for each.
+- **One escape hatch — explicit, documented, never silent.** If a phase legitimately has nothing to acceptance-test (e.g. pure-CI work, internal refactor with zero user-visible change), record the rationale on a single line in the phase checklist's `## Phase exit` block:
+
+  > `Acceptance tests intentionally skipped — rationale: {{one sentence}}`
+
+  The rationale gets surfaced in the SESSION-LOG entry that closes the phase. Skipping without a rationale is a convention violation, not a customization.
+- **The `/close-phase` slash command enforces both rules.** It refuses to close when neither condition is met (no non-empty results file AND no skip-rationale line), and refuses if the checklist's `## Acceptance testing` section was deleted. The convention is the source of truth; the slash command makes it operationally hard to skip silently.
+
 ## Auto-memory
 
 - **Save feedback from both corrections and confirmations.** Corrections are easy to notice; quiet "yes exactly, keep doing that" moments are what keep you from drifting away from validated approaches.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -193,7 +193,7 @@ The working-folder template includes a planning structure that scales from weeke
 - **`plan.md`** — phases at a high level. One section per phase, with goals and exit criteria.
 - **`phase-N-checklist.md`** — current phase's task list. Tick boxes, branch + PR per item.
 - **`implementation.md`** — running design / decision log for the active phase.
-- **`acceptance-test-results.md`** — end-of-phase verification record.
+- **`acceptance-test-results.md`** — end-of-phase verification record. **Required at every phase exit** — `/close-phase` refuses to close without it. See [`CONVENTIONS.md`](CONVENTIONS.md) → "Acceptance tests at phase boundaries" for the rule and the explicit-skip escape hatch.
 - **`research.md`** — exploratory notes, references, dead ends.
 
 Bootstrap renames the phase-N template to `phase-0-checklist.md` so you can start filling it immediately. Subsequent phases follow the `phase-1-checklist.md`, `phase-2-checklist.md` pattern — the `/close-phase` slash command handles the writeback when one wraps.
@@ -237,7 +237,7 @@ Six slash commands stage in `<working-folder>/.claude/commands/`. Same install p
 
 - **`/session-start`** — packages Prompt 1 from `PROMPTS.md`. Loads `CONTEXT.md`, `SESSION-LOG.md`, and the current phase checklist; hands back a 3–5 bullet grounding summary. Use at the start of a fresh session.
 - **`/refresh-context`** — re-reads the working folder mid-session, after a `/close-phase` or `/session-end` writeback or when a long session has drifted. Hands back a delta read against the latest state.
-- **`/close-phase`** — runs the phase-close writeback (checklist tick, `plan.md` status bump, `CONTEXT.md` update, optional acceptance-results archive). Takes a phase number or infers from `CONTEXT.md`.
+- **`/close-phase`** — packages Prompt 7 from `PROMPTS.md`. Runs the phase-close writeback (checklist tick, `plan.md` status bump, `CONTEXT.md` update, acceptance-results archive). Refuses to close without a non-empty `acceptance-test-results.md` or an explicit skip-rationale line — see [`CONVENTIONS.md`](CONVENTIONS.md) → "Acceptance tests at phase boundaries". Takes a phase number or infers from `CONTEXT.md`.
 - **`/session-end`** — packages Prompt 3 from `PROMPTS.md`. Drafts the four end-of-session updates (SESSION-LOG entry, CONTEXT bump, checklist scan, memory candidates) and waits for confirmation before writing.
 - **`/session-handoff`** — same drafting work as `/session-end`, but **writes immediately** without a confirmation gate. Use when waiting risks losing work: switching to Claude desktop, context-window pressure, abrupt pause. Persistence > polish; review on the next `/session-start`. Pairs with `bootstrap.sh`'s automatic Bootstrap entry — between the two, the bootstrap-and-seed-prompt session is durable end-to-end even if the user pauses without a clean wrap-up.
 - **`/pull-ticket <KEY>`** — packages Prompt 6 from `PROMPTS.md`. Fetches a tracker ticket (JIRA / GitHub Issues / Linear / GitLab / Shortcut) via the relevant MCP, creates `tickets/<KEY>-<slug>.md` from the kit's ticket template, updates `workspace-CONTEXT.md` "Active tickets" list, stages a `SESSION-LOG.md` line. Read-only against the tracker. See [Per-ticket scratchpads](#per-ticket-scratchpads) for the full flow.

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -269,6 +269,67 @@ remind me the tracker is the source of truth. Don't propose a branch — wait.
 
 ---
 
+## 7. Closing a phase
+
+Use this when the current phase is done and you want to draft all the closure paperwork — checklist tick-throughs, `plan.md` status bump, `CONTEXT.md` update, acceptance-results archive, SESSION-LOG entry. Mirrors `/close-phase`. Includes the kit's acceptance-tests-must-exist enforcement.
+
+```
+Close phase <N> of this project. (If you don't know which phase, read
+CONTEXT.md and infer the current one.)
+
+## Files to load
+
+1. `<working-folder>/CONTEXT.md` — current phase status
+2. `<working-folder>/plan.md` — phase breakdown
+3. `<working-folder>/phase-<N>-checklist.md`
+4. `<working-folder>/SESSION-LOG.md` — last entry for context
+5. `<working-folder>/acceptance-test-results.md` if it exists
+
+## Enforcement — acceptance tests must exist
+
+Before drafting anything else, verify the convention from CONVENTIONS.md →
+"Acceptance tests at phase boundaries". Refuse and stop if either check fails:
+
+1. The phase checklist contains a `## Acceptance testing` section.
+2. Either `acceptance-test-results.md` exists and is non-empty (at least one
+   Result field set to ✅ PASS or ❌ FAIL, not ⏳ Pending), OR the checklist's
+   `## Phase exit` block contains a single line matching:
+   `Acceptance tests intentionally skipped — rationale: <one sentence>`
+
+If neither is met, stop and tell me which condition failed and how to fix it.
+If a skip-rationale line is present, surface the rationale verbatim in the
+SESSION-LOG entry drafted in Step 5 below.
+
+## What to do
+
+1. Tick remaining unchecked items in the phase checklist. Find the matching
+   merged PR (`gh pr list --state merged`) for each, add PR number + merge
+   date. Flag any item without a PR for human review rather than ticking
+   blindly.
+2. Update plan.md "Status" line at the top to reflect phase closure.
+3. Update CONTEXT.md "Current Phase Status" block.
+4. Archive acceptance results: rename `acceptance-test-results.md` →
+   `acceptance-test-results-phase-<N>.md`, update CONTEXT.md Reference
+   section to point at the archive.
+5. Draft a SESSION-LOG entry covering focus, PRs landed, key decisions,
+   non-obvious findings, open threads. Include a Next session prompt as
+   a fenced code block under `**Next session prompt:**`.
+
+## Hand back
+
+Show each change as a diff. Wait for my confirmation per change before
+writing. After confirmation, echo the next-session prompt back in chat.
+Don't invoke `git commit` or push — I'll commit the working-folder updates
+separately.
+```
+
+**Notes:**
+- The `/close-phase` slash command runs this flow as a one-step invocation. Copy `templates/.claude/commands/close-phase.md` into your repo's `.claude/commands/` to enable.
+- The enforcement rules above are the same ones the slash command applies. If you're terminal-only without slash-command support, this prompt keeps the discipline in place.
+- See `CONVENTIONS.md` → "Acceptance tests at phase boundaries" for the rule and the explicit-skip escape hatch.
+
+---
+
 ## When to write a new prompt
 
 Add one here whenever you find yourself typing similar setup instructions into a fresh session for the third time. A good prompt is:

--- a/SETUP.md
+++ b/SETUP.md
@@ -186,6 +186,23 @@ For a scaffolded version of this pass, paste **Prompt 3 ("Wrapping up a session"
 
 ---
 
+## 8. Closing a phase
+
+When all the items in `phase-N-checklist.md` have shipped, run **`/close-phase`** (or paste **Prompt 7** from [PROMPTS.md](PROMPTS.md)) to draft the closure paperwork — checklist tick-throughs, `plan.md` status bump, `CONTEXT.md` update, acceptance-results archive, SESSION-LOG entry.
+
+> **Heads-up: `/close-phase` enforces acceptance tests.** It will refuse to close the phase if `acceptance-test-results.md` is empty AND the checklist's `## Phase exit` block doesn't carry an explicit skip-rationale line. This is by design — see [`CONVENTIONS.md`](CONVENTIONS.md) → "Acceptance tests at phase boundaries". Two paths to satisfy it:
+>
+> - **Run your acceptance tests** and fill in the Goal / Setup / Steps / Expected / Actual / Result fields in `acceptance-test-results.md` before invoking `/close-phase`.
+> - **Or, if the phase has nothing to acceptance-test** (pure-CI work, internal refactor with zero user-visible change), add a single line to the checklist's `## Phase exit` block:
+>
+>   ```
+>   Acceptance tests intentionally skipped — rationale: {{one sentence}}
+>   ```
+>
+>   `/close-phase` will surface the rationale verbatim in the SESSION-LOG entry it drafts. Skipping without a rationale is a convention violation, not a customization.
+
+---
+
 ## Manual alternative
 
 If you can't run `bootstrap.sh` (no Bash available, restricted environment, or you just want to see what it does) **or** you'd rather fill the templates by hand instead of running the seed prompt, perform the same work manually.

--- a/templates/.claude/commands/close-phase.md
+++ b/templates/.claude/commands/close-phase.md
@@ -28,6 +28,22 @@ Close phase $ARGUMENTS of this project. If no phase number was given, read `CONT
 
 The working-folder path comes from `reference_ai_working_folder.md` in auto-memory. If that's not set, ask the user before guessing.
 
+## Enforcement — acceptance tests must exist
+
+Before any of the "What to do" steps, verify the convention from `CONVENTIONS.md` → "Acceptance tests at phase boundaries". This is enforcement, not a suggestion — refuse and stop if either check fails.
+
+1. **`## Acceptance testing` section present in the closing phase's checklist.** Grep `phase-$ARGUMENTS-checklist.md` (or current `phase-N-checklist.md`) for a line matching `^## Acceptance testing`. If absent, refuse:
+   > "Phase checklist is missing the `## Acceptance testing` section. The kit requires every phase to declare acceptance tests — see CONVENTIONS.md → 'Acceptance tests at phase boundaries'. Restore the section from `templates/phase-N-checklist.md` and re-run /close-phase."
+
+2. **Results recorded OR skip explicitly documented.** Exactly one of these must be true:
+   - `acceptance-test-results.md` (or `acceptance-test-results-phase-$ARGUMENTS.md` if already archived) exists in the working folder AND is non-empty (more than the unfilled template — at least one Test section has its Result field set to `✅ PASS` or `❌ FAIL`, not `⏳ Pending`), OR
+   - the phase checklist's `## Phase exit` block contains a single line matching the literal pattern `Acceptance tests intentionally skipped — rationale: <something>`.
+
+   If neither is true, refuse:
+   > "Cannot close phase $ARGUMENTS: no acceptance test results found and no explicit skip-rationale recorded. Either fill in `acceptance-test-results.md` and re-run, or — if this phase legitimately has nothing to acceptance-test — add a single line to the checklist's `## Phase exit` block reading `Acceptance tests intentionally skipped — rationale: <one sentence>`. See CONVENTIONS.md → 'Acceptance tests at phase boundaries' for the rule."
+
+3. **If a skip-rationale line is present**, capture the rationale verbatim and surface it in the SESSION-LOG entry drafted in Step 5 below, under "Key decisions" as: `Acceptance tests intentionally skipped — <rationale>`. Do not silently elide it.
+
 ## What to do
 
 1. **Tick remaining unchecked items** in the phase checklist. For each, find the matching merged PR (`gh pr list --state merged`) and add the PR number + merge date. If no PR exists for an item, flag it for human review rather than ticking blindly.

--- a/templates/acceptance-test-results.md
+++ b/templates/acceptance-test-results.md
@@ -11,6 +11,7 @@
 
 ## How to use this doc
 
+- **This file is required at every phase exit.** See `CONVENTIONS.md` → "Acceptance tests at phase boundaries" for the rule. `/close-phase` will refuse to close a phase when this file is empty AND the checklist doesn't carry an explicit skip-rationale line.
 - One test per section. Number them (Test 1, Test 2, …) so PRs and follow-up work can reference them.
 - Every test has: **Goal**, **Setup**, **Steps**, **Expected**, **Actual**, **Result**.
 - When a test fails, file a bug (or PR), link it under **Actual**, then re-run and update.

--- a/templates/phase-N-checklist.md
+++ b/templates/phase-N-checklist.md
@@ -49,7 +49,9 @@
 
 ## Acceptance testing
 
-Before marking this phase ✅ complete, run the manual test sequence and record results in `acceptance-test-results.md`. List the tests here so the checklist itself signals when testing starts:
+> **Required by convention.** Every phase MUST exit with a non-empty `acceptance-test-results.md`. See `CONVENTIONS.md` → "Acceptance tests at phase boundaries" for the rule and the one allowed escape hatch. Removing this section is a convention violation, not a customization — `/close-phase` will refuse to close if it's missing.
+
+Before marking this phase ✅ complete, run the test sequence and record results in `acceptance-test-results.md` (Goal / Setup / Steps / Expected / Actual / Result per test). List the tests here so the checklist itself signals when testing starts:
 
 - [ ] Test 1 — {{what to verify}}
 - [ ] Test 2 — {{…}}
@@ -59,7 +61,7 @@ Before marking this phase ✅ complete, run the manual test sequence and record 
 ## Phase exit
 
 - [ ] All items in all sections ticked
-- [ ] Acceptance tests pass (see `acceptance-test-results.md`)
+- [ ] Acceptance tests pass (see `acceptance-test-results.md`) — OR document the skip on a single line below this block: `Acceptance tests intentionally skipped — rationale: {{one sentence}}`
 - [ ] `plan.md` status line updated to reflect phase complete
 - [ ] `CONTEXT.md` updated — current phase, known issues, architectural decisions that landed
 - [ ] Session entry appended to `SESSION-LOG.md` describing phase completion

--- a/tests/phase_acceptance_enforcement.bats
+++ b/tests/phase_acceptance_enforcement.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+# Regression check — the kit's "Acceptance tests at phase boundaries"
+# convention must be reflected in three places:
+#
+#   1. CONVENTIONS.md carries the rule.
+#   2. templates/phase-N-checklist.md retains the `## Acceptance testing`
+#      section and the matching exit-criterion line.
+#   3. templates/.claude/commands/close-phase.md carries the enforcement
+#      block that refuses to close without results or an explicit skip.
+#
+# Closes the D.1 + D.2 acceptance criteria of #153. Substring checks rather
+# than exact-wording matches — keeps the test honest without coupling to
+# editorial polish.
+
+load 'helpers'
+
+CONVENTIONS="$KIT_ROOT/CONVENTIONS.md"
+PHASE_TEMPLATE="$KIT_ROOT/templates/phase-N-checklist.md"
+RESULTS_TEMPLATE="$KIT_ROOT/templates/acceptance-test-results.md"
+CLOSE_PHASE="$KIT_ROOT/templates/.claude/commands/close-phase.md"
+
+@test "CONVENTIONS.md declares the acceptance-tests-at-phase-boundaries rule" {
+  [ -f "$CONVENTIONS" ]
+  grep -q "^## Acceptance tests at phase boundaries$" "$CONVENTIONS"
+  grep -q "non-empty .acceptance-test-results" "$CONVENTIONS"
+  grep -q "Acceptance tests intentionally skipped" "$CONVENTIONS"
+}
+
+@test "templates/phase-N-checklist.md retains the Acceptance testing section" {
+  [ -f "$PHASE_TEMPLATE" ]
+  grep -q "^## Acceptance testing$" "$PHASE_TEMPLATE"
+}
+
+@test "templates/phase-N-checklist.md retains the Acceptance tests pass exit criterion" {
+  grep -q "Acceptance tests pass" "$PHASE_TEMPLATE"
+}
+
+@test "templates/phase-N-checklist.md documents the explicit-skip escape hatch" {
+  grep -q "Acceptance tests intentionally skipped" "$PHASE_TEMPLATE"
+}
+
+@test "templates/acceptance-test-results.md references the convention" {
+  [ -f "$RESULTS_TEMPLATE" ]
+  grep -q "Acceptance tests at phase boundaries" "$RESULTS_TEMPLATE"
+}
+
+@test "/close-phase carries an Enforcement section" {
+  [ -f "$CLOSE_PHASE" ]
+  grep -q "^## Enforcement — acceptance tests must exist$" "$CLOSE_PHASE"
+}
+
+@test "/close-phase enforcement refuses on missing Acceptance testing section" {
+  grep -q "missing the .## Acceptance testing. section" "$CLOSE_PHASE"
+}
+
+@test "/close-phase enforcement refuses on missing results + missing skip line" {
+  grep -q "no acceptance test results found and no explicit skip-rationale" "$CLOSE_PHASE"
+}
+
+@test "/close-phase surfaces the skip rationale in the SESSION-LOG entry" {
+  grep -q "skip-rationale line is present" "$CLOSE_PHASE"
+  grep -q "surface it in the SESSION-LOG entry\|surface the rationale\|surface .*rationale" "$CLOSE_PHASE"
+}


### PR DESCRIPTION
Closes #153.

## Summary

- Promote acceptance tests from "templates suggest it" to a load-bearing kit convention. New `## Acceptance tests at phase boundaries` section in `CONVENTIONS.md` codifies the rule, the rationale, and the one allowed escape hatch (explicit skip-rationale line).
- `/close-phase` now refuses to close when neither a non-empty `acceptance-test-results.md` nor a skip-rationale line in the checklist's `## Phase exit` block is present, and refuses if the checklist's `## Acceptance testing` section was deleted.
- Templates reinforced: `phase-N-checklist.md` and `acceptance-test-results.md` both call out that the convention is binding, not aspirational.
- New paired Prompt 7 in `PROMPTS.md` mirrors `/close-phase` (matching the `/session-end ↔ Prompt 3`, `/session-start ↔ Prompt 1`, `/refresh-context ↔ Prompt 5`, `/pull-ticket ↔ Prompt 6` pattern). Closes a small consistency gap that was already there.
- Bats coverage (9 new tests) locks the convention text in `CONVENTIONS.md`, the template structure, and the `/close-phase` enforcement substrings against silent regression.
- `FEATURES.md` and `SETUP.md` surface the rule so adopters aren't surprised when `/close-phase` refuses on their first try. `SETUP.md` gains a dedicated §8 "Closing a phase" walkthrough.
- Dogfooded `.claude/commands/close-phase.md` re-synced via `scripts/sync-claude-dogfood.sh`.

## Commits

| Commit | Scope |
|---|---|
| `docs(conventions): require acceptance tests at every phase exit` | Issue Section A.1 |
| `docs(templates): reinforce acceptance-tests section in phase-N-checklist` | Sections B.1 + B.2 |
| `feat(commands): /close-phase refuses without acceptance results` | Sections C.1 + C.2 + C.3 (including new Prompt 7) |
| `chore(dogfood): sync .claude/ with close-phase template change` | sync hygiene |
| `test: bats coverage for phase-exit acceptance enforcement` | Sections D.1 + D.2 (9 new tests) |
| `docs: surface acceptance-tests rule in FEATURES.md and SETUP.md` | Sections E.1 + E.2 |

Section F (dogfood backfill in this kit's own private working folder) lands separately after merge — not part of the public PR.

## Test plan

### Automated (locks behavior against regression)

- [x] `bats tests/phase_acceptance_enforcement.bats` — all 9 new tests pass ✅
  - Local run: `ok 1 … ok 9` end-to-end pass.
- [x] `bats tests/` — full suite passes (218 tests total: 209 existing + 9 new) ✅
  - `bats tests/ | grep -c "^ok"` → `218`.
- [x] CI bats workflow passes on this PR ✅
  - [Run 25246443649](https://github.com/IamMrCupp/claude-project-kit/actions/runs/25246443649) — passed after one re-run (initial run hung on `apt-get install bats expect` for 30+ min, classic GitHub-runner-side glitch; cancel + rerun cleared it).
- [x] CI link-check workflow passes ✅
  - [Run 25246443653](https://github.com/IamMrCupp/claude-project-kit/actions/runs/25246443653) — passed first time, no flake.

### Manual — kit conventions

1. [x] **`CONVENTIONS.md` new section present.** ✅
   - `grep -c "^## Acceptance tests at phase boundaries$" CONVENTIONS.md` → `1`. Three sub-bullets confirmed (required-by-default, escape-hatch with example line, `/close-phase` enforces).
2. [x] **`templates/phase-N-checklist.md` reinforcement present.** ✅
   - `## Acceptance testing` heading retained; Phase exit bullet now reads:
     `Acceptance tests pass (see acceptance-test-results.md) — OR document the skip on a single line below this block: Acceptance tests intentionally skipped — rationale: {{one sentence}}`.
3. [x] **`templates/acceptance-test-results.md` references the convention.** ✅
   - First "How to use this doc" bullet now starts with `**This file is required at every phase exit.**` and links to CONVENTIONS.md.

### Manual — `/close-phase` enforcement (substring sanity)

4. [x] **`/close-phase.md` carries the Enforcement section.** ✅
   - `grep -A1 "^## Enforcement" templates/.claude/commands/close-phase.md` → `## Enforcement — acceptance tests must exist` between "Files to load" and "What to do".
5. [x] **Dogfood `.claude/commands/close-phase.md` is in lockstep.** ✅
   - `diff templates/.claude/commands/close-phase.md .claude/commands/close-phase.md` → no output (zero diff). `dogfood_claude_in_sync.bats` also covers this in CI.

### Manual — PROMPTS.md

6. [x] **Prompt 7 added.** ✅
   - `grep "^## 7. Closing a phase$" PROMPTS.md` → match. Carries the same enforcement language as the slash command, mirrors `/close-phase` semantics for terminal-only adopters.

### Manual — top-level docs

7. [x] **`FEATURES.md` Phase-based planning docs section updated.** ✅
   - `acceptance-test-results.md` bullet now reads: `Required at every phase exit — /close-phase refuses to close without it. See CONVENTIONS.md → "Acceptance tests at phase boundaries"`.
8. [x] **`FEATURES.md` Starter slash commands section updated.** ✅
   - `/close-phase` bullet now mentions Prompt 7 + the refusal behavior + link to CONVENTIONS.md.
9. [x] **`SETUP.md` new §8 added.** ✅
   - `## 8. Closing a phase` section present between §7 (end-of-session) and Manual alternative. Includes the heads-up callout with the skip-rationale code fence.

### Behavioral (next session that runs `/close-phase`)

10. [ ] **First real-world `/close-phase` invocation post-merge.** Verifies all four behaviors:
    (a) refuses cleanly when no `acceptance-test-results.md` exists,
    (b) refuses cleanly when checklist `## Acceptance testing` section is missing,
    (c) succeeds and surfaces the rationale verbatim in the SESSION-LOG when a skip-rationale line is present,
    (d) succeeds normally when results are filled in.
    - **Status:** ⏳ pending — by definition can't be ticked until `/close-phase` is invoked on a real phase. Will be reported in the SESSION-LOG entry that closes the next phase, and Section F (post-merge dogfood backfill on this kit's Phase 3 + Phase 4 in the private working folder) is the first opportunity to exercise path (c).

## Out of scope

- Section F (dogfood backfill — adds a skip-rationale line to this kit's own Phase 3 + Phase 4 checklists in the private working folder). Lands separately after merge so the public PR stays focused on kit code.
- Acceptance test execution + PR-body writeback (covered by [#154](https://github.com/IamMrCupp/claude-project-kit/issues/154), depends on this PR landing first).

## Notes

- This is the first runtime-behavior change to `/close-phase` since it landed. Existing kit users who routinely close phases without filling in `acceptance-test-results.md` will see the refusal on their next phase close — by design, but worth surfacing in the v0.30.0 release notes.
- release-please bump: `feat:` commit → minor version bump.