### PR TITLE
feat(workspace): workspace-phase-N-checklist.md + long-running workspace docs (PR A of #133)

### DIFF
--- a/.claude/commands/session-start.md
+++ b/.claude/commands/session-start.md
@@ -17,7 +17,9 @@ If the precheck passes, continue.
 
 Before we start, read these files in my AI working folder, in order:
 
-1. **In workspace mode only** — if `<working-folder>/../workspace-CONTEXT.md` exists, read it FIRST. It tells you the current initiative so the per-repo load below makes sense in context. Also read `<working-folder>/../workspace-plan.md` if it exists for the broader initiative arc.
+1. **In workspace mode only** — if `<working-folder>/../workspace-CONTEXT.md` exists, read it FIRST. It tells you the current initiative so the per-repo load below makes sense in context. Also read:
+   - `<working-folder>/../workspace-plan.md` if it exists — initiative roster (Active / Planned / Completed) for the broader initiative arc.
+   - `<working-folder>/../workspace-phase-N-checklist.md` if it exists — current phase of the active initiative at workspace scope. May span multiple repos.
 2. `<working-folder>/CONTEXT.md` — project overview, working rules, current phase
 3. `<working-folder>/SESSION-LOG.md` — chronological session history
 4. The current phase's checklist (e.g. `<working-folder>/phase-<N>-checklist.md`)

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -477,6 +477,50 @@ the plan only. Still no implementation.
 
 ---
 
+## 11. Starting a session in a long-running multi-initiative workspace
+
+Use this when opening a fresh Claude session in a workspace that hosts many initiatives over time. Loads workspace-level context first (which initiative is active, what phase it's in), then drills into per-repo state for the repo you're working in today.
+
+Distinct from Prompt 1 — that one targets a single-repo (or single-initiative) working folder. Use this when the active initiative changes from session to session and you want to surface that arc up front.
+
+### Verbose form (or first-session)
+
+```
+Before we start, read these files in my AI workspace, in order:
+
+1. `<workspace-root>/workspace-CONTEXT.md` — workspace overview, "Current Initiative" pointer
+2. `<workspace-root>/workspace-plan.md` — initiative roster (Active / Planned / Completed)
+3. `<workspace-root>/workspace-phase-N-checklist.md` — current phase of the active initiative
+4. (If working in a specific repo today) `<workspace-root>/<repo>/CONTEXT.md` and
+   `<workspace-root>/<repo>/SESSION-LOG.md` — that repo's per-repo context
+
+These hold both the cross-cutting workspace state and the active initiative's status.
+
+Once read, give me a 4–5 bullet summary of:
+- What the workspace is for (one line, from `workspace-CONTEXT.md`)
+- Which initiative is currently active and where it stands
+- What landed most recently (most recent `workspace-SESSION-LOG.md` entry, or per-repo if more relevant)
+- Any open threads from the latest log entry
+- The likely starting point for this session
+
+Then wait for my next instruction. Don't propose changes or start coding yet.
+```
+
+### Short form
+
+If `reference_ai_working_folder.md` in auto-memory points at the workspace working folder, this collapses to:
+
+```
+Load workspace context and give me a 4-bullet summary of where we are.
+```
+
+**Notes:**
+- The `/session-start` slash command (in `templates/.claude/commands/`) automatically loads workspace-level files first when `workspace-CONTEXT.md` is present in the working folder's parent — same pattern as this prompt, packaged as a one-step invocation.
+- Use Prompt 1 for single-repo (or single-initiative) working folders.
+- Use Prompt 4 (resuming mid-PR) when you have a branch in flight; it adds branch + PR + CI assessment on top of context loading.
+
+---
+
 ## When to write a new prompt
 
 Add one here whenever you find yourself typing similar setup instructions into a fresh session for the third time. A good prompt is:

--- a/SETUP.md
+++ b/SETUP.md
@@ -347,6 +347,25 @@ The templates support both. For single-initiative use, fill in "Current Initiati
 
 If a workspace's purpose drifts substantially (e.g. a "platform-infra" workspace that started for Terraform now becoming a general program), consider whether the right move is a new workspace rather than retrofitting the old one.
 
+#### Long-running workspace layout
+
+When a workspace hosts many initiatives over time, three workspace-scope files do the heavy lifting (each mirrors a per-repo file at workspace scope):
+
+| File | Purpose | Per-repo counterpart |
+|---|---|---|
+| `workspace-CONTEXT.md` | Workspace overview, working rules, "Current Initiative" pointer | `CONTEXT.md` |
+| `workspace-plan.md` | Initiative roster — Active / Planned-or-on-deck / Completed | `plan.md` |
+| `workspace-phase-N-checklist.md` | Phase tracking for the **active initiative**'s current phase. One file at a time; archive when the initiative wraps. | `phase-N-checklist.md` |
+
+Per-repo working folders live as subfolders under the workspace root, each with their own `CONTEXT.md`, `SESSION-LOG.md`, and per-repo `plan.md` / `phase-N-checklist.md` for repo-internal phases. The workspace-level checklist tracks the **cross-repo arc** of an initiative; per-repo checklists track repo-internal phases that may have nothing to do with the active initiative.
+
+**When the active initiative wraps:**
+
+1. Move it from "Active initiative" to "Completed initiatives" in `workspace-plan.md` with a one-paragraph outcome.
+2. Archive the workspace phase checklist — either rename `workspace-phase-N-checklist.md` → `<initiative-slug>-phase-{{N}}-checklist.md`, or move all the initiative's phase checklists into an `archive/` subfolder. The next initiative starts with a fresh `workspace-phase-N-checklist.md` (renumbering from 1).
+3. Archive any active tickets for the initiative — see [Per-ticket scratchpads](#pulling-a-ticket-into-the-workspace).
+4. Append a `workspace-SESSION-LOG.md` entry summarizing the initiative arc (or update the per-repo SESSION-LOG entries that touched it — your call which lives where).
+
 ### First repo in a new workspace
 
 ```bash

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -789,6 +789,7 @@ if [ "$DRY_RUN" -eq 1 ]; then
       echo "  + create workspace dir + tickets/archive/"
       echo "  + copy $KIT_ROOT/templates/workspace/workspace-CONTEXT.md → workspace-CONTEXT.md"
       echo "  + copy $KIT_ROOT/templates/workspace/workspace-plan.md → workspace-plan.md"
+      echo "  + copy $KIT_ROOT/templates/workspace/workspace-phase-N-checklist.md → workspace-phase-N-checklist.md"
     fi
     echo
   fi
@@ -884,7 +885,8 @@ if [ "$WORKSPACE_MODE" -eq 1 ]; then
   if [ ! -f "$WORKSPACE_DIR/workspace-CONTEXT.md" ]; then
     cp "$KIT_ROOT/templates/workspace/workspace-CONTEXT.md" "$WORKSPACE_DIR/"
     cp "$KIT_ROOT/templates/workspace/workspace-plan.md" "$WORKSPACE_DIR/"
-    echo "  ✓ Created workspace at $WORKSPACE_DIR (workspace-CONTEXT.md, workspace-plan.md, tickets/archive/)"
+    cp "$KIT_ROOT/templates/workspace/workspace-phase-N-checklist.md" "$WORKSPACE_DIR/"
+    echo "  ✓ Created workspace at $WORKSPACE_DIR (workspace-CONTEXT.md, workspace-plan.md, workspace-phase-N-checklist.md, tickets/archive/)"
     WORKSPACE_FIRST_REPO=1
   else
     echo "  ✓ Existing workspace at $WORKSPACE_DIR — adding repo subfolder $WORKSPACE_REPO_NAME"

--- a/templates/.claude/commands/session-start.md
+++ b/templates/.claude/commands/session-start.md
@@ -17,7 +17,9 @@ If the precheck passes, continue.
 
 Before we start, read these files in my AI working folder, in order:
 
-1. **In workspace mode only** — if `<working-folder>/../workspace-CONTEXT.md` exists, read it FIRST. It tells you the current initiative so the per-repo load below makes sense in context. Also read `<working-folder>/../workspace-plan.md` if it exists for the broader initiative arc.
+1. **In workspace mode only** — if `<working-folder>/../workspace-CONTEXT.md` exists, read it FIRST. It tells you the current initiative so the per-repo load below makes sense in context. Also read:
+   - `<working-folder>/../workspace-plan.md` if it exists — initiative roster (Active / Planned / Completed) for the broader initiative arc.
+   - `<working-folder>/../workspace-phase-N-checklist.md` if it exists — current phase of the active initiative at workspace scope. May span multiple repos.
 2. `<working-folder>/CONTEXT.md` — project overview, working rules, current phase
 3. `<working-folder>/SESSION-LOG.md` — chronological session history
 4. The current phase's checklist (e.g. `<working-folder>/phase-<N>-checklist.md`)

--- a/templates/workspace/workspace-phase-N-checklist.md
+++ b/templates/workspace/workspace-phase-N-checklist.md
@@ -1,0 +1,69 @@
+# Workspace Phase {{N}} Checklist — {{Phase Name}}
+
+**Initiative:** {{Initiative name from `workspace-plan.md` "Active initiative"}}
+**Goal:** {{one sentence — what done looks like for this phase of this initiative}}
+**Status:** {{⏳ In progress / ✅ Complete}}
+**Exit criteria:** {{what must be true before this phase is considered done — typically an acceptance test pass across the touched repos}}
+**Repos touched:** {{<repo-a>, <repo-b>}}
+
+---
+
+## How to use this doc
+
+This is the workspace counterpart to a per-repo `phase-N-checklist.md`. It tracks one phase of the **active initiative** at the workspace level — the cross-repo arc, not the internals of any one repo.
+
+- One item ≈ one branch ≈ one PR. Items often span repos within the workspace — record the branch + PR for each repo touched.
+- For ticket-driven work, items typically reference a tracker key (e.g. ACME-1234) shared across the per-repo PRs.
+- Organize items into sections (A, B, C, …) with checkpoints between major chunks.
+- Tick items ✅ the moment the LAST per-repo PR for that item merges — not at end of phase.
+- Per-repo phases (each repo's `plan.md` / `phase-N-checklist.md`) drift independently from this workspace phase. Use this checklist for the cross-repo initiative arc; use per-repo checklists for repo-internal phases.
+
+---
+
+## Section A — {{Section name}}
+
+### A.1 {{Task title}}
+
+- **Tracker:** {{KEY-NNN if applicable}}
+- **Repos:**
+  - **{{repo-a}}** — branch `{{type/KEY-NNN-slug}}` → PR #{{N}}
+  - **{{repo-b}}** — branch `{{type/KEY-NNN-slug}}` → PR #{{N}}
+- **Status:** [ ] merged
+
+---
+
+### A.2 {{Task title}}
+
+…
+
+---
+
+**Checkpoint A:** {{What's working across repos after A is done. Cross-repo validation steps if any.}}
+
+---
+
+## Section B — {{Section name}}
+
+…
+
+---
+
+## Acceptance testing
+
+> **Required by convention.** Every phase MUST exit with a non-empty `acceptance-test-results.md`. See `CONVENTIONS.md` → "Acceptance tests at phase boundaries" for the rule and the one allowed escape hatch. Removing this section is a convention violation, not a customization — `/close-phase` will refuse to close if it's missing.
+
+For workspace phases, acceptance tests typically span repos. List them here:
+
+- [ ] Test 1 — {{cross-repo verification — e.g. "deploy the new module from <repo-a>, run the integration suite from <repo-b>"}}
+- [ ] Test 2 — {{…}}
+
+---
+
+## Phase exit
+
+- [ ] All items in all sections ticked (across every repo touched)
+- [ ] Acceptance tests pass (see `acceptance-test-results.md`) — OR document the skip on a single line below this block: `Acceptance tests intentionally skipped — rationale: {{one sentence}}`
+- [ ] `workspace-plan.md` updated — initiative phase status, any scope drift recorded
+- [ ] `workspace-CONTEXT.md` updated — current initiative status, known issues, architectural decisions
+- [ ] Session entry appended to `workspace-SESSION-LOG.md` describing phase completion
+- [ ] If this phase completes the **active initiative**: move it from "Active initiative" to "Completed initiatives" in `workspace-plan.md` and archive this checklist (rename to `<initiative-slug>-phase-{{N}}-checklist.md`, or move all the initiative's phase checklists to an `archive/` subfolder). The next initiative starts with a fresh `workspace-phase-N-checklist.md` (renumbering from 1).

--- a/tests/bootstrap_workspace.bats
+++ b/tests/bootstrap_workspace.bats
@@ -46,6 +46,18 @@ teardown() { bootstrap_teardown; }
   grep -q "Active initiative" "$WS/workspace-plan.md"
 }
 
+@test "--workspace copies workspace-phase-N-checklist.md to workspace root" {
+  WS="$TEST_TMP/acme-platform"
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory
+  [ "$status" -eq 0 ]
+
+  [ -f "$WS/workspace-phase-N-checklist.md" ]
+  grep -q "Workspace Phase" "$WS/workspace-phase-N-checklist.md"
+  grep -q "Active initiative" "$WS/workspace-phase-N-checklist.md"
+  grep -q "Acceptance testing" "$WS/workspace-phase-N-checklist.md"
+  grep -q "Phase exit" "$WS/workspace-phase-N-checklist.md"
+}
+
 @test "--workspace workspace-CONTEXT.md has Current Initiative + Past initiatives sections" {
   WS="$TEST_TMP/acme-platform"
   run "$BOOTSTRAP" --workspace "$WS" --skip-memory


### PR DESCRIPTION
First of three staged PRs working through #133's deferred ACs (per the staging proposed in [this comment](https://github.com/IamMrCupp/claude-project-kit/issues/133#issuecomment-4365529750)). Closes the **template + bootstrap + session-start + docs** parts; leaves the multi-initiative exemplar (PR B) and the ADR (PR C) for follow-ups.

## Summary

Multiple long-running workspaces are about to spin up across personal + work projects, all hosting many initiatives over months. This PR ships the workspace-scope phase-tracking template that the existing `workspace-CONTEXT.md` (Current Initiative pointer) and `workspace-plan.md` (initiative roster) were designed to anchor against.

- **`templates/workspace/workspace-phase-N-checklist.md`** — new template. Mirrors per-repo `phase-N-checklist.md` at workspace scope: Section/Item structure, Acceptance testing block, Phase exit checklist. Crucial differences vs. per-repo: each item records branches + PRs across **multiple repos**, items reference a tracker key shared across the per-repo PRs, acceptance tests typically span repos, and the Phase exit checklist includes the "if this completes the active initiative, archive this checklist" step.
- **`bootstrap.sh`** — copies the new template alongside `workspace-CONTEXT.md` + `workspace-plan.md` whenever `--workspace <path>` creates a workspace. Dry-run preview echo line updated to match.
- **`templates/.claude/commands/session-start.md`** + dogfood-synced `.claude/commands/session-start.md` — adds `workspace-phase-N-checklist.md` to the workspace-mode load list so the slash command surfaces the active initiative's current phase up front.
- **`SETUP.md` "Long-running workspace layout"** — new sub-section under "Single-initiative vs. long-running workspaces". Documents the three workspace-scope files (CONTEXT / plan / phase-N-checklist), the per-repo + workspace layering, and the archival ritual when an initiative wraps.
- **`PROMPTS.md` Prompt 11** — paired prompt for users who want the same multi-initiative session-start flow without the slash command. References the slash command as the packaged form.
- **`tests/bootstrap_workspace.bats`** — one new test asserting the file is created with correct headers (Workspace Phase, Active initiative, Acceptance testing, Phase exit).

## What ticket-driven, multi-repo work looks like in this template

The template's Section A example shows a single item that spans two repos:

```
### A.1 {{Task title}}

- **Tracker:** {{KEY-NNN if applicable}}
- **Repos:**
  - **{{repo-a}}** — branch `{{type/KEY-NNN-slug}}` → PR #{{N}}
  - **{{repo-b}}** — branch `{{type/KEY-NNN-slug}}` → PR #{{N}}
- **Status:** [ ] merged
```

This matches the existing JIRA-driven workspace convention from #61 (same ticket key reused across multiple repo PRs, single shared tracker entry).

## Test plan

- [x] `bats tests/` passes (259/259 — 258 prior + 1 new)
- [x] `bats tests/bootstrap_workspace.bats` passes (20/20 including the new assertion)
- [x] `bats tests/dogfood_claude_in_sync.bats` passes (templates/.claude/ matches .claude/ for the session-start.md update)
- [x] `bootstrap.sh --workspace <new-path>` dry-run echo includes the new file in its plan
- [x] `bootstrap.sh --workspace <new-path>` actually creates the file alongside the other two workspace files
- [ ] Manual: bootstrap a fresh workspace and verify all three workspace files render reasonably; spot-check the session-start slash command's workspace-mode load list now mentions the phase checklist
- [ ] CI link-check passes
- [ ] CI bats suite passes

## Out of scope (PR B + PR C of the staging)

- **Multi-initiative exemplar** under `examples/` — a worked example showing one completed initiative + one in-progress initiative in the same workspace. Reference material; depends on this PR's templates being in place.
- **ADR** documenting the workspace-scale phase/initiative tracking design. Captures rationale; doesn't block adoption.

Both follow #133's staging plan. PR A makes the pattern *usable*; PR B makes it *demonstrable*; PR C makes it *justifiable*.