### PR TITLE
feat(scripts): upgrade.sh — one-command kit + project upgrade orchestrator

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -182,7 +182,9 @@ Anything that can't be derived stays as `{{PLACEHOLDER}}` so it's grep-able. The
 
 The memory files are **starters**, not commandments. Prune what doesn't apply, add your own, keep `MEMORY.md` (the index) in sync. The harness loads `MEMORY.md` into context every session, so it stays small (under ~150 lines is a reasonable target).
 
-When the kit ships new starter rules, `scripts/sync-memory.sh` copies any missing templates into an existing auto-memory dir without overwriting customized files. Skips `MEMORY.md`, `project_current.md`, and `user_role.md` (user-curated). When run from inside a kit-bootstrapped repo, paths are inferred from `$PWD` — pass an explicit memory-dir arg only if you're not in the repo. The companion helper for working-folder and workspace templates is `scripts/sync-templates.sh`, with the same write-once shape and the same `$PWD`-based inference (see [SETUP.md §Upgrading an existing project](SETUP.md#upgrading-an-existing-project)).
+When the kit ships new starter rules, `scripts/sync-memory.sh` copies any missing templates into an existing auto-memory dir without overwriting customized files. Skips `MEMORY.md`, `project_current.md`, and `user_role.md` (user-curated). When run from inside a kit-bootstrapped repo, paths are inferred from `$PWD` — pass an explicit memory-dir arg only if you're not in the repo. The companion helper for working-folder and workspace templates is `scripts/sync-templates.sh`, with the same write-once shape and the same `$PWD`-based inference.
+
+Both feed into **`scripts/upgrade.sh`**, the one-command orchestrator that runs the full kit upgrade flow end-to-end: pulls the kit checkout, runs the sync helpers (auto-detecting workspace mode if applicable), installs any new global slash commands, prints a clean summary. Refuses to run if the kit checkout is dirty so you don't upgrade against in-flight kit work. Flags: `--dry-run`, `--skip-pull`, `--skip-commands`. See [SETUP.md §Upgrading an existing project](SETUP.md#upgrading-an-existing-project) for the orchestrator's place in the flow plus the manual fallback steps.
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -253,7 +253,18 @@ For fully filled-in references, see [`examples/widget-tracker/CONTEXT.md`](examp
 
 ## Upgrading an existing project
 
-`bootstrap.sh` is deliberately **write-once** — it won't touch a working folder or auto-memory dir that's already populated. When the kit evolves, existing adopters upgrade manually:
+`bootstrap.sh` is deliberately **write-once** — it won't touch a working folder or auto-memory dir that's already populated. When the kit evolves, existing adopters upgrade with one command:
+
+```bash
+cd ~/Code/<your-project>
+~/Code/claude-project-kit/scripts/upgrade.sh
+```
+
+That runs the full flow end-to-end: pulls the kit, syncs auto-memory, syncs working-folder templates, runs workspace-mode sync if the project is in a workspace, and installs any new global slash commands. Pass `--dry-run` first to preview, `--skip-pull` if you've already pulled the kit, or `--skip-commands` to skip the global slash-command install. After completion, restart Claude.app (Cmd+Q + reopen) to pick up new slash commands.
+
+**One known limitation:** `install-commands.sh` (and the orchestrator's Step 5) is write-once — it adds *missing* command files but does NOT overwrite existing ones. If a kit release ships an *updated* version of a command you already have installed, you currently need to manually `rm` it before `upgrade.sh` will reinstall the new copy. A `--force-update` flag is tracked in [#170](https://github.com/IamMrCupp/claude-project-kit/issues/170) and will land the orchestrator-friendly version of this fix.
+
+If you'd rather run the steps manually (or want to understand exactly what the orchestrator does), here they are:
 
 1. Check [`CHANGELOG.md`](CHANGELOG.md) to see what's landed since your bootstrap SHA (or since the last time you upgraded). Each entry has a **For existing adopters** section with specifics.
 2. **New files in `templates/`** — easiest path is the sync helper. From inside the kit-bootstrapped repo, paths are inferred automatically:

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Upgrade orchestrator — runs the kit upgrade flow end-to-end with one
+# command. Replaces the multi-step ritual of: pull the kit, run
+# sync-memory.sh, run sync-templates.sh (+ --workspace if applicable), run
+# install-commands.sh --global.
+#
+# Run from inside any kit-bootstrapped repo. Paths are inferred from $PWD
+# via lib/infer.sh (per #163), so no path args are needed.
+#
+# Pre-flight:
+#   - Kit checkout (where this script lives) must be clean. Refuses to run
+#     if uncommitted changes are present, to protect against upgrading
+#     against in-flight kit work. Pass --skip-pull to bypass.
+#   - $PWD must be inside a kit-bootstrapped repo (must have an auto-memory
+#     dir at ~/.claude/projects/<sanitized>/memory/).
+#
+# Default flow (each step is a separately-tested helper, well-isolated):
+#   1. git pull --ff-only on the kit checkout
+#   2. sync-memory.sh           — auto-memory templates
+#   3. sync-templates.sh        — working-folder templates
+#   4. sync-templates.sh --workspace  — only if $PWD is inside a workspace
+#   5. install-commands.sh --global   — slash commands + agents
+#
+# Each step is invoked with the same $PWD-inference the user would get if
+# they ran the helper themselves. See scripts/lib/infer.sh.
+#
+# Closes #169.
+set -euo pipefail
+
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "error: upgrade.sh requires bash" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KIT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/infer.sh
+. "$SCRIPT_DIR/lib/infer.sh"
+
+usage() {
+  cat <<EOF
+Usage: upgrade.sh [options]
+
+Run the kit upgrade flow end-to-end:
+  1. (kit checkout) Verify clean, then git pull --ff-only
+  2. (current project) sync-memory.sh
+  3. (current project) sync-templates.sh
+  4. (workspace, if applicable) sync-templates.sh --workspace
+  5. (global) install-commands.sh --global
+
+Run from inside any kit-bootstrapped repo. Paths inferred from \$PWD.
+
+Options:
+  --dry-run         Print the plan; run nothing destructive. Sub-scripts
+                    run in their own --dry-run mode where supported.
+  --skip-pull       Don't git-pull the kit; assume already current.
+                    Also bypasses the kit-checkout-clean pre-flight check.
+  --skip-commands   Don't install/update global slash commands or agents.
+  -h, --help        Show this help and exit.
+
+Examples:
+  # Default — from inside any kit-bootstrapped repo
+  cd ~/Code/some-project && ~/Code/claude-project-kit/scripts/upgrade.sh
+
+  # Preview without writing
+  ~/Code/claude-project-kit/scripts/upgrade.sh --dry-run
+
+  # Kit already pulled separately
+  ~/Code/claude-project-kit/scripts/upgrade.sh --skip-pull
+
+After completion, restart Claude.app (Cmd+Q + reopen) to pick up new
+slash commands. Existing commands are preserved (write-once invariant);
+to update changed commands, see install-commands.sh --force-update once
+issue #170 ships.
+EOF
+}
+
+DRY_RUN=0
+SKIP_PULL=0
+SKIP_COMMANDS=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --skip-pull) SKIP_PULL=1; shift ;;
+    --skip-commands) SKIP_COMMANDS=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --*) echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *) echo "error: unexpected positional argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+# ─── Pre-flight 1: kit checkout cleanliness ────────────────────────────────
+if [ "$SKIP_PULL" -eq 0 ]; then
+  if ! git -C "$KIT_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "error: kit checkout at $KIT_ROOT is not a git repository." >&2
+    echo "       Either point this script at a proper checkout, or pass --skip-pull." >&2
+    exit 1
+  fi
+  if ! git -C "$KIT_ROOT" diff --quiet 2>/dev/null \
+     || ! git -C "$KIT_ROOT" diff --cached --quiet 2>/dev/null \
+     || [ -n "$(git -C "$KIT_ROOT" ls-files --others --exclude-standard 2>/dev/null)" ]; then
+    echo "error: kit checkout has uncommitted changes — refusing to upgrade." >&2
+    git -C "$KIT_ROOT" status --short | head -5 | sed 's/^/         /' >&2
+    echo "       Resolve first (commit / stash / clean), then re-run, or pass --skip-pull." >&2
+    exit 1
+  fi
+fi
+
+# ─── Pre-flight 2: $PWD must be a kit-bootstrapped repo ───────────────────
+INFERRED_MEMORY="$(infer_memory_dir)"
+if [ ! -d "$INFERRED_MEMORY" ]; then
+  echo "error: \$PWD is not inside a kit-bootstrapped repo." >&2
+  echo "       Inferred memory path: $INFERRED_MEMORY" >&2
+  echo "       cd into a kit-bootstrapped repo first, then re-run." >&2
+  exit 1
+fi
+
+WORKING_FOLDER="$(infer_working_folder)"
+WORKSPACE_ROOT="$(infer_workspace_root)"
+
+# ─── Plan summary ─────────────────────────────────────────────────────────
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "=== DRY RUN — no changes will be made ==="
+fi
+echo "Upgrade plan"
+echo "  Kit:             $KIT_ROOT"
+echo "  Repo (\$PWD):     $PWD"
+if [ "$SKIP_PULL" -eq 1 ]; then
+  echo "  Step 1 (pull):       SKIPPED (--skip-pull)"
+else
+  echo "  Step 1 (pull):       git pull --ff-only origin main"
+fi
+echo "  Step 2 (memory):     sync-memory.sh        → $INFERRED_MEMORY"
+if [ -n "$WORKING_FOLDER" ]; then
+  echo "  Step 3 (templates):  sync-templates.sh     → $WORKING_FOLDER"
+else
+  echo "  Step 3 (templates):  SKIPPED (no working folder inferred from auto-memory)"
+fi
+if [ -n "$WORKSPACE_ROOT" ]; then
+  echo "  Step 4 (workspace):  sync-templates.sh --workspace  → $WORKSPACE_ROOT"
+else
+  echo "  Step 4 (workspace):  SKIPPED (not in a workspace)"
+fi
+if [ "$SKIP_COMMANDS" -eq 1 ]; then
+  echo "  Step 5 (commands):   SKIPPED (--skip-commands)"
+else
+  echo "  Step 5 (commands):   install-commands.sh --global"
+fi
+echo
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "(dry-run; no changes were made — re-run without --dry-run to execute)"
+  exit 0
+fi
+
+# ─── Step 1 — pull ────────────────────────────────────────────────────────
+if [ "$SKIP_PULL" -eq 0 ]; then
+  echo "── Step 1 — pulling kit checkout ──"
+  git -C "$KIT_ROOT" pull --ff-only origin main
+  echo
+fi
+
+# ─── Step 2 — sync memory ─────────────────────────────────────────────────
+echo "── Step 2 — syncing memory ──"
+"$SCRIPT_DIR/sync-memory.sh"
+echo
+
+# ─── Step 3 — sync templates (working-folder mode) ────────────────────────
+if [ -n "$WORKING_FOLDER" ]; then
+  echo "── Step 3 — syncing working-folder templates ──"
+  "$SCRIPT_DIR/sync-templates.sh"
+  echo
+else
+  echo "── Step 3 — skipped (no working folder inferred) ──"
+  echo
+fi
+
+# ─── Step 4 — sync templates (workspace mode) ─────────────────────────────
+if [ -n "$WORKSPACE_ROOT" ]; then
+  echo "── Step 4 — syncing workspace templates ──"
+  "$SCRIPT_DIR/sync-templates.sh" --workspace
+  echo
+fi
+
+# ─── Step 5 — install commands ────────────────────────────────────────────
+if [ "$SKIP_COMMANDS" -eq 0 ]; then
+  echo "── Step 5 — installing global slash commands + agents ──"
+  "$SCRIPT_DIR/install-commands.sh" --global
+  echo
+fi
+
+echo "✓ Upgrade complete."
+echo
+echo "Next steps:"
+echo "  • Restart Claude.app (Cmd+Q + reopen) to pick up new slash commands."
+echo "  • Existing commands are preserved (write-once invariant). To update"
+echo "    changed commands, see install-commands.sh --force-update once #170 ships."

--- a/tests/upgrade.bats
+++ b/tests/upgrade.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+# scripts/upgrade.sh — orchestrator that runs the kit upgrade flow end-to-end.
+# Calls the existing per-script helpers (sync-memory, sync-templates,
+# install-commands) with $PWD-inference. Tests use --skip-pull throughout to
+# avoid hitting the real kit checkout's git state.
+
+load 'helpers'
+
+UPGRADE="$KIT_ROOT/scripts/upgrade.sh"
+
+setup() { bootstrap_setup; }
+teardown() { bootstrap_teardown; }
+
+@test "upgrade.sh -h prints usage" {
+  run "$UPGRADE" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: upgrade.sh"* ]]
+  [[ "$output" == *"--dry-run"* ]]
+  [[ "$output" == *"--skip-pull"* ]]
+  [[ "$output" == *"--skip-commands"* ]]
+}
+
+@test "upgrade.sh errors on unknown flag" {
+  run "$UPGRADE" --bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown option"* ]]
+}
+
+@test "upgrade.sh errors on unexpected positional argument" {
+  run "$UPGRADE" --skip-pull some-extra-arg
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unexpected positional argument"* ]]
+}
+
+@test "upgrade.sh errors when not in a kit-bootstrapped repo" {
+  # Brand-new dir with no auto-memory
+  NON_KIT="$TEST_TMP/random"
+  mkdir -p "$NON_KIT"
+  cd "$NON_KIT"
+
+  run "$UPGRADE" --skip-pull
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not inside a kit-bootstrapped repo"* ]]
+  [[ "$output" == *"cd into a kit-bootstrapped repo"* ]]
+}
+
+@test "upgrade.sh --dry-run prints plan and writes nothing" {
+  # Bootstrap the test repo so auto-memory exists
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+  MEMORY_BEFORE="$(ls "$(memory_dir)" | sort)"
+
+  run "$UPGRADE" --skip-pull --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY RUN"* ]]
+  [[ "$output" == *"Upgrade plan"* ]]
+  [[ "$output" == *"Step 2 (memory)"* ]]
+  [[ "$output" == *"(dry-run; no changes were made"* ]]
+
+  # No new files in memory dir
+  MEMORY_AFTER="$(ls "$(memory_dir)" | sort)"
+  [ "$MEMORY_BEFORE" = "$MEMORY_AFTER" ]
+
+  # No global commands dir created (would be at $TEST_HOME/.claude/commands)
+  [ ! -d "$TEST_HOME/.claude/commands" ]
+}
+
+@test "upgrade.sh --skip-pull --skip-commands runs syncs only" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+
+  # Pre-bootstrap state — confirm a memory file we expect sync to NOT-add (already there)
+  ls "$(memory_dir)/feedback_commit_format.md" >/dev/null
+
+  run "$UPGRADE" --skip-pull --skip-commands
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Step 5 (commands):   SKIPPED"* ]]
+  [[ "$output" == *"Upgrade complete"* ]]
+
+  # Memory + templates should still have run; global commands dir not created
+  [ ! -d "$TEST_HOME/.claude/commands" ]
+}
+
+@test "upgrade.sh --skip-pull happy path runs all steps" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+
+  run "$UPGRADE" --skip-pull
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Step 2 — syncing memory"* ]]
+  [[ "$output" == *"Step 3 — syncing working-folder templates"* ]]
+  [[ "$output" == *"Step 5 — installing global slash commands"* ]]
+  [[ "$output" == *"Upgrade complete"* ]]
+  [[ "$output" == *"Restart Claude.app"* ]]
+
+  # Global commands dir should now exist in the sandboxed HOME
+  [ -d "$TEST_HOME/.claude/commands" ]
+  [ -f "$TEST_HOME/.claude/commands/session-start.md" ]
+  [ -f "$TEST_HOME/.claude/agents/code-reviewer.md" ]
+}
+
+@test "upgrade.sh --skip-pull infers workspace mode and runs Step 4" {
+  # Bootstrap a workspace + repo (Section D.4 / --workspace) — working folder
+  # lands at $WS/<repo-name>, auto-memory is keyed off the source repo path.
+  WS="$TEST_TMP/ws"
+  run "$BOOTSTRAP" --workspace "$WS"
+  [ "$status" -eq 0 ]
+
+  # Stay in the source repo ($TEST_REPO from bootstrap_setup). upgrade.sh
+  # infers the working folder from auto-memory and detects the workspace
+  # root via the working folder's parent.
+  cd "$TEST_REPO"
+
+  run "$UPGRADE" --skip-pull --skip-commands
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Step 4 (workspace):  sync-templates.sh --workspace"* ]]
+  [[ "$output" == *"Step 4 — syncing workspace templates"* ]]
+}
+
+@test "upgrade.sh shows --skip-pull skipped step in plan" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+
+  run "$UPGRADE" --skip-pull --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Step 1 (pull):       SKIPPED (--skip-pull)"* ]]
+}
+
+@test "upgrade.sh shows --skip-commands skipped step in plan" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+
+  run "$UPGRADE" --skip-pull --skip-commands --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Step 5 (commands):   SKIPPED (--skip-commands)"* ]]
+}


### PR DESCRIPTION
Closes #169.

## Summary

Adds `scripts/upgrade.sh` — a one-command orchestrator that runs the full kit upgrade flow end-to-end. Replaces the previous ritual:

```bash
# Before (5 commands across 2 cd's, easy to forget a step)
cd ~/Code/claude-project-kit && git pull
cd ~/Code/some-project
~/Code/claude-project-kit/scripts/sync-memory.sh
~/Code/claude-project-kit/scripts/sync-templates.sh
~/Code/claude-project-kit/scripts/install-commands.sh --global

# After
cd ~/Code/some-project && ~/Code/claude-project-kit/scripts/upgrade.sh
```

## Behavior

1. **Pre-flight 1** — kit checkout must be clean (refuses if `git status` dirty). Bypassable with `--skip-pull`.
2. **Pre-flight 2** — `$PWD` must be inside a kit-bootstrapped repo (auto-memory dir exists). Friendly error otherwise.
3. **Step 1** — `git pull --ff-only origin main` on the kit checkout. Skip with `--skip-pull`.
4. **Step 2** — `sync-memory.sh` with `$PWD`-inference (per #163).
5. **Step 3** — `sync-templates.sh` with `$PWD`-inference. Skipped if no working folder is inferred.
6. **Step 4** — `sync-templates.sh --workspace` if `$PWD` is inside a workspace (also auto-detected). Otherwise skipped.
7. **Step 5** — `install-commands.sh --global`. Skip with `--skip-commands`.
8. **Summary** — print a clean recap and remind the user to restart Claude.app.

Flags: `--dry-run`, `--skip-pull`, `--skip-commands`, `-h`.

Built on the `$PWD` inference from #163 — every sub-script is invoked the same way the user would invoke it themselves, no extra args.

## What's in here

- **`scripts/upgrade.sh`** — new executable, ~200 lines, sources `scripts/lib/infer.sh`. Each step is logged to stdout with the actual paths it's operating on.
- **`tests/upgrade.bats`** — 10 bats tests covering: `-h` usage, unknown flag, unexpected positional, friendly error outside a kit-bootstrapped repo, dry-run plan output (writes nothing), skip-flags display in plan, skip-flags work end-to-end, happy path runs all steps, workspace-mode auto-detect runs Step 4. All use `--skip-pull` so tests don't hit the real kit's git state.
- **`SETUP.md`** — "Upgrading an existing project" rewritten to lead with `upgrade.sh` as the one-command path. Manual step-by-step retained as a fallback for users who want to understand or skip steps. Documents the known `install-commands.sh` write-once limitation and points at sibling issue #170.
- **`FEATURES.md`** — "Upgrade helpers" entry now includes `upgrade.sh` as the front door.

## Known limitation, called out in docs

`install-commands.sh` (and therefore `upgrade.sh` Step 5) is write-once — it adds *missing* command files but does NOT overwrite existing ones. When the kit ships an *updated* version of a command you already have installed, the user still needs to manually `rm` it before re-running. The orchestrator-friendly fix (`--force-update` flag) is tracked in **#170**, intentionally a sibling issue rather than scope-creep into this one.

## Test plan

- [x] `bats tests/` passes (247/247 — 237 prior + 10 new)
- [x] `bats tests/upgrade.bats` passes in isolation (10/10)
- [x] `scripts/upgrade.sh -h` renders cleanly
- [x] Manual: `cd ~/Code/claude-project-kit && ./scripts/upgrade.sh --dry-run --skip-pull` prints the full plan against the kit's own dogfood project
- [ ] CI link-check passes
- [ ] CI bats suite passes
- [ ] Post-merge: run `upgrade.sh` against the kit's own working folder + a real bootstrapped project; verify all steps land cleanly

## Out of scope

- `--all-projects` mode (walk `~/.claude/projects/` and upgrade each) — interesting but separate; misuse risk requires more thought.
- `install-commands.sh --force-update` — sibling issue **#170**, lands separately.
- Auto-restart of Claude.app — user-driven; the orchestrator just reminds.