### PR TITLE
fix(commands): rewrite precheck to read pointer file directly

### DIFF
--- a/.claude/agents/session-summarizer.md
+++ b/.claude/agents/session-summarizer.md
@@ -8,7 +8,7 @@ tools: Read, Bash, Glob
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell the user:
    > "No kit working folder found for this project. To use this agent, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or invoke me from a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/close-phase.md
+++ b/.claude/commands/close-phase.md
@@ -7,7 +7,7 @@ argument-hint: [phase-number]
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -14,7 +14,7 @@ with a load-bearing "don't implement yet" guard.
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/pull-ticket.md
+++ b/.claude/commands/pull-ticket.md
@@ -7,7 +7,7 @@ argument-hint: <KEY>
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/refresh-context.md
+++ b/.claude/commands/refresh-context.md
@@ -6,7 +6,7 @@ description: Re-read CONTEXT.md, SESSION-LOG.md, and the current phase checklist
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -13,7 +13,7 @@ phase that produces a written report before any planning or implementation.
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/run-acceptance.md
+++ b/.claude/commands/run-acceptance.md
@@ -7,7 +7,7 @@ argument-hint: [test-N | all]
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/session-end.md
+++ b/.claude/commands/session-end.md
@@ -6,7 +6,7 @@ description: End-of-session wrap-up — draft SESSION-LOG entry, suggest CONTEXT
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/session-handoff.md
+++ b/.claude/commands/session-handoff.md
@@ -6,7 +6,7 @@ description: Hand off mid-session — capture everything to disk now, no confirm
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/session-start.md
+++ b/.claude/commands/session-start.md
@@ -6,7 +6,7 @@ description: Load the working folder's CONTEXT.md, SESSION-LOG.md, and current p
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/agents/session-summarizer.md
+++ b/templates/.claude/agents/session-summarizer.md
@@ -8,7 +8,7 @@ tools: Read, Bash, Glob
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell the user:
    > "No kit working folder found for this project. To use this agent, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or invoke me from a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/close-phase.md
+++ b/templates/.claude/commands/close-phase.md
@@ -7,7 +7,7 @@ argument-hint: [phase-number]
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/plan.md
+++ b/templates/.claude/commands/plan.md
@@ -14,7 +14,7 @@ with a load-bearing "don't implement yet" guard.
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/pull-ticket.md
+++ b/templates/.claude/commands/pull-ticket.md
@@ -7,7 +7,7 @@ argument-hint: <KEY>
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/refresh-context.md
+++ b/templates/.claude/commands/refresh-context.md
@@ -6,7 +6,7 @@ description: Re-read CONTEXT.md, SESSION-LOG.md, and the current phase checklist
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/research.md
+++ b/templates/.claude/commands/research.md
@@ -13,7 +13,7 @@ phase that produces a written report before any planning or implementation.
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/run-acceptance.md
+++ b/templates/.claude/commands/run-acceptance.md
@@ -7,7 +7,7 @@ argument-hint: [test-N | all]
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/session-end.md
+++ b/templates/.claude/commands/session-end.md
@@ -6,7 +6,7 @@ description: End-of-session wrap-up — draft SESSION-LOG entry, suggest CONTEXT
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/session-handoff.md
+++ b/templates/.claude/commands/session-handoff.md
@@ -6,7 +6,7 @@ description: Hand off mid-session — capture everything to disk now, no confirm
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/session-start.md
+++ b/templates/.claude/commands/session-start.md
@@ -6,7 +6,7 @@ description: Load the working folder's CONTEXT.md, SESSION-LOG.md, and current p
 
 Before doing anything else:
 
-1. Look up `reference_ai_working_folder.md` in this project's auto-memory.
+1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/tests/precheck_in_commands.bats
+++ b/tests/precheck_in_commands.bats
@@ -16,6 +16,8 @@ KIT_COUPLED_COMMANDS=(
   templates/.claude/commands/close-phase.md
   templates/.claude/commands/pull-ticket.md
   templates/.claude/commands/run-acceptance.md
+  templates/.claude/commands/plan.md
+  templates/.claude/commands/research.md
 )
 
 # Kit-coupled agents (code-reviewer is universal — no kit dependency).
@@ -54,12 +56,42 @@ KIT_COUPLED_AGENTS=(
   done
 }
 
