### PR TITLE
fix(bootstrap): stamp working-folder path into MEMORY.md index line

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -302,6 +302,7 @@ If you'd rather run the steps manually (or want to understand exactly what the o
    ```bash
    cp <kit-dir>/memory-templates/<NEW_FILE>.md ~/.claude/projects/<sanitized-path>/memory/
    ```
+   **One-time fix for projects bootstrapped before v0.39:** the `[AI working folder location]` line in those `MEMORY.md` files reads `at session start` instead of the absolute working-folder path. `/session-start`'s precheck only sees `MEMORY.md` content, so the missing path makes the precheck bail. Hand-edit the line to end with `at <absolute-working-folder-path>/ before work` — sync-memory leaves `MEMORY.md` alone by design, so this is a one-shot manual edit.
 4. **New files in `templates/.claude/`** — easiest path is to re-run the install helper, which adds any missing commands or agents without overwriting existing files:
    ```bash
    <kit-dir>/scripts/install-commands.sh --global   # or --project <repo-path>

--- a/memory-templates/MEMORY.md
+++ b/memory-templates/MEMORY.md
@@ -9,7 +9,7 @@ Starter index. Every file in this folder is a **starting point** — copy them i
 Do not treat these as canonical without reading them first — they encode one opinionated way of working.
 
 - [User role and background](user_role.md) — who you're collaborating with, how to calibrate explanations
-- [AI working folder location](reference_ai_working_folder.md) — read CONTEXT.md + SESSION-LOG.md at session start
+- [AI working folder location](reference_ai_working_folder.md) — read CONTEXT.md + SESSION-LOG.md at {{WORKING_FOLDER}}/ before work
 - [Commit format](feedback_commit_format.md) — Conventional Commits, single line, signed off
 - [Merge strategy](feedback_merge_strategy.md) — always merge commits; never squash or rebase
 - [Push branches by default](feedback_push_branches.md) — `git push -u origin <branch>` after commit without asking

--- a/tests/bootstrap_memory.bats
+++ b/tests/bootstrap_memory.bats
@@ -81,6 +81,17 @@ teardown() { bootstrap_teardown; }
   ! grep -q '{{REPO_PATH}}' "$(memory_dir)/reference_ai_working_folder.md"
 }
 
+@test "AI working folder index line in MEMORY.md is stamped with absolute path" {
+  run "$BOOTSTRAP" "$TEST_WF"
+  [ "$status" -eq 0 ]
+  # Bug fix: the [AI working folder location] index line must embed the actual
+  # working-folder path, because /session-start's precheck only sees MEMORY.md
+  # content (not the linked reference_ai_working_folder.md file). A generic
+  # description like "at session start" makes the precheck bail.
+  grep -q "AI working folder location.*$TEST_WF" "$(memory_dir)/MEMORY.md"
+  ! grep -q '{{WORKING_FOLDER}}' "$(memory_dir)/MEMORY.md"
+}
+
 @test "placeholder substitution fills {{REPO_SLUG}} when git remote exists" {
   run "$BOOTSTRAP" "$TEST_WF"
   [ "$status" -eq 0 ]

--- a/tests/bootstrap_workspace.bats
+++ b/tests/bootstrap_workspace.bats
@@ -190,6 +190,18 @@ teardown() { bootstrap_teardown; }
   [ -f "$MEM/MEMORY.md" ]
 }
 
+@test "--workspace stamps per-repo path (not workspace root) into MEMORY.md AI working folder line" {
+  WS="$TEST_TMP/acme-platform"
+  REPO_NAME="$(basename "$TEST_REPO")"
+  run "$BOOTSTRAP" --workspace "$WS"
+  [ "$status" -eq 0 ]
+
+  MEM="$(memory_dir)"
+  # Line must reference the per-repo subfolder, not the workspace root
+  grep -q "AI working folder location.*$WS/$REPO_NAME" "$MEM/MEMORY.md"
+  ! grep -q '{{WORKING_FOLDER}}' "$MEM/MEMORY.md"
+}
+
 # --- Phase 4 D.1 — tracker config substitution into workspace-CONTEXT.md ---
 
 @test "--workspace --tracker jira fills tracker config in workspace-CONTEXT.md" {


### PR DESCRIPTION
## Summary

- Replace the generic `at session start` description on the `[AI working folder location]` line in `memory-templates/MEMORY.md` with the `{{WORKING_FOLDER}}` placeholder, so the existing `substitute_memory_placeholders_in_dir` step stamps the absolute working-folder path during bootstrap.
- Why this matters: auto-memory at session start only loads `MEMORY.md` content into the system reminder, not the linked `reference_ai_working_folder.md`. `/session-start`'s precheck reads only the index line — without the path, it bails with "No reference_ai_working_folder.md in this project's auto-memory" even when the file is on disk.
- Add bats coverage for both single-repo and `--workspace` modes; the workspace test specifically asserts the per-repo subfolder (not the workspace root) gets stamped.
- SETUP.md upgrade flow now documents the one-time hand-edit existing adopters need (sync-memory.sh skips `MEMORY.md` by design).

Closes #184

## Test plan

- [x] `bats tests/` — all 279 tests pass locally, including two new tests:
  - `AI working folder index line in MEMORY.md is stamped with absolute path`
  - `--workspace stamps per-repo path (not workspace root) into MEMORY.md AI working folder line`
- [x] CI on this PR is green
- [ ] Manual verification: bootstrap a fresh single-repo project and confirm `MEMORY.md`'s AI working folder line includes the absolute working-folder path