### PR TITLE
feat(scripts): $PWD-inferred paths for sync-memory / sync-templates / rename-workspace

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -182,7 +182,7 @@ Anything that can't be derived stays as `{{PLACEHOLDER}}` so it's grep-able. The
 
 The memory files are **starters**, not commandments. Prune what doesn't apply, add your own, keep `MEMORY.md` (the index) in sync. The harness loads `MEMORY.md` into context every session, so it stays small (under ~150 lines is a reasonable target).
 
-When the kit ships new starter rules, `scripts/sync-memory.sh <memory-dir>` copies any missing templates into an existing auto-memory dir without overwriting customized files. Skips `MEMORY.md`, `project_current.md`, and `user_role.md` (user-curated). The companion helper for working-folder and workspace templates is `scripts/sync-templates.sh` — same write-once shape (see [SETUP.md §Upgrading an existing project](SETUP.md#upgrading-an-existing-project)).
+When the kit ships new starter rules, `scripts/sync-memory.sh` copies any missing templates into an existing auto-memory dir without overwriting customized files. Skips `MEMORY.md`, `project_current.md`, and `user_role.md` (user-curated). When run from inside a kit-bootstrapped repo, paths are inferred from `$PWD` — pass an explicit memory-dir arg only if you're not in the repo. The companion helper for working-folder and workspace templates is `scripts/sync-templates.sh`, with the same write-once shape and the same `$PWD`-based inference (see [SETUP.md §Upgrading an existing project](SETUP.md#upgrading-an-existing-project)).
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -256,19 +256,27 @@ For fully filled-in references, see [`examples/widget-tracker/CONTEXT.md`](examp
 `bootstrap.sh` is deliberately **write-once** — it won't touch a working folder or auto-memory dir that's already populated. When the kit evolves, existing adopters upgrade manually:
 
 1. Check [`CHANGELOG.md`](CHANGELOG.md) to see what's landed since your bootstrap SHA (or since the last time you upgraded). Each entry has a **For existing adopters** section with specifics.
-2. **New files in `templates/`** — easiest path is the sync helper, which copies any missing templates into a working folder without overwriting existing files (and reports any *outdated* files for you to merge by hand):
+2. **New files in `templates/`** — easiest path is the sync helper. From inside the kit-bootstrapped repo, paths are inferred automatically:
    ```bash
-   # For a single-repo working folder (or a per-repo subfolder of a workspace)
+   # cd into the bootstrapped repo, then:
+   <kit-dir>/scripts/sync-templates.sh                  # working-folder mode
+   <kit-dir>/scripts/sync-templates.sh --workspace      # workspace-root mode
+   ```
+   The helper reads `reference_ai_working_folder.md` from the repo's auto-memory to find the right target. Pass an explicit path if you'd rather, or if you're not inside the repo:
+   ```bash
    <kit-dir>/scripts/sync-templates.sh <working-folder>
-
-   # For workspace-level files (workspace-CONTEXT.md, workspace-plan.md)
    <kit-dir>/scripts/sync-templates.sh --workspace <workspace-root>
    ```
    Pass `--dry-run` first to preview. The helper never overwrites — when an existing file differs from the kit's current template, it reports "outdated; review and merge by hand if desired" rather than clobbering your filled-in content. To copy a single file by hand instead:
    ```bash
    cp <kit-dir>/templates/<NEW_FILE>.md <working-folder>/
    ```
-3. **New files in `memory-templates/`** — easiest path is the sync helper, which copies any missing templates into your auto-memory without overwriting existing files:
+3. **New files in `memory-templates/`** — same pattern: from inside the bootstrapped repo, the auto-memory dir is inferred from `$PWD`:
+   ```bash
+   # cd into the bootstrapped repo, then:
+   <kit-dir>/scripts/sync-memory.sh
+   ```
+   Or pass the path explicitly:
    ```bash
    <kit-dir>/scripts/sync-memory.sh ~/.claude/projects/<sanitized-path>/memory
    ```
@@ -358,6 +366,10 @@ Idempotence: both refuse to overwrite an existing scratchpad with the same `<KEY
 A naive `mv` of the workspace folder works for the directory tree, but **leaves stale references** in per-repo auto-memory at `~/.claude/projects/<sanitized-repo-path>/memory/reference_ai_working_folder.md` (which pins the workspace path baked in at bootstrap time). Use the rename helper instead:
 
 ```bash
+# From inside the workspace (or a member repo) — old path is inferred:
+<framework-dir>/scripts/rename-workspace.sh ~/Documents/Claude/Projects/<new-name>/
+
+# Or explicit form, works from anywhere:
 <framework-dir>/scripts/rename-workspace.sh \
   ~/Documents/Claude/Projects/<old-name>/ \
   ~/Documents/Claude/Projects/<new-name>/

--- a/scripts/lib/infer.sh
+++ b/scripts/lib/infer.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Shared inference helpers for the kit's helper scripts.
+#
+# Source-able from sync-memory.sh, sync-templates.sh, rename-workspace.sh —
+# any helper that today takes an explicit path and could reasonably infer it
+# from $PWD when run inside a kit-bootstrapped repo.
+#
+# Functions are pure (no side effects, no exits) so the calling script
+# decides how to handle empty returns. All return paths use absolute,
+# unresolved-symlink form to match bootstrap.sh's sanitization rule
+# (sed 's|/|-|g').
+#
+# Conventions:
+#   - All functions take an optional first arg (defaults to $PWD).
+#   - Empty stdout = could not infer. Caller must check.
+#   - Functions never error / never call exit. Caller decides.
+
+# Sanitize a filesystem path the way the Claude harness keys auto-memory:
+# replace `/` with `-`. Result is the directory name under
+# ~/.claude/projects/.
+sanitize_path_for_memory() {
+  echo "$1" | sed 's|/|-|g'
+}
+
+# Walk up from $1 (default $PWD) to find a directory that contains .git.
+# Echoes the repo root on success. Echoes the original $1 (or $PWD) if no
+# .git is found in any ancestor, since some target repos may not be git
+# repos at all.
+find_repo_root() {
+  local start="${1:-$PWD}"
+  local dir="$start"
+  while [ "$dir" != "/" ] && [ -n "$dir" ]; do
+    if [ -d "$dir/.git" ]; then
+      echo "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  echo "$start"
+}
+
+# Echo the auto-memory dir for a given repo path (default: walk up from
+# $PWD to find the repo root). Does NOT check that the dir exists; callers
+# decide how to handle missing dirs.
+infer_memory_dir() {
+  local start="${1:-$PWD}"
+  local repo
+  repo="$(find_repo_root "$start")"
+  local sanitized
+  sanitized="$(sanitize_path_for_memory "$repo")"
+  echo "$HOME/.claude/projects/${sanitized}/memory"
+}
+
+# Echo the working-folder path for the kit-bootstrapped project rooted at
+# $1 (default $PWD).
+#
+# Strategy: read reference_ai_working_folder.md from the repo's auto-memory
+# and extract the first backtick-quoted absolute path ending in /CONTEXT.md.
+# Strip the trailing /CONTEXT.md and return the parent directory.
+#
+# Returns empty string on any failure (no memory dir, no reference file,
+# no parseable path). Does not error.
+infer_working_folder() {
+  local start="${1:-$PWD}"
+  local memory_dir
+  memory_dir="$(infer_memory_dir "$start")"
+  local ref_file="$memory_dir/reference_ai_working_folder.md"
+  [ -f "$ref_file" ] || return 0
+
+  # Match: backtick + / + non-backtick chars + /CONTEXT.md + backtick.
+  # Example line in memory file:
+  #   - `/Users/x/Documents/Claude/Projects/foo/CONTEXT.md` — overview...
+  local match
+  match="$(grep -oE '`/[^`]+/CONTEXT\.md`' "$ref_file" 2>/dev/null | head -1)"
+  [ -n "$match" ] || return 0
+
+  # Strip surrounding backticks and trailing /CONTEXT.md
+  match="${match#\`}"
+  match="${match%\`}"
+  match="${match%/CONTEXT.md}"
+  echo "$match"
+}
+
+# Echo the workspace root for the project at $1 (default $PWD). Workspace
+# root = the directory containing workspace-CONTEXT.md.
+#
+# Tries three strategies in order:
+#   1. $dir itself is a workspace root.
+#   2. $dir's parent is a workspace root (i.e. $dir is a per-repo subfolder
+#      of a workspace).
+#   3. $dir is a kit-bootstrapped repo whose working folder is per-repo
+#      under a workspace — infer the working folder via auto-memory, then
+#      check the working folder's parent for workspace-CONTEXT.md.
+#
+# Returns empty string if none of the strategies find a workspace root.
+infer_workspace_root() {
+  local start="${1:-$PWD}"
+
+  if [ -f "$start/workspace-CONTEXT.md" ]; then
+    echo "$start"
+    return 0
+  fi
+
+  if [ -f "$start/../workspace-CONTEXT.md" ]; then
+    (cd "$start/.." && pwd)
+    return 0
+  fi
+
+  local wf
+  wf="$(infer_working_folder "$start")"
+  if [ -n "$wf" ] && [ -f "$wf/../workspace-CONTEXT.md" ]; then
+    (cd "$wf/.." && pwd)
+    return 0
+  fi
+
+  return 0
+}

--- a/scripts/rename-workspace.sh
+++ b/scripts/rename-workspace.sh
@@ -20,13 +20,21 @@ if [ -z "${BASH_VERSION:-}" ]; then
   exit 1
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=lib/infer.sh
+. "$SCRIPT_DIR/lib/infer.sh"
+
 usage() {
   cat <<EOF
-Usage: rename-workspace.sh [options] <old-workspace-path> <new-workspace-path>
+Usage: rename-workspace.sh [options] [old-workspace-path] <new-workspace-path>
 
-Rename a kit workspace folder. Both paths must be absolute. The old path must
-exist and contain workspace-CONTEXT.md (i.e. it must have been bootstrapped
-with --workspace). The new path must NOT already exist.
+Rename a kit workspace folder. The new path must NOT already exist.
+
+The old path is optional — if omitted, inferred from \$PWD (must be inside
+a workspace, or a kit-bootstrapped repo whose working folder lives inside
+one). The new path is always required since there's no good way to infer a
+destination.
 
 What happens:
   1. mv <old-workspace-path> <new-workspace-path>
@@ -42,21 +50,23 @@ Options:
   -h, --help    Show this help and exit.
 
 Examples:
-  # Rename ~/Documents/Claude/Projects/old-name to ...new-name
+  # Inferred old — run from inside the workspace or a member repo
+  cd ~/Code/some-repo && rename-workspace.sh \\
+    ~/Documents/Claude/Projects/new-name
+
+  # Explicit form — works from anywhere
   rename-workspace.sh \\
     ~/Documents/Claude/Projects/old-name \\
     ~/Documents/Claude/Projects/new-name
 
   # Preview without writing
   rename-workspace.sh --dry-run \\
-    ~/Documents/Claude/Projects/old-name \\
     ~/Documents/Claude/Projects/new-name
 EOF
 }
 
 DRY_RUN=0
-OLD=""
-NEW=""
+POSITIONAL=()
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -64,25 +74,45 @@ while [ $# -gt 0 ]; do
     -h|--help) usage; exit 0 ;;
     --*) echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
     *)
-      if [ -z "$OLD" ]; then
-        OLD="$1"
-      elif [ -z "$NEW" ]; then
-        NEW="$1"
-      else
-        echo "error: unexpected extra argument: $1" >&2
-        usage >&2
-        exit 2
-      fi
+      POSITIONAL+=("$1")
       shift
       ;;
   esac
 done
 
-if [ -z "$OLD" ] || [ -z "$NEW" ]; then
-  echo "error: both <old-workspace-path> and <new-workspace-path> are required" >&2
-  usage >&2
-  exit 2
-fi
+OLD=""
+NEW=""
+INFERRED_OLD=0
+
+case "${#POSITIONAL[@]}" in
+  0)
+    echo "error: <new-workspace-path> is required" >&2
+    usage >&2
+    exit 2
+    ;;
+  1)
+    # Single positional → it's NEW. OLD must be inferred.
+    NEW="${POSITIONAL[0]}"
+    OLD="$(infer_workspace_root)"
+    INFERRED_OLD=1
+    if [ -z "$OLD" ]; then
+      echo "error: couldn't infer a workspace root from \$PWD." >&2
+      echo "       Either cd into a workspace (or a repo whose working folder" >&2
+      echo "       lives inside one), or pass both paths explicitly:" >&2
+      echo "       rename-workspace.sh <old> <new>" >&2
+      exit 1
+    fi
+    ;;
+  2)
+    OLD="${POSITIONAL[0]}"
+    NEW="${POSITIONAL[1]}"
+    ;;
+  *)
+    echo "error: unexpected extra positional argument: ${POSITIONAL[2]}" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
 
 # Tilde expansion (in case argument was literal "~/...")
 case "$OLD" in
@@ -133,7 +163,11 @@ if [ -d "$MEMORY_ROOT" ]; then
 fi
 
 echo "Workspace rename plan"
-echo "  Old: $OLD"
+if [ "$INFERRED_OLD" -eq 1 ]; then
+  echo "  Old: $OLD  (inferred from \$PWD)"
+else
+  echo "  Old: $OLD"
+fi
 echo "  New: $NEW"
 echo
 

--- a/scripts/sync-memory.sh
+++ b/scripts/sync-memory.sh
@@ -20,6 +20,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 KIT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEMPLATES_DIR="$KIT_ROOT/memory-templates"
 
+# shellcheck source=lib/infer.sh
+. "$SCRIPT_DIR/lib/infer.sh"
+
 # Files in memory-templates/ that are user-customized scaffolds (not generic
 # rules) and must NEVER be auto-synced — overwriting them would clobber the
 # user's project notes / role profile / curated index.
@@ -27,26 +30,30 @@ SKIP_FILES=(MEMORY.md project_current.md user_role.md)
 
 usage() {
   cat <<EOF
-Usage: sync-memory.sh [options] <memory-dir>
+Usage: sync-memory.sh [options] [memory-dir]
 
-Sync missing memory-templates/*.md into <memory-dir>. Never overwrites
-existing files. Never touches MEMORY.md, project_current.md, or
-user_role.md (those are user-customized).
+Sync missing memory-templates/*.md into the auto-memory directory. Never
+overwrites existing files. Never touches MEMORY.md, project_current.md,
+or user_role.md (those are user-customized).
 
 Arguments:
-  <memory-dir>   Absolute path to an auto-memory directory.
-                 Typically ~/.claude/projects/<sanitized-repo-path>/memory/.
+  [memory-dir]   Optional. Absolute path to an auto-memory directory.
+                 If omitted, inferred from \$PWD: walks up to find the
+                 repo root, then derives ~/.claude/projects/<sanitized>/memory.
 
 Options:
   --dry-run      Print what would be copied; write nothing.
   -h, --help     Show this help and exit.
 
 Examples:
-  # Sync the kit's own dogfood memory after pulling kit updates
-  sync-memory.sh ~/.claude/projects/-Users-you-Code-claude-project-kit/memory
+  # Inferred mode — run from inside any kit-bootstrapped repo
+  cd ~/Code/some-project && sync-memory.sh
+
+  # Explicit mode — useful for scripting or when not inside the repo
+  sync-memory.sh ~/.claude/projects/-Users-you-Code-some-project/memory
 
   # Preview without writing
-  sync-memory.sh --dry-run ~/.claude/projects/.../memory
+  sync-memory.sh --dry-run
 
 After files copy, the script prints suggested MEMORY.md index lines for
 the new entries — paste the ones you want into your MEMORY.md. The
@@ -94,10 +101,10 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+INFERRED=0
 if [ -z "$TARGET" ]; then
-  echo "error: missing <memory-dir> argument" >&2
-  usage >&2
-  exit 2
+  TARGET="$(infer_memory_dir)"
+  INFERRED=1
 fi
 
 case "$TARGET" in
@@ -107,7 +114,7 @@ esac
 
 case "$TARGET" in
   /*) ;;
-  *) echo "error: <memory-dir> must be an absolute path (got: $TARGET)" >&2; exit 2 ;;
+  *) echo "error: memory-dir must be an absolute path (got: $TARGET)" >&2; exit 2 ;;
 esac
 
 if [ ! -d "$TEMPLATES_DIR" ]; then
@@ -116,8 +123,15 @@ if [ ! -d "$TEMPLATES_DIR" ]; then
 fi
 
 if [ ! -d "$TARGET" ]; then
-  echo "error: target memory dir does not exist: $TARGET" >&2
-  echo "       Run bootstrap.sh first to seed initial memory." >&2
+  if [ "$INFERRED" -eq 1 ]; then
+    echo "error: couldn't find an auto-memory dir for \$PWD." >&2
+    echo "       Inferred path: $TARGET" >&2
+    echo "       Either cd into a kit-bootstrapped repo first, or pass the" >&2
+    echo "       memory-dir explicitly: sync-memory.sh <path>" >&2
+  else
+    echo "error: target memory dir does not exist: $TARGET" >&2
+    echo "       Run bootstrap.sh first to seed initial memory." >&2
+  fi
   exit 1
 fi
 
@@ -125,7 +139,11 @@ if [ "$DRY_RUN" -eq 1 ]; then
   echo "=== DRY RUN — no files will be written ==="
 fi
 echo "Source:  $TEMPLATES_DIR"
-echo "Target:  $TARGET"
+if [ "$INFERRED" -eq 1 ]; then
+  echo "Target:  $TARGET  (inferred from \$PWD)"
+else
+  echo "Target:  $TARGET"
+fi
 echo
 
 COPIED=()

--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -25,44 +25,48 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 KIT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# shellcheck source=lib/infer.sh
+. "$SCRIPT_DIR/lib/infer.sh"
+
 usage() {
   cat <<EOF
-Usage: sync-templates.sh [options] <target-folder>
+Usage: sync-templates.sh [options] [target-folder]
 
-Sync missing kit templates into <target-folder>. Never overwrites existing
+Sync missing kit templates into the target. Never overwrites existing
 files. Reports files that exist but differ from the kit's current template
 ("outdated") so you can review and merge by hand if desired.
 
 Modes:
-  Default            Sync templates/*.md from the kit into <target-folder>.
-                     Use this on a per-repo working folder (or per-repo
-                     subfolder of a workspace).
-  --workspace        Sync templates/workspace/*.md from the kit into
-                     <target-folder>. Use this on a workspace root
-                     (the directory that contains workspace-CONTEXT.md).
+  Default            Sync templates/*.md into a working folder.
+  --workspace        Sync templates/workspace/*.md into a workspace root
+                     (directory containing workspace-CONTEXT.md).
 
 Other options:
   --dry-run          Print what would be copied; write nothing.
   -h, --help         Show this help and exit.
 
 Arguments:
-  <target-folder>    Absolute path to the target. For default mode, this is
-                     a working folder (per-repo). For --workspace mode,
-                     this is the workspace root.
+  [target-folder]    Optional. Absolute path to the target.
+                     - Default mode: working folder (per-repo).
+                     - --workspace mode: workspace root.
+
+                     If omitted, inferred from \$PWD by reading the repo's
+                     auto-memory (reference_ai_working_folder.md). Pass
+                     explicitly when not inside a kit-bootstrapped repo.
 
 Examples:
-  # Sync new templates into a single-repo working folder
-  sync-templates.sh ~/Documents/Claude/Projects/my-project
+  # Inferred mode (default) — run from a kit-bootstrapped repo
+  cd ~/Code/some-project && sync-templates.sh
 
-  # Sync workspace-level templates (workspace-CONTEXT.md, workspace-plan.md)
+  # Inferred mode (workspace) — run from anywhere inside the workspace
+  cd ~/Code/some-project && sync-templates.sh --workspace
+
+  # Explicit forms still work
+  sync-templates.sh ~/Documents/Claude/Projects/my-project
   sync-templates.sh --workspace ~/Documents/Claude/Projects/platform-infra
 
-  # Sync a per-repo subfolder under a workspace (use default mode, point
-  # at the repo subfolder, NOT --workspace)
-  sync-templates.sh ~/Documents/Claude/Projects/platform-infra/terraform-envs
-
   # Preview without writing
-  sync-templates.sh --dry-run ~/Documents/Claude/Projects/my-project
+  sync-templates.sh --dry-run
 
 Notes:
   - Default mode skips templates/.claude/ (use scripts/install-commands.sh
@@ -95,10 +99,29 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+INFERRED=0
 if [ -z "$TARGET" ]; then
-  echo "error: missing <target-folder> argument" >&2
-  usage >&2
-  exit 2
+  if [ "$WORKSPACE_MODE" -eq 1 ]; then
+    TARGET="$(infer_workspace_root)"
+    if [ -z "$TARGET" ]; then
+      echo "error: couldn't find a workspace root from \$PWD." >&2
+      echo "       Either cd into a workspace (or a repo whose working folder" >&2
+      echo "       lives inside one), or pass the path explicitly:" >&2
+      echo "       sync-templates.sh --workspace <path>" >&2
+      exit 1
+    fi
+  else
+    TARGET="$(infer_working_folder)"
+    if [ -z "$TARGET" ]; then
+      echo "error: couldn't infer a working folder from \$PWD." >&2
+      echo "       Either cd into a kit-bootstrapped repo first (its" >&2
+      echo "       auto-memory must contain reference_ai_working_folder.md)," >&2
+      echo "       or pass the working-folder path explicitly:" >&2
+      echo "       sync-templates.sh <path>" >&2
+      exit 1
+    fi
+  fi
+  INFERRED=1
 fi
 
 case "$TARGET" in
@@ -108,7 +131,7 @@ esac
 
 case "$TARGET" in
   /*) ;;
-  *) echo "error: <target-folder> must be an absolute path (got: $TARGET)" >&2; exit 2 ;;
+  *) echo "error: target-folder must be an absolute path (got: $TARGET)" >&2; exit 2 ;;
 esac
 
 if [ ! -d "$TARGET" ]; then
@@ -134,7 +157,11 @@ if [ "$DRY_RUN" -eq 1 ]; then
 fi
 echo "Mode:   $MODE_LABEL"
 echo "Source: $SRC_DIR"
-echo "Target: $TARGET"
+if [ "$INFERRED" -eq 1 ]; then
+  echo "Target: $TARGET  (inferred from \$PWD)"
+else
+  echo "Target: $TARGET"
+fi
 echo
 
 COPIED=()

--- a/tests/rename_workspace.bats
+++ b/tests/rename_workspace.bats
@@ -31,10 +31,10 @@ setup_workspace_with_one_repo() {
   [[ "$output" == *"<new-workspace-path>"* ]]
 }
 
-@test "rename-workspace.sh errors when args missing" {
+@test "rename-workspace.sh errors when no args" {
   run "$RENAME"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"both <old-workspace-path> and <new-workspace-path> are required"* ]]
+  [[ "$output" == *"<new-workspace-path> is required"* ]]
 }
 
 @test "rename-workspace.sh errors on relative paths" {
@@ -168,4 +168,53 @@ setup_workspace_with_one_repo() {
   [ ! -d "$HOME/old-ws" ]
 
   export HOME="$HOME_BACKUP"
+}
+
+# ─── Inference tests (issue #163) ─────────────────────────────────────────
+
+@test "rename-workspace.sh single arg infers OLD from \$PWD when inside a workspace" {
+  WS="$TEST_TMP/old-ws"
+  NEW="$TEST_TMP/new-ws"
+  mkdir -p "$WS"
+  touch "$WS/workspace-CONTEXT.md"
+
+  cd "$WS"
+  run "$RENAME" "$NEW"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"(inferred from \$PWD)"* ]]
+  [ -d "$NEW" ]
+  [ ! -d "$WS" ]
+}
+
+@test "rename-workspace.sh single arg errors with friendly message when not in workspace" {
+  HOME_BACKUP="$HOME"
+  TEST_HOME="$TEST_TMP/home"
+  NON_KIT="$TEST_TMP/random"
+  mkdir -p "$TEST_HOME" "$NON_KIT"
+  export HOME="$TEST_HOME"
+
+  cd "$NON_KIT"
+  run "$RENAME" "$TEST_TMP/new-ws"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"couldn't infer a workspace root"* ]]
+  [[ "$output" == *"rename-workspace.sh <old> <new>"* ]]
+
+  export HOME="$HOME_BACKUP"
+}
+
+@test "rename-workspace.sh single arg infers via parent dir from a member repo" {
+  WS="$TEST_TMP/parent-ws"
+  REPO_WF="$WS/repo-a"
+  NEW="$TEST_TMP/parent-ws-renamed"
+  mkdir -p "$REPO_WF"
+  touch "$WS/workspace-CONTEXT.md"
+
+  cd "$REPO_WF"
+  run "$RENAME" --dry-run "$NEW"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"(inferred from \$PWD)"* ]]
+  [[ "$output" == *"$WS"* ]]
 }

--- a/tests/sync_memory.bats
+++ b/tests/sync_memory.bats
@@ -18,17 +18,25 @@ teardown() {
   [ -n "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"
 }
 
+# Set up an isolated $HOME with a kit-bootstrapped fake repo so inference
+# tests can run sync-memory.sh without an explicit path arg.
+inferred_setup() {
+  TEST_HOME="$TEST_TMP/home"
+  TEST_REPO="$TEST_TMP/repo"
+  mkdir -p "$TEST_HOME" "$TEST_REPO"
+  git -C "$TEST_REPO" init -q
+  export HOME="$TEST_HOME"
+  local sanitized
+  sanitized="$(echo "$TEST_REPO" | sed 's|/|-|g')"
+  INFERRED_MEMORY="$HOME/.claude/projects/${sanitized}/memory"
+  mkdir -p "$INFERRED_MEMORY"
+}
+
 @test "sync-memory.sh -h prints usage" {
   run "$SYNC" -h
   [ "$status" -eq 0 ]
   [[ "$output" == *"Usage: sync-memory.sh"* ]]
   [[ "$output" == *"--dry-run"* ]]
-}
-
-@test "sync-memory.sh errors when no memory-dir arg" {
-  run "$SYNC"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"missing <memory-dir> argument"* ]]
 }
 
 @test "sync-memory.sh errors on unknown flag" {
@@ -144,4 +152,52 @@ EOF
   [[ "$output" != *"copied feedback_merge_strategy.md"* ]]
   # Other files DID get copied
   [[ "$output" == *"copied feedback_push_branches.md"* ]]
+}
+
+# ─── Inference tests (issue #163) ─────────────────────────────────────────
+
+@test "sync-memory.sh inferred mode works when run from a kit-bootstrapped repo" {
+  HOME_BACKUP="$HOME"
+  inferred_setup
+
+  cd "$TEST_REPO"
+  run "$SYNC"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"(inferred from \$PWD)"* ]]
+  [ -f "$INFERRED_MEMORY/feedback_commit_format.md" ]
+
+  export HOME="$HOME_BACKUP"
+}
+
+@test "sync-memory.sh inferred mode walks up to find repo root from a subdir" {
+  HOME_BACKUP="$HOME"
+  inferred_setup
+  mkdir -p "$TEST_REPO/src/deep"
+
+  cd "$TEST_REPO/src/deep"
+  run "$SYNC"
+
+  [ "$status" -eq 0 ]
+  # Inferred memory should be the repo's, NOT a subdirectory's
+  [ -f "$INFERRED_MEMORY/feedback_commit_format.md" ]
+
+  export HOME="$HOME_BACKUP"
+}
+
+@test "sync-memory.sh inferred mode errors when not in a kit-bootstrapped repo" {
+  HOME_BACKUP="$HOME"
+  TEST_HOME="$TEST_TMP/home"
+  NON_KIT="$TEST_TMP/random"
+  mkdir -p "$TEST_HOME" "$NON_KIT"
+  export HOME="$TEST_HOME"
+
+  cd "$NON_KIT"
+  run "$SYNC"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"couldn't find an auto-memory dir"* ]]
+  [[ "$output" == *"cd into a kit-bootstrapped repo"* ]]
+
+  export HOME="$HOME_BACKUP"
 }

--- a/tests/sync_templates.bats
+++ b/tests/sync_templates.bats
@@ -25,12 +25,6 @@ teardown() {
   [[ "$output" == *"--dry-run"* ]]
 }
 
-@test "sync-templates.sh errors when no target arg" {
-  run "$SYNC"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"missing <target-folder> argument"* ]]
-}
-
 @test "sync-templates.sh errors on relative path" {
   run "$SYNC" relative/path
   [ "$status" -ne 0 ]
@@ -164,4 +158,112 @@ teardown() {
   [[ "$output" != *"copied SESSION-LOG.md"* ]]
   # Other files DID get copied
   [[ "$output" == *"copied plan.md"* ]] || [[ "$output" == *"copied SEED-PROMPT.md"* ]]
+}
+
+# ─── Inference tests (issue #163) ─────────────────────────────────────────
+
+# Set up an isolated $HOME with a kit-bootstrapped fake repo + working folder
+# + auto-memory whose reference_ai_working_folder.md points at the working
+# folder. Tests run sync-templates.sh from the repo with no positional arg.
+inferred_setup() {
+  TEST_HOME="$TEST_TMP/home"
+  TEST_REPO="$TEST_TMP/repo"
+  TEST_WF="$TEST_TMP/wf"
+  mkdir -p "$TEST_HOME" "$TEST_REPO" "$TEST_WF"
+  git -C "$TEST_REPO" init -q
+  export HOME="$TEST_HOME"
+  local sanitized
+  sanitized="$(echo "$TEST_REPO" | sed 's|/|-|g')"
+  INFERRED_MEMORY="$HOME/.claude/projects/${sanitized}/memory"
+  mkdir -p "$INFERRED_MEMORY"
+  cat > "$INFERRED_MEMORY/reference_ai_working_folder.md" <<REF
+---
+name: AI working folder for test
+type: reference
+---
+
+At the start of every session for this project, read these two files first:
+
+- \`$TEST_WF/CONTEXT.md\` — project overview
+- \`$TEST_WF/SESSION-LOG.md\` — chronological history
+REF
+  touch "$TEST_WF/CONTEXT.md"
+}
+
+@test "sync-templates.sh inferred default mode reads working folder from auto-memory" {
+  HOME_BACKUP="$HOME"
+  inferred_setup
+
+  cd "$TEST_REPO"
+  run "$SYNC"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"(inferred from \$PWD)"* ]]
+  # Working folder got templates
+  [ -f "$TEST_WF/plan.md" ]
+  [ -f "$TEST_WF/SEED-PROMPT.md" ]
+
+  export HOME="$HOME_BACKUP"
+}
+
+@test "sync-templates.sh inferred --workspace mode finds workspace root via working folder" {
+  HOME_BACKUP="$HOME"
+  inferred_setup
+  # Create a workspace root one level above the working folder
+  mkdir -p "$TEST_TMP/workspace"
+  mv "$TEST_WF" "$TEST_TMP/workspace/repo-wf"
+  TEST_WF="$TEST_TMP/workspace/repo-wf"
+  touch "$TEST_TMP/workspace/workspace-CONTEXT.md"
+  # Rewrite the memory pointer to the new working folder location
+  cat > "$INFERRED_MEMORY/reference_ai_working_folder.md" <<REF
+---
+type: reference
+---
+
+- \`$TEST_WF/CONTEXT.md\` — project overview
+- \`$TEST_WF/SESSION-LOG.md\` — chronological history
+REF
+
+  cd "$TEST_REPO"
+  run "$SYNC" --workspace
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"(inferred from \$PWD)"* ]]
+  # Workspace root got workspace-template files
+  [ -f "$TEST_TMP/workspace/workspace-plan.md" ]
+
+  export HOME="$HOME_BACKUP"
+}
+
+@test "sync-templates.sh inferred default mode errors when no auto-memory" {
+  HOME_BACKUP="$HOME"
+  TEST_HOME="$TEST_TMP/home"
+  NON_KIT="$TEST_TMP/random"
+  mkdir -p "$TEST_HOME" "$NON_KIT"
+  export HOME="$TEST_HOME"
+
+  cd "$NON_KIT"
+  run "$SYNC"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"couldn't infer a working folder"* ]]
+  [[ "$output" == *"sync-templates.sh <path>"* ]]
+
+  export HOME="$HOME_BACKUP"
+}
+
+@test "sync-templates.sh inferred --workspace mode errors when not in a workspace" {
+  HOME_BACKUP="$HOME"
+  TEST_HOME="$TEST_TMP/home"
+  NON_KIT="$TEST_TMP/random"
+  mkdir -p "$TEST_HOME" "$NON_KIT"
+  export HOME="$TEST_HOME"
+
+  cd "$NON_KIT"
+  run "$SYNC" --workspace
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"couldn't find a workspace root"* ]]
+
+  export HOME="$HOME_BACKUP"
 }


### PR DESCRIPTION
Closes #163.

## Summary

Helper scripts now infer their path arg from `$PWD` when run from inside a kit-bootstrapped repo. Explicit-path forms remain unchanged for scripted use.

| Script | Inferred mode |
|---|---|
| `sync-memory.sh` | Walks up from `$PWD` to find the repo root, then derives `~/.claude/projects/<sanitized>/memory`. |
| `sync-templates.sh` (default) | Reads `reference_ai_working_folder.md` from the repo's auto-memory and extracts the working folder path. |
| `sync-templates.sh --workspace` | Same lookup, then walks up one directory if a `workspace-CONTEXT.md` lives there. Also accepts `$PWD/workspace-CONTEXT.md` and `$PWD/../workspace-CONTEXT.md` directly. |
| `rename-workspace.sh` | Single positional arg = NEW path; OLD inferred from `$PWD` (must be a workspace, or a member repo whose working folder lives inside one). Two-arg form still works. |

The path-extraction heuristic is intentionally simple: grep for the first backtick-quoted absolute path ending in `/CONTEXT.md` in `reference_ai_working_folder.md`, strip the `/CONTEXT.md`. Works for every memory file the kit writes today, no template-format changes required, fully backward-compatible.

## What's in here

- **`scripts/lib/infer.sh`** — new shared library, four functions: `sanitize_path_for_memory`, `find_repo_root`, `infer_memory_dir`, `infer_working_folder`, `infer_workspace_root`. Pure (no side effects), empty stdout = "couldn't infer," caller decides.
- **Three updated scripts** — each makes the path arg optional, falls back to inference, prints "(inferred from `$PWD`)" in the source/target line for visibility, and emits a friendly error pointing at both fixes (cd into a kit-bootstrapped repo, or pass the path explicitly) when inference fails.
- **9 new bats tests across `tests/sync_memory.bats`, `tests/sync_templates.bats`, `tests/rename_workspace.bats`** — cover inferred-success, walk-up-from-subdir, workspace-via-parent, workspace-via-working-folder, and friendly-error-when-not-bootstrapped paths. Two pre-existing tests retired (the "missing arg" ones — that case is now inferred mode, not error).
- **Docs** — `SETUP.md` "Upgrading an existing project" section and "Renaming a workspace" subsection now lead with inferred forms; `FEATURES.md` auto-memory section notes the inference behavior.

## Test plan

Acceptance tests for issue #163:

- [x] `cd ~/Code/some-kit-bootstrapped-repo && sync-memory.sh` works without a path arg → covered by `sync-memory.sh inferred mode works when run from a kit-bootstrapped repo`
- [x] Subdir invocation walks up to the repo root → covered by `sync-memory.sh inferred mode walks up to find repo root from a subdir`
- [x] `cd ~/Code/some-kit-bootstrapped-repo && sync-templates.sh` works without a path arg → covered by `sync-templates.sh inferred default mode reads working folder from auto-memory`
- [x] `cd ~/Code/some-kit-bootstrapped-repo && sync-templates.sh --workspace` works → covered by `sync-templates.sh inferred --workspace mode finds workspace root via working folder`
- [x] `cd ~/Documents/Claude/Projects/<workspace> && rename-workspace.sh <new>` works → covered by `rename-workspace.sh single arg infers OLD from $PWD when inside a workspace`
- [x] Member-repo invocation infers the workspace root → covered by `rename-workspace.sh single arg infers via parent dir from a member repo`
- [x] Friendly error when run outside a kit-bootstrapped repo → covered by `*inferred mode errors when not in a kit-bootstrapped repo` tests across all three scripts (3 tests total)
- [x] Explicit-path mode unchanged → all 32 pre-existing explicit-path tests still pass
- [x] Bats suite green: `bats tests/` → 237/237

### Manual verification

- [x] On main after merge, `cd ~/Code/claude-project-kit && ./scripts/sync-memory.sh` runs cleanly against the kit's own auto-memory dir (no path arg) — verified pre-merge by user 2026-05-02 21:32 PT, output:
  ```
  Source:  /Users/aaroncupp/Code/claude-project-kit/memory-templates
  Target:  /Users/aaroncupp/.claude/projects/-Users-aaroncupp-Code-claude-project-kit/memory  (inferred from $PWD)

  Already in sync — no files to copy.
  Skipped (user-customized, never auto-synced): MEMORY.md project_current.md user_role.md
  ```
- [x] CI link-check passes — green on the PR
- [x] CI bats suite passes — green on the PR (237/237)

## Out of scope

- Memory-template format changes (B.3 in the issue spec) — the heuristic on existing prose is reliable enough; deferred.
- `bootstrap.sh` writing a structured field for forward-compat (B.5) — same reasoning.
- `install-commands.sh` inference for `--project` (B.6) — low priority, not friction-blocking.
- Acceptance-test phase boundary — N/A, this is off-phase work (Phase 4 closed).