+# Regression guard for #187 — the precheck must instruct the model to use
+# the Read tool against the auto-memory pointer file directly. The earlier
+# wording ("Look up `reference_ai_working_folder.md` in this project's
+# auto-memory") was ambiguous — models sometimes read it as "check the
+# session-reminder", which only contains MEMORY.md, and bailed on properly
+# bootstrapped projects.
+@test "every kit-coupled command Precheck uses unambiguous Read-tool wording" {
+  for cmd in "${KIT_COUPLED_COMMANDS[@]}"; do
+    f="$KIT_ROOT/$cmd"
+    if ! grep -q 'Use the `Read` tool to load `~/\.claude/projects/' "$f"; then
+      echo "missing explicit Read-tool wording in: $cmd"
+      return 1
+    fi
+    if grep -q "Look up \`reference_ai_working_folder\.md\` in this project's auto-memory" "$f"; then
+      echo "regression — old ambiguous wording still present in: $cmd"
+      return 1
+    fi
+  done
+}
+
 @test "kit-coupled agents include a Precheck block" {
   for agent in "${KIT_COUPLED_AGENTS[@]}"; do
     f="$KIT_ROOT/$agent"
     [ -f "$f" ]
     if ! grep -q "^## Precheck — is this a kit project?$" "$f"; then
       echo "missing Precheck block: $agent"
+      return 1
+    fi
+  done
+}
+
+@test "kit-coupled agents Precheck uses unambiguous Read-tool wording" {
+  for agent in "${KIT_COUPLED_AGENTS[@]}"; do
+    f="$KIT_ROOT/$agent"
+    if ! grep -q 'Use the `Read` tool to load `~/\.claude/projects/' "$f"; then
+      echo "missing explicit Read-tool wording in: $agent"
       return 1
     fi
   done


### PR DESCRIPTION
Closes #187.

## Summary

Rewrites the `## Precheck — is this a kit project?` block across every kit-coupled slash command and the `session-summarizer` agent so the model is told to **`Read` the auto-memory pointer file directly** rather than "look it up in this project's auto-memory" — which the model was misinterpreting on properly bootstrapped projects.

## Why

The precheck added in #142 (2026-05-01) instructed the model:

> 1. Look up `reference_ai_working_folder.md` in this project's auto-memory.

That sentence is ambiguous. Two valid interpretations:

- **(A)** *check whether the file exists in the auto-memory directory* → uses `Read` / `Bash ls` → finds it → proceeds.
- **(B)** *check whether the auto-memory system reminder mentions it* → reads `MEMORY.md`, sees the kit-template line `read CONTEXT.md + SESSION-LOG.md at session start` (no embedded path) → bails.

Auto-memory at session start only loads `MEMORY.md` content into the system reminder, not the linked memory files. When a model picks interpretation (B) on a `MEMORY.md` whose `[AI working folder location]` line wasn't path-stamped, `/session-start` mis-bails with "No kit working folder found for this project" — even though the pointer is on disk and the working folder exists.

Surfaced today by an adopter running `upgrade.sh` against a workspace-bootstrapped pair of repos: `/session-start` worked in one repo and bailed in the sibling on identical setup.

#185 (just merged) addressed half the problem by stamping the absolute path into MEMORY.md at bootstrap. But that only helps **new bootstraps** — `sync-memory.sh` deliberately skips `MEMORY.md` so existing adopters keep the generic line. This PR is the other half: rewording the precheck so it works regardless of `MEMORY.md` content.

## What changed

New step 1 (replaces "Look up `reference_ai_working_folder.md` in this project's auto-memory."):

> 1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.

Steps 2 and 3 (bail message + don't-load-partial-state) unchanged.

## Surfaces touched

- 10 commands × 2 mirrors (`templates/.claude/commands/` + dogfood `.claude/commands/`) = 20 files
- 1 agent × 2 mirrors (session-summarizer)
- `tests/precheck_in_commands.bats`:
  - Added `plan.md` and `research.md` to `KIT_COUPLED_COMMANDS` (they had the precheck since v0.33.0 but were never in the test array — pre-existing coverage gap, fixed here)
  - Added regression-guard test asserting the new explicit Read-tool wording is present and the old ambiguous wording is gone (commands)
  - Added equivalent regression-guard test for kit-coupled agents

No bootstrap, sync, or template-installation logic changes.

## Once shipped

Existing adopters re-run `upgrade.sh --force-commands` on each kit-bootstrapped repo to pick up the corrected slash commands. No `MEMORY.md` edits required. Combined with #185, future bootstraps get both the path-stamped `MEMORY.md` (defense-in-depth) and the unambiguous precheck.

## Test plan

- [x] **`bats tests/` passes** — 281 / 281 (was 279; +2 new regression-guard tests)
- [x] **Dogfood pairs byte-identical** — `diff -r templates/.claude/commands .claude/commands` and the agent counterpart both produce empty output post-edit
- [x] **Precheck text replaced cleanly** — verified visually in `templates/.claude/commands/session-start.md`; old "Look up …" line absent (`grep -L 'Look up \`reference_ai_working_folder' templates/.claude/commands/*.md` lists every file, i.e. all 10 are clean)
- [ ] **CI green on this PR** — bats + link-check expected to pass on push