### PR TITLE
feat: /run-acceptance + PR-body writeback as kit conventions

### DIFF
--- a/.claude/commands/close-phase.md
+++ b/.claude/commands/close-phase.md
@@ -28,6 +28,18 @@ Close phase $ARGUMENTS of this project. If no phase number was given, read `CONT
 
 The working-folder path comes from `reference_ai_working_folder.md` in auto-memory. If that's not set, ask the user before guessing.
 
+## Optional pre-step — offer /run-acceptance
+
+Before the enforcement check, scan the phase checklist's `## Acceptance testing` section for unchecked items (`- [ ]`) and check whether `acceptance-test-results.md` has any Result fields still reading `⏳ Pending`. If either signal is present, propose running `/run-acceptance` first:
+
+> "Phase $ARGUMENTS has N acceptance test(s) still pending. Want me to run `/run-acceptance` to attempt the automatable ones and post results back to both `acceptance-test-results.md` and the open PR body before closing? (yes / no)"
+
+If the user accepts: invoke `/run-acceptance` (Prompt 8 / `templates/.claude/commands/run-acceptance.md`) first, then resume `/close-phase` at the enforcement check below — the writebacks may now satisfy it.
+
+If the user declines: continue to the enforcement check. If it fails, refuse per its rules.
+
+This is propose-don't-execute. Don't silently run `/run-acceptance` — it can mutate the PR body.
+
 ## Enforcement — acceptance tests must exist
 
 Before any of the "What to do" steps, verify the convention from `CONVENTIONS.md` → "Acceptance tests at phase boundaries". This is enforcement, not a suggestion — refuse and stop if either check fails.
@@ -40,7 +52,12 @@ Before any of the "What to do" steps, verify the convention from `CONVENTIONS.md
    - the phase checklist's `## Phase exit` block contains a single line matching the literal pattern `Acceptance tests intentionally skipped — rationale: <something>`.
 
    If neither is true, refuse:
-   > "Cannot close phase $ARGUMENTS: no acceptance test results found and no explicit skip-rationale recorded. Either fill in `acceptance-test-results.md` and re-run, or — if this phase legitimately has nothing to acceptance-test — add a single line to the checklist's `## Phase exit` block reading `Acceptance tests intentionally skipped — rationale: <one sentence>`. See CONVENTIONS.md → 'Acceptance tests at phase boundaries' for the rule."
+   > "Cannot close phase $ARGUMENTS: no acceptance test results found and no explicit skip-rationale recorded. Three paths to satisfy this:
+   > 1. Run `/run-acceptance` to attempt the automatable tests and write results to `acceptance-test-results.md` + the open PR body.
+   > 2. Fill in `acceptance-test-results.md` by hand and re-run `/close-phase`.
+   > 3. If this phase legitimately has nothing to acceptance-test, add a single line to the checklist's `## Phase exit` block reading `Acceptance tests intentionally skipped — rationale: <one sentence>`.
+   >
+   > See CONVENTIONS.md → 'Acceptance tests at phase boundaries' for the rule."
 
 3. **If a skip-rationale line is present**, capture the rationale verbatim and surface it in the SESSION-LOG entry drafted in Step 5 below, under "Key decisions" as: `Acceptance tests intentionally skipped — <rationale>`. Do not silently elide it.
 

--- a/.claude/commands/run-acceptance.md
+++ b/.claude/commands/run-acceptance.md
@@ -1,0 +1,97 @@
+---
+description: Run the current phase's acceptance tests — attempts the automatable ones, proposes writebacks to acceptance-test-results.md and the open PR body. Defers UI / judgment items to the human.
+argument-hint: [test-N | all]
+---
+
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
+   > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
+Run acceptance tests for the current phase. Argument is optional:
+
+- No argument or `all` → attempt every test in the plan
+- `test-N` (e.g. `test-3`) → only that test
+
+## Files to load
+
+- `<working-folder>/CONTEXT.md` — confirms the current phase
+- `<working-folder>/phase-<current-N>-checklist.md` — the `## Acceptance testing` section lists which tests exist
+- `<working-folder>/acceptance-test-results.md` — current per-test record (Goal / Setup / Steps / Expected / Actual / Result)
+- The open PR for the current branch, if any: `gh pr list --head $(git branch --show-current) --json number,body,title`
+
+The working-folder path comes from `reference_ai_working_folder.md` in auto-memory.
+
+## What to do
+
+### 1. Classify each test per `CONVENTIONS.md` → "Automating acceptance tests where it makes sense"
+
+For each test in scope, decide one of:
+
+- **Run automatically** — bats / pytest / jest / shell commands; link-check / lint runs; CLI invocations whose expected output is grep-able; template renders diffable against a fixture. No external state mutation.
+- **Run with confirmation** — anything that mutates external state (`gh pr edit`, `git push`, `gh release create`, hitting a real tracker, publishing). Propose the command, wait for nod.
+- **Defer to human** — visual rendering on GitHub.com, behavior in a UI, prose-feel judgment. Don't silently skip — surface with rationale ("Test 4 needs Aaron's eye on the rendered GH page; can't be automated").
+
+Print the classification table before running anything so the user sees what you're about to do.
+
+### 2. Execute the run-automatically items
+
+For each:
+
+- Run the command (`bats tests/foo.bats`, `gh run list --branch X`, `grep -c pattern file`, etc.)
+- Capture exit code + relevant output (the line(s) that matter, not entire logs)
+- Decide PASS / FAIL against the test's Expected field
+- On FAIL: capture the exact command, exact output, and a candidate fix. Do **not** silently retry.
+
+### 3. Propose writebacks — both surfaces
+
+After all run-automatically items finish, draft updates for **both**:
+
+**A. `acceptance-test-results.md`** — for each tested item, fill in:
+- **Actual:** the captured evidence (log line, run ID, output snippet)
+- **Result:** ✅ PASS / ❌ FAIL — *next-step if fail*
+
+**B. The open PR body** (if `gh pr list --head <branch>` returns one) — for each item that maps to a PR test-plan checkbox:
+- Tick the box (`- [ ]` → `- [x]`)
+- Paste evidence inline below the item
+- Mark deferred-to-human items as `Aaron to verify` (or whatever the human's name / role is, from CONTEXT.md if available)
+
+Show both diffs. Wait for confirmation per writeback. **Posting back is the default**, not opt-in — don't ask "want me to update the PR?" after the user already invoked `/run-acceptance`.
+
+### 4. Apply writebacks after confirmation
+
+- Write `acceptance-test-results.md` directly.
+- Update the PR body via `gh pr edit <PR-number> --body-file <tempfile-with-full-new-body>`. Writing the full body in one shot is more reliable than patching individual lines.
+
+### 5. Run-with-confirmation items
+
+For each, propose the exact command + what it'll change. Run only after the user nods. Apply the same writeback flow as automatable items.
+
+### 6. Defer-to-human items
+
+Surface explicitly in the hand-back. Don't tick anything for these — they stay open with the rationale.
+
+## Hand back
+
+A summary table:
+
+| Test | Class | Result | Evidence |
+|---|---|---|---|
+| 1. {{name}} | auto | ✅ PASS | {{one-line evidence}} |
+| 2. {{name}} | confirm | ⏸ pending nod | {{proposed cmd}} |
+| 3. {{name}} | human | ⏳ deferred | {{why}} |
+
+Then list:
+- Writebacks applied (paths + line counts)
+- Items still pending the user (confirms, human-deferred)
+- Any failures with command + output + candidate fix
+
+Do **not** invoke `git commit` or `git push` as part of this command — the user reviews + commits writebacks separately.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -30,8 +30,38 @@ Project-agnostic habits that have proven out across real work. Start from these,
   - Steps (copy-pasteable)
   - Expected outcomes (log lines to grep for, timing thresholds, state transitions)
   - Pass / fail criteria (concrete)
-- **Check off the test plan after passing.** `gh pr edit` the body to tick checkboxes, paste measured evidence inline, mark ✅ PASS sections. This is the single best defense against "I thought we tested that."
+- **Run the automatable test-plan items + post results back, by default.** When the user asks you to run the test plan (or "verify this PR", "kick off the tests", "check the ATs"), the default workflow is:
+  1. Attempt the automatable items yourself (see *Automating acceptance tests where it makes sense* below for the heuristic).
+  2. Tick the matching checkboxes in the PR body via `gh pr edit <PR> --body-file <path>` and paste measured evidence inline (log line, timing, run ID, diff snippet — whatever proves the check passed).
+  3. If the test corresponds to an item in `acceptance-test-results.md`, update the Actual / Result fields there too.
+
+  Posting back is the **default** when the user invokes a run — not an opt-in, not a "ask if you want me to update the PR" follow-up. The single best defense against "I thought we tested that" is making the evidence durable on the PR itself.
 - **Pure-CI / docs PRs:** short plan is fine, but still explicit — "no runtime change; verification is CI alone."
+
+### Automating acceptance tests where it makes sense
+
+When running an AT plan, classify each item before reaching for the human:
+
+- **Run automatically.** Anything scriptable: bats / pytest / jest / shell commands; link-check or lint runs; CLI invocations whose expected output is grep-able; template renders that can be diffed against a fixture.
+- **Run with confirmation.** Anything that mutates external state: `gh pr edit`, `git push`, `gh release create`, hitting a real tracker, publishing to a registry. Propose the exact command, wait for the nod, then run.
+- **Defer to human.** Visual rendering on GitHub.com, behavior in a UI, anything requiring human judgment ("does this prose feel right?"). Surface explicitly with rationale — don't silently skip.
+
+When something fails, report the exact command, the exact output, and a candidate fix — not "❌ FAIL" alone. The user shouldn't have to re-run the failing command to see what broke.
+
+### How to post test results back to the PR
+
+The mechanics:
+
+1. Edit the PR body via `gh pr edit <PR> --body-file <path-to-updated-body>` (writing the full body once is more reliable than patching individual lines).
+2. Tick the corresponding checkboxes (`- [ ]` → `- [x]`) and paste evidence inline. Good evidence shapes:
+   - Log line that proves a behavior fired (e.g. `grep -c "^ok" output → 218`)
+   - Run ID + link for CI workflows (e.g. `[Run 25246443649](...) — passed`)
+   - Diff or `wc -l` output for content checks
+   - Screenshot link for UI verifications
+3. If an item failed, mark `❌ FAIL` and paste the exact failure output + your hypothesis. A failed-but-documented item is better than silence.
+4. Items the human still owns (e.g. visual GH render checks) stay unticked, with an explicit "Aaron to verify" or similar tag.
+
+Goal: any reviewer reading the PR body should be able to tell "what was tested, how, and what the result was" without rerunning anything.
 
 ## CI
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -233,7 +233,7 @@ These are **starters**. Edit the frontmatter (model, tool allowlist), customize 
 
 ## Starter slash commands
 
-Six slash commands stage in `<working-folder>/.claude/commands/`. Same install path as agents — `scripts/install-commands.sh --global` (recommended, covers every project) or `--project <repo-path>` (scope to one repo).
+Seven slash commands stage in `<working-folder>/.claude/commands/`. Same install path as agents — `scripts/install-commands.sh --global` (recommended, covers every project) or `--project <repo-path>` (scope to one repo).
 
 - **`/session-start`** — packages Prompt 1 from `PROMPTS.md`. Loads `CONTEXT.md`, `SESSION-LOG.md`, and the current phase checklist; hands back a 3–5 bullet grounding summary. Use at the start of a fresh session.
 - **`/refresh-context`** — re-reads the working folder mid-session, after a `/close-phase` or `/session-end` writeback or when a long session has drifted. Hands back a delta read against the latest state.
@@ -241,6 +241,7 @@ Six slash commands stage in `<working-folder>/.claude/commands/`. Same install p
 - **`/session-end`** — packages Prompt 3 from `PROMPTS.md`. Drafts the four end-of-session updates (SESSION-LOG entry, CONTEXT bump, checklist scan, memory candidates) and waits for confirmation before writing.
 - **`/session-handoff`** — same drafting work as `/session-end`, but **writes immediately** without a confirmation gate. Use when waiting risks losing work: switching to Claude desktop, context-window pressure, abrupt pause. Persistence > polish; review on the next `/session-start`. Pairs with `bootstrap.sh`'s automatic Bootstrap entry — between the two, the bootstrap-and-seed-prompt session is durable end-to-end even if the user pauses without a clean wrap-up.
 - **`/pull-ticket <KEY>`** — packages Prompt 6 from `PROMPTS.md`. Fetches a tracker ticket (JIRA / GitHub Issues / Linear / GitLab / Shortcut) via the relevant MCP, creates `tickets/<KEY>-<slug>.md` from the kit's ticket template, updates `workspace-CONTEXT.md` "Active tickets" list, stages a `SESSION-LOG.md` line. Read-only against the tracker. See [Per-ticket scratchpads](#per-ticket-scratchpads) for the full flow.
+- **`/run-acceptance [test-N | all]`** — packages Prompt 8 from `PROMPTS.md`. Runs the current phase's acceptance tests, classifying each per the run-automatically / run-with-confirmation / defer-to-human heuristic in [`CONVENTIONS.md`](CONVENTIONS.md) → "Automating acceptance tests where it makes sense". Attempts the automatable items, then proposes writebacks to **both** `acceptance-test-results.md` and the open PR body via `gh pr edit`. Posting back is the default, not opt-in. `/close-phase` will offer to run this first when ATs are pending.
 
 ---
 

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -330,6 +330,69 @@ separately.
 
 ---
 
+## 8. Running acceptance tests with writeback
+
+Use this when the current phase has unchecked acceptance tests and you want Claude to attempt the automatable ones and post results back to both `acceptance-test-results.md` AND the open PR body — without you having to ask "did you update the PR?" afterwards. Mirrors `/run-acceptance`.
+
+```
+Run the acceptance tests for the current phase.
+
+## Files to load
+
+1. `<working-folder>/CONTEXT.md` — confirms current phase
+2. `<working-folder>/phase-<N>-checklist.md` — the `## Acceptance testing` section
+3. `<working-folder>/acceptance-test-results.md`
+4. The open PR for the current branch:
+   `gh pr list --head $(git branch --show-current) --json number,body,title`
+
+## Classify each test (per CONVENTIONS.md → "Automating acceptance tests where it makes sense")
+
+- **Run automatically** — bats / pytest / jest / shell commands; link-check or
+  lint runs; CLI invocations whose expected output is grep-able; template
+  renders diffable against a fixture.
+- **Run with confirmation** — anything that mutates external state
+  (`gh pr edit`, `git push`, `gh release create`, hitting a real tracker).
+  Propose the command, wait for nod.
+- **Defer to human** — visual rendering on GitHub.com, behavior in a UI,
+  prose-feel judgment. Don't silently skip — surface with rationale.
+
+Print the classification table before running anything.
+
+## Execute the run-automatically items
+
+For each: run the command, capture exit code + relevant output, decide
+PASS / FAIL against the Expected field. On FAIL: capture exact command,
+exact output, and a candidate fix. Don't silently retry.
+
+## Propose writebacks — both surfaces
+
+Posting back is the default, not opt-in. After all auto items finish, draft:
+
+1. **`acceptance-test-results.md`** — fill Actual / Result for each tested item
+2. **The open PR body** — tick matching checkboxes, paste evidence inline,
+   mark deferred-to-human items "Aaron to verify" or similar
+
+Show both diffs. Wait for confirmation per writeback. Apply via
+`gh pr edit <PR> --body-file <tempfile>` (write the full body, not patches).
+
+## Hand back
+
+A summary table of test / class / result / evidence, plus:
+- Writebacks applied (paths)
+- Items still pending the user (confirms, human-deferred)
+- Failures with command + output + candidate fix
+
+Don't `git commit` or `git push` — I review and commit writebacks separately.
+```
+
+**Notes:**
+- The `/run-acceptance` slash command (in `templates/.claude/commands/`) packages this as a one-step invocation. Copy into your repo's `.claude/commands/` to enable.
+- Optionally pass `test-N` (e.g. `test-3`) to scope to a single test instead of the whole plan.
+- This is the execution counterpart to `/close-phase`'s structural enforcement — `/close-phase` checks that ATs *exist*, `/run-acceptance` checks that they *pass*. `/close-phase` will offer to run `/run-acceptance` first when ATs are pending.
+- See `CONVENTIONS.md` → "PRs" → "How to post test results back to the PR" for the writeback mechanics.
+
+---
+
 ## When to write a new prompt
 
 Add one here whenever you find yourself typing similar setup instructions into a fresh session for the third time. A good prompt is:

--- a/SETUP.md
+++ b/SETUP.md
@@ -190,9 +190,12 @@ For a scaffolded version of this pass, paste **Prompt 3 ("Wrapping up a session"
 
 When all the items in `phase-N-checklist.md` have shipped, run **`/close-phase`** (or paste **Prompt 7** from [PROMPTS.md](PROMPTS.md)) to draft the closure paperwork — checklist tick-throughs, `plan.md` status bump, `CONTEXT.md` update, acceptance-results archive, SESSION-LOG entry.
 
-> **Heads-up: `/close-phase` enforces acceptance tests.** It will refuse to close the phase if `acceptance-test-results.md` is empty AND the checklist's `## Phase exit` block doesn't carry an explicit skip-rationale line. This is by design — see [`CONVENTIONS.md`](CONVENTIONS.md) → "Acceptance tests at phase boundaries". Two paths to satisfy it:
+If acceptance tests are still pending, `/close-phase` will offer to run **`/run-acceptance`** (Prompt 8) first — it attempts the automatable items (bats / pytest / shell-script-able checks) and proposes writebacks to both `acceptance-test-results.md` and the open PR body via `gh pr edit`. Posting back is the default, not opt-in. See [`CONVENTIONS.md`](CONVENTIONS.md) → "PRs" for the heuristic and the writeback mechanics.
+
+> **Heads-up: `/close-phase` enforces acceptance tests.** It will refuse to close the phase if `acceptance-test-results.md` is empty AND the checklist's `## Phase exit` block doesn't carry an explicit skip-rationale line. This is by design — see [`CONVENTIONS.md`](CONVENTIONS.md) → "Acceptance tests at phase boundaries". Three paths to satisfy it:
 >
-> - **Run your acceptance tests** and fill in the Goal / Setup / Steps / Expected / Actual / Result fields in `acceptance-test-results.md` before invoking `/close-phase`.
+> - **Run `/run-acceptance`** to attempt the automatable tests and have Claude post results to both surfaces.
+> - **Fill in `acceptance-test-results.md` by hand** with Goal / Setup / Steps / Expected / Actual / Result for each test, then invoke `/close-phase`.
 > - **Or, if the phase has nothing to acceptance-test** (pure-CI work, internal refactor with zero user-visible change), add a single line to the checklist's `## Phase exit` block:
 >
 >   ```

--- a/templates/.claude/README.md
+++ b/templates/.claude/README.md
@@ -1,6 +1,6 @@
 # `.claude/` starters
 
-Two agents and six slash commands that follow the kit's session-start, session-end, session-handoff, and phase-close conventions. Staged here in your working folder; copy into your target repo's `.claude/` if you want them.
+Two agents and seven slash commands that follow the kit's session-start, session-end, session-handoff, phase-close, and acceptance-test conventions. Staged here in your working folder; copy into your target repo's `.claude/` if you want them.
 
 ## What's here
 
@@ -17,6 +17,7 @@ Two agents and six slash commands that follow the kit's session-start, session-e
 - **`/session-end`** — Prompt 3 from `PROMPTS.md` packaged as a slash command. Drafts the end-of-session updates, waits for confirmation before writing.
 - **`/session-handoff`** — same drafting work as `/session-end`, but **writes immediately** without a confirmation gate. Use when waiting risks losing the session: switching to Claude desktop, context-window pressure, abrupt pause. Persistence > polish; review on the next `/session-start`.
 - **`/pull-ticket <KEY>`** — pull a tracker ticket (JIRA / GitHub Issues / Linear / GitLab / Shortcut) into a per-ticket scratchpad at `tickets/<KEY>-<slug>.md`. Reads tracker config from `CONTEXT.md` (or `../workspace-CONTEXT.md` in workspace mode), fetches via the relevant MCP, fills the kit's ticket template. Updates `workspace-CONTEXT.md` and stages a `SESSION-LOG.md` line. **Read-only against the tracker** — never creates, edits, transitions, or comments. Same flow as Prompt 6 in `PROMPTS.md`. For terminal-driven use without Claude, see `pull-ticket.sh` at the kit root.
+- **`/run-acceptance [test-N | all]`** — run the current phase's acceptance tests. Classifies each one (run-automatically / run-with-confirmation / defer-to-human) per `CONVENTIONS.md` → "Automating acceptance tests where it makes sense", attempts the automatable items, and proposes writebacks to **both** `acceptance-test-results.md` and the open PR body (via `gh pr edit`). Posting back is the default, not opt-in. Same flow as Prompt 8 in `PROMPTS.md`.
 
 ## How to activate them
 

--- a/templates/.claude/commands/close-phase.md
+++ b/templates/.claude/commands/close-phase.md
@@ -28,6 +28,18 @@ Close phase $ARGUMENTS of this project. If no phase number was given, read `CONT
 
 The working-folder path comes from `reference_ai_working_folder.md` in auto-memory. If that's not set, ask the user before guessing.
 
+## Optional pre-step — offer /run-acceptance
+
+Before the enforcement check, scan the phase checklist's `## Acceptance testing` section for unchecked items (`- [ ]`) and check whether `acceptance-test-results.md` has any Result fields still reading `⏳ Pending`. If either signal is present, propose running `/run-acceptance` first:
+
+> "Phase $ARGUMENTS has N acceptance test(s) still pending. Want me to run `/run-acceptance` to attempt the automatable ones and post results back to both `acceptance-test-results.md` and the open PR body before closing? (yes / no)"
+
+If the user accepts: invoke `/run-acceptance` (Prompt 8 / `templates/.claude/commands/run-acceptance.md`) first, then resume `/close-phase` at the enforcement check below — the writebacks may now satisfy it.
+
+If the user declines: continue to the enforcement check. If it fails, refuse per its rules.
+
+This is propose-don't-execute. Don't silently run `/run-acceptance` — it can mutate the PR body.
+
 ## Enforcement — acceptance tests must exist
 
 Before any of the "What to do" steps, verify the convention from `CONVENTIONS.md` → "Acceptance tests at phase boundaries". This is enforcement, not a suggestion — refuse and stop if either check fails.
@@ -40,7 +52,12 @@ Before any of the "What to do" steps, verify the convention from `CONVENTIONS.md
    - the phase checklist's `## Phase exit` block contains a single line matching the literal pattern `Acceptance tests intentionally skipped — rationale: <something>`.
 
    If neither is true, refuse:
-   > "Cannot close phase $ARGUMENTS: no acceptance test results found and no explicit skip-rationale recorded. Either fill in `acceptance-test-results.md` and re-run, or — if this phase legitimately has nothing to acceptance-test — add a single line to the checklist's `## Phase exit` block reading `Acceptance tests intentionally skipped — rationale: <one sentence>`. See CONVENTIONS.md → 'Acceptance tests at phase boundaries' for the rule."
+   > "Cannot close phase $ARGUMENTS: no acceptance test results found and no explicit skip-rationale recorded. Three paths to satisfy this:
+   > 1. Run `/run-acceptance` to attempt the automatable tests and write results to `acceptance-test-results.md` + the open PR body.
+   > 2. Fill in `acceptance-test-results.md` by hand and re-run `/close-phase`.
+   > 3. If this phase legitimately has nothing to acceptance-test, add a single line to the checklist's `## Phase exit` block reading `Acceptance tests intentionally skipped — rationale: <one sentence>`.
+   >
+   > See CONVENTIONS.md → 'Acceptance tests at phase boundaries' for the rule."
 
 3. **If a skip-rationale line is present**, capture the rationale verbatim and surface it in the SESSION-LOG entry drafted in Step 5 below, under "Key decisions" as: `Acceptance tests intentionally skipped — <rationale>`. Do not silently elide it.
 

--- a/templates/.claude/commands/run-acceptance.md
+++ b/templates/.claude/commands/run-acceptance.md
@@ -1,0 +1,97 @@
+---
+description: Run the current phase's acceptance tests — attempts the automatable ones, proposes writebacks to acceptance-test-results.md and the open PR body. Defers UI / judgment items to the human.
+argument-hint: [test-N | all]
+---
+
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
+   > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
+Run acceptance tests for the current phase. Argument is optional:
+
+- No argument or `all` → attempt every test in the plan
+- `test-N` (e.g. `test-3`) → only that test
+
+## Files to load
+
+- `<working-folder>/CONTEXT.md` — confirms the current phase
+- `<working-folder>/phase-<current-N>-checklist.md` — the `## Acceptance testing` section lists which tests exist
+- `<working-folder>/acceptance-test-results.md` — current per-test record (Goal / Setup / Steps / Expected / Actual / Result)
+- The open PR for the current branch, if any: `gh pr list --head $(git branch --show-current) --json number,body,title`
+
+The working-folder path comes from `reference_ai_working_folder.md` in auto-memory.
+
+## What to do
+
+### 1. Classify each test per `CONVENTIONS.md` → "Automating acceptance tests where it makes sense"
+
+For each test in scope, decide one of:
+
+- **Run automatically** — bats / pytest / jest / shell commands; link-check / lint runs; CLI invocations whose expected output is grep-able; template renders diffable against a fixture. No external state mutation.
+- **Run with confirmation** — anything that mutates external state (`gh pr edit`, `git push`, `gh release create`, hitting a real tracker, publishing). Propose the command, wait for nod.
+- **Defer to human** — visual rendering on GitHub.com, behavior in a UI, prose-feel judgment. Don't silently skip — surface with rationale ("Test 4 needs Aaron's eye on the rendered GH page; can't be automated").
+
+Print the classification table before running anything so the user sees what you're about to do.
+
+### 2. Execute the run-automatically items
+
+For each:
+
+- Run the command (`bats tests/foo.bats`, `gh run list --branch X`, `grep -c pattern file`, etc.)
+- Capture exit code + relevant output (the line(s) that matter, not entire logs)
+- Decide PASS / FAIL against the test's Expected field
+- On FAIL: capture the exact command, exact output, and a candidate fix. Do **not** silently retry.
+
+### 3. Propose writebacks — both surfaces
+
+After all run-automatically items finish, draft updates for **both**:
+
+**A. `acceptance-test-results.md`** — for each tested item, fill in:
+- **Actual:** the captured evidence (log line, run ID, output snippet)
+- **Result:** ✅ PASS / ❌ FAIL — *next-step if fail*
+
+**B. The open PR body** (if `gh pr list --head <branch>` returns one) — for each item that maps to a PR test-plan checkbox:
+- Tick the box (`- [ ]` → `- [x]`)
+- Paste evidence inline below the item
+- Mark deferred-to-human items as `Aaron to verify` (or whatever the human's name / role is, from CONTEXT.md if available)
+
+Show both diffs. Wait for confirmation per writeback. **Posting back is the default**, not opt-in — don't ask "want me to update the PR?" after the user already invoked `/run-acceptance`.
+
+### 4. Apply writebacks after confirmation
+
+- Write `acceptance-test-results.md` directly.
+- Update the PR body via `gh pr edit <PR-number> --body-file <tempfile-with-full-new-body>`. Writing the full body in one shot is more reliable than patching individual lines.
+
+### 5. Run-with-confirmation items
+
+For each, propose the exact command + what it'll change. Run only after the user nods. Apply the same writeback flow as automatable items.
+
+### 6. Defer-to-human items
+
+Surface explicitly in the hand-back. Don't tick anything for these — they stay open with the rationale.
+
+## Hand back
+
+A summary table:
+
+| Test | Class | Result | Evidence |
+|---|---|---|---|
+| 1. {{name}} | auto | ✅ PASS | {{one-line evidence}} |
+| 2. {{name}} | confirm | ⏸ pending nod | {{proposed cmd}} |
+| 3. {{name}} | human | ⏳ deferred | {{why}} |
+
+Then list:
+- Writebacks applied (paths + line counts)
+- Items still pending the user (confirms, human-deferred)
+- Any failures with command + output + candidate fix
+
+Do **not** invoke `git commit` or `git push` as part of this command — the user reviews + commits writebacks separately.

--- a/tests/precheck_in_commands.bats
+++ b/tests/precheck_in_commands.bats
@@ -15,6 +15,7 @@ KIT_COUPLED_COMMANDS=(
   templates/.claude/commands/refresh-context.md
   templates/.claude/commands/close-phase.md
   templates/.claude/commands/pull-ticket.md
+  templates/.claude/commands/run-acceptance.md
 )
 
 # Kit-coupled agents (code-reviewer is universal — no kit dependency).

--- a/tests/run_acceptance.bats
+++ b/tests/run_acceptance.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# Regression check — the kit's "AT execution + writeback" surface
+# (#154) lives in three places that must stay in sync:
+#
+#   1. CONVENTIONS.md carries the heuristic ("Automating acceptance tests
+#      where it makes sense") + the PR-body writeback how-to.
+#   2. templates/.claude/commands/run-acceptance.md exists with the right
+#      shape (classify → run → propose writebacks to BOTH surfaces).
+#   3. templates/.claude/commands/close-phase.md offers /run-acceptance
+#      when ATs are pending.
+#
+# Substring checks rather than exact-wording matches — keeps the test
+# honest without coupling to editorial polish.
+
+load 'helpers'
+
+CONVENTIONS="$KIT_ROOT/CONVENTIONS.md"
+PROMPTS="$KIT_ROOT/PROMPTS.md"
+RUN_ACCEPTANCE="$KIT_ROOT/templates/.claude/commands/run-acceptance.md"
+CLOSE_PHASE="$KIT_ROOT/templates/.claude/commands/close-phase.md"
+CLAUDE_README="$KIT_ROOT/templates/.claude/README.md"
+
+@test "CONVENTIONS.md declares the AT-automation heuristic" {
+  [ -f "$CONVENTIONS" ]
+  grep -q "^### Automating acceptance tests where it makes sense$" "$CONVENTIONS"
+  grep -q "Run automatically" "$CONVENTIONS"
+  grep -q "Run with confirmation" "$CONVENTIONS"
+  grep -q "Defer to human" "$CONVENTIONS"
+}
+
+@test "CONVENTIONS.md documents the PR-body writeback flow" {
+  grep -q "^### How to post test results back to the PR$" "$CONVENTIONS"
+  grep -q "gh pr edit" "$CONVENTIONS"
+  grep -q "body-file" "$CONVENTIONS"
+}
+
+@test "CONVENTIONS.md makes writeback the default, not opt-in" {
+  grep -q "Posting back is the \*\*default\*\*\|Posting back is the default" "$CONVENTIONS"
+}
+
+@test "/run-acceptance command file exists" {
+  [ -f "$RUN_ACCEPTANCE" ]
+}
+
+@test "/run-acceptance describes the classify → run → writeback flow" {
+  grep -q "Run automatically" "$RUN_ACCEPTANCE"
+  grep -q "Run with confirmation" "$RUN_ACCEPTANCE"
+  grep -q "Defer to human" "$RUN_ACCEPTANCE"
+}
+
+@test "/run-acceptance proposes writebacks to BOTH acceptance-test-results.md and PR body" {
+  grep -q "acceptance-test-results\.md" "$RUN_ACCEPTANCE"
+  grep -q "gh pr edit" "$RUN_ACCEPTANCE"
+}
+
+@test "/run-acceptance includes failure-reporting discipline" {
+  grep -qE "exact command.*exact output|silently retry|candidate fix" "$RUN_ACCEPTANCE"
+}
+
+@test "/close-phase offers /run-acceptance when ATs are pending" {
+  grep -q "/run-acceptance" "$CLOSE_PHASE"
+  grep -q "still pending\|pending\b" "$CLOSE_PHASE"
+}
+
+@test "/close-phase enforcement refusal mentions /run-acceptance as a path" {
+  grep -q "Run \`/run-acceptance\`\|run \`/run-acceptance\`\|/run-acceptance" "$CLOSE_PHASE"
+}
+
+@test "templates/.claude/README.md lists /run-acceptance" {
+  [ -f "$CLAUDE_README" ]
+  grep -q "/run-acceptance" "$CLAUDE_README"
+  grep -q "seven slash commands" "$CLAUDE_README"
+}
+
+@test "PROMPTS.md adds Prompt 8 mirroring /run-acceptance" {
+  [ -f "$PROMPTS" ]
+  grep -q "^## 8\. Running acceptance tests with writeback$" "$PROMPTS"
+  grep -q "/run-acceptance" "$PROMPTS"
+}


### PR DESCRIPTION
Closes #154.

## Summary

The structural enforcement from #155 ensures acceptance tests *exist* at phase exit. This PR addresses the *execution quality* gap:

- **`/run-acceptance` slash command** (and matching Prompt 8) — classifies each AT as run-automatically / run-with-confirmation / defer-to-human, attempts the automatable items, and proposes writebacks to **both** \`acceptance-test-results.md\` and the open PR body via \`gh pr edit\`. Posting back is the **default**, not opt-in.
- **`/close-phase` integration** — when ATs are pending, \`/close-phase\` offers to run \`/run-acceptance\` first. Its enforcement refusal message now lists \`/run-acceptance\` as the first of three paths to satisfy the rule.
- **CONVENTIONS.md** — graduates two patterns from Aaron's personal auto-memory (\`feedback_pr_check_off_on_pass.md\`, \`feedback_pr_test_plans.md\`) into the kit's public PRs section: the auto-attempt heuristic (run / confirm / defer-to-human) and the PR-body writeback how-to with concrete \`gh pr edit\` mechanics + evidence-shape guidance.
- **11 new bats tests** lock the convention text, the new command file, the \`/close-phase\` integration, and the README/PROMPTS surfaces against silent regression. Full suite: 229 tests pass (218 prior + 11 new).
- **Dogfooded `.claude/`** re-synced via \`scripts/sync-claude-dogfood.sh\`. The kit immediately uses its own new command — \`/run-acceptance\` shows up in this very session's available-skills list.

## Commits

| Commit | Scope |
|---|---|
| \`docs(conventions): add acceptance-test execution + PR-body writeback rules\` | Issue Sections A.1 + A.2 + C.1 |
| \`feat(commands): /run-acceptance attempts automatable ATs and proposes writebacks\` | Section B.1 (+ templates/.claude/README.md count update) |
| \`feat(commands): /close-phase offers /run-acceptance when ATs pending\` | Section B.2 |
| \`docs(prompts): add Prompt 8 mirroring /run-acceptance\` | Section B.3 |
| \`chore(dogfood): sync .claude/ with new /run-acceptance command\` | sync hygiene |
| \`test: bats coverage for /run-acceptance + writeback conventions\` | Sections D.1 + D.2 |
| \`docs: surface AT execution + writeback in FEATURES.md and SETUP.md\` | Sections E.1 + E.2 |

**Deferred per the issue's own \"optional\" notes:**
- C.2 (helper script) — slash command + Prompt 8 cover the surface; helper doesn't earn weight yet.
- D.3 (meta-test against kit's own private working folder) — coupling public tests to private state isn't worth it.

**Post-merge:** F.1 (retire \`feedback_pr_check_off_on_pass.md\` + \`feedback_pr_test_plans.md\` from Aaron's auto-memory now that they're public convention).

## Test plan

### Automated (locks behavior against regression)

- [x] \`bats tests/run_acceptance.bats\` — 11 new tests pass ✅
  - Local run: \`ok 1 … ok 11\` end-to-end pass.
- [x] \`bats tests/precheck_in_commands.bats\` — \`/run-acceptance\` added to KIT_COUPLED_COMMANDS, all 5 precheck tests still pass ✅
- [x] \`bats tests/\` — full suite (229 tests: 218 prior + 11 new) ✅
  - \`bats tests/ | grep -c \"^ok\"\` → \`229\`.
- [x] CI bats workflow passes on this PR ✅
  - [Run 25247437758](https://github.com/IamMrCupp/claude-project-kit/actions/runs/25247437758) — passed first try, no flake.
- [x] CI link-check workflow passes ✅
  - [Run 25247437739](https://github.com/IamMrCupp/claude-project-kit/actions/runs/25247437739) — passed first try, no flake.

### Manual — kit conventions

1. [x] **CONVENTIONS.md adds the AT-automation heuristic.** ✅
   - \`grep -c \"^### Automating acceptance tests where it makes sense$\" CONVENTIONS.md\` → \`1\`. Heuristic lists Run automatically / Run with confirmation / Defer to human.
2. [x] **CONVENTIONS.md documents the PR-body writeback flow.** ✅
   - \`grep -c \"^### How to post test results back to the PR$\" CONVENTIONS.md\` → \`1\`. Includes \`gh pr edit --body-file\` example + evidence-shape guidance.
3. [x] **Posting back is documented as default, not opt-in.** ✅
   - Bullet now reads: *\"Posting back is the **default** when the user invokes a run — not an opt-in, not a 'ask if you want me to update the PR?' follow-up.\"*

### Manual — `/run-acceptance` slash command

4. [x] **`/run-acceptance.md` exists.** ✅
   - File present at \`templates/.claude/commands/run-acceptance.md\`. Frontmatter includes \`description\` + \`argument-hint: [test-N | all]\`.
5. [x] **Command describes classify → run → propose-writeback flow.** ✅
   - All three classification labels present; explicit \"propose writebacks — both surfaces\" section names \`acceptance-test-results.md\` AND \`gh pr edit\`.
6. [x] **Failure-reporting discipline documented.** ✅
   - Says: *\"On FAIL: capture the exact command, exact output, and a candidate fix. Do not silently retry.\"*
7. [x] **Precheck block matches kit standard.** ✅
   - Added to \`KIT_COUPLED_COMMANDS\` in \`tests/precheck_in_commands.bats\`; all 5 precheck tests pass.

### Manual — `/close-phase` integration

8. [x] **`/close-phase` carries an Optional pre-step section offering `/run-acceptance`.** ✅
   - \`grep -A1 \"^## Optional pre-step\" templates/.claude/commands/close-phase.md\` shows the new section between \"Files to load\" and \"Enforcement\".
9. [x] **Enforcement refusal message lists `/run-acceptance` as first of three paths.** ✅
   - Message now reads: *\"Three paths to satisfy this: 1. Run \`/run-acceptance\` to attempt the automatable tests and write results to acceptance-test-results.md + the open PR body. 2. Fill in acceptance-test-results.md by hand. 3. … skip-rationale line.\"*

### Manual — top-level docs

10. [x] **PROMPTS.md adds Prompt 8.** ✅
    - \`grep \"^## 8\\. Running acceptance tests with writeback$\" PROMPTS.md\` → match.
11. [x] **`templates/.claude/README.md` updated to seven slash commands + lists `/run-acceptance`.** ✅
    - Both substring checks pass in bats.
12. [x] **`FEATURES.md` count + bullet updated.** ✅
    - \"Seven slash commands\" replaces \"Six slash commands\"; new \`/run-acceptance\` bullet under Starter slash commands.
13. [x] **`SETUP.md` §8 mentions `/run-acceptance` as the natural pre-step + adds it to the three-path satisfaction list.** ✅
    - New paragraph between the §8 intro and the Heads-up callout; the callout's bullet list now leads with \"Run \`/run-acceptance\`\".

### Behavioral (next session that runs `/run-acceptance` or `/close-phase` with pending ATs)

14. [ ] **First real-world `/run-acceptance` invocation post-merge.** Verifies:
    (a) classification table prints before any execution,
    (b) automatable items run + capture evidence,
    (c) writebacks proposed for BOTH \`acceptance-test-results.md\` AND the open PR body,
    (d) confirmation gate per writeback (no silent PR edits),
    (e) failures report exact command + exact output + candidate fix.
    - **Status:** ⏳ pending — by definition can't be ticked until \`/run-acceptance\` runs on a real phase. Will be reported in the SESSION-LOG entry that exercises it.

## Out of scope

- Section F (memory retirement of \`feedback_pr_check_off_on_pass.md\` + \`feedback_pr_test_plans.md\`). Lands separately after merge so the public PR doesn't depend on private auto-memory state.
- Helper script \`scripts/post-results.sh\` (issue's optional C.2). Slash command + Prompt 8 cover the surface today.
- Auto-merging PRs after writeback completes. Still a human action — writeback is informational.

## Notes

- **Eats its own dogfood:** the very gap that motivated #154 (me missing the writeback step on PR #155 until you nudged) is now closed by the kit itself. \`/run-acceptance\`'s default-on writeback semantics mean future-me would have written results back automatically.
- release-please bump: two \`feat:\` commits → minor version bump (likely v0.31.0).
