### PR TITLE
fix(commands): resolve absolute path via Bash before Read

### DIFF
--- a/.claude/agents/session-summarizer.md
+++ b/.claude/agents/session-summarizer.md
@@ -8,7 +8,11 @@ tools: Read, Bash, Glob
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell the user:
    > "No kit working folder found for this project. To use this agent, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or invoke me from a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/close-phase.md
+++ b/.claude/commands/close-phase.md
@@ -7,7 +7,11 @@ argument-hint: [phase-number]
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -14,7 +14,11 @@ with a load-bearing "don't implement yet" guard.
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/pull-ticket.md
+++ b/.claude/commands/pull-ticket.md
@@ -7,7 +7,11 @@ argument-hint: <KEY>
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/refresh-context.md
+++ b/.claude/commands/refresh-context.md
@@ -6,7 +6,11 @@ description: Re-read CONTEXT.md, SESSION-LOG.md, and the current phase checklist
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -13,7 +13,11 @@ phase that produces a written report before any planning or implementation.
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/run-acceptance.md
+++ b/.claude/commands/run-acceptance.md
@@ -7,7 +7,11 @@ argument-hint: [test-N | all]
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/session-end.md
+++ b/.claude/commands/session-end.md
@@ -6,7 +6,11 @@ description: End-of-session wrap-up — draft SESSION-LOG entry, suggest CONTEXT
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/session-handoff.md
+++ b/.claude/commands/session-handoff.md
@@ -6,7 +6,11 @@ description: Hand off mid-session — capture everything to disk now, no confirm
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/.claude/commands/session-start.md
+++ b/.claude/commands/session-start.md
@@ -6,7 +6,11 @@ description: Load the working folder's CONTEXT.md, SESSION-LOG.md, and current p
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/agents/session-summarizer.md
+++ b/templates/.claude/agents/session-summarizer.md
@@ -8,7 +8,11 @@ tools: Read, Bash, Glob
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell the user:
    > "No kit working folder found for this project. To use this agent, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or invoke me from a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/close-phase.md
+++ b/templates/.claude/commands/close-phase.md
@@ -7,7 +7,11 @@ argument-hint: [phase-number]
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/plan.md
+++ b/templates/.claude/commands/plan.md
@@ -14,7 +14,11 @@ with a load-bearing "don't implement yet" guard.
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/pull-ticket.md
+++ b/templates/.claude/commands/pull-ticket.md
@@ -7,7 +7,11 @@ argument-hint: <KEY>
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/refresh-context.md
+++ b/templates/.claude/commands/refresh-context.md
@@ -6,7 +6,11 @@ description: Re-read CONTEXT.md, SESSION-LOG.md, and the current phase checklist
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/research.md
+++ b/templates/.claude/commands/research.md
@@ -13,7 +13,11 @@ phase that produces a written report before any planning or implementation.
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/run-acceptance.md
+++ b/templates/.claude/commands/run-acceptance.md
@@ -7,7 +7,11 @@ argument-hint: [test-N | all]
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/session-end.md
+++ b/templates/.claude/commands/session-end.md
@@ -6,7 +6,11 @@ description: End-of-session wrap-up — draft SESSION-LOG entry, suggest CONTEXT
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/session-handoff.md
+++ b/templates/.claude/commands/session-handoff.md
@@ -6,7 +6,11 @@ description: Hand off mid-session — capture everything to disk now, no confirm
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/templates/.claude/commands/session-start.md
+++ b/templates/.claude/commands/session-start.md
@@ -6,7 +6,11 @@ description: Load the working folder's CONTEXT.md, SESSION-LOG.md, and current p
 
 Before doing anything else:
 
-1. Use the `Read` tool to load `~/.claude/projects/<KEY>/memory/reference_ai_working_folder.md`, where `<KEY>` is the absolute current working directory with `/` replaced by `-` (compute via `echo "$PWD" | sed 's|/|-|g'` — e.g. `/Users/foo/Code/bar` → `-Users-foo-Code-bar`). Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
    > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
 3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.

--- a/tests/precheck_in_commands.bats
+++ b/tests/precheck_in_commands.bats
@@ -56,21 +56,36 @@ KIT_COUPLED_AGENTS=(
   done
 }
 
-# Regression guard for #187 — the precheck must instruct the model to use
-# the Read tool against the auto-memory pointer file directly. The earlier
-# wording ("Look up `reference_ai_working_folder.md` in this project's
-# auto-memory") was ambiguous — models sometimes read it as "check the
-# session-reminder", which only contains MEMORY.md, and bailed on properly
-# bootstrapped projects.
-@test "every kit-coupled command Precheck uses unambiguous Read-tool wording" {
+# Regression guard for #187 / #190 — the precheck must instruct the model to
+# resolve the auto-memory pointer path via Bash ($HOME + $PWD-derived key)
+# and then Read the resolved absolute path. Earlier wordings either:
+#   - "Look up `reference_ai_working_folder.md` in this project's auto-memory"
+#     was ambiguous — models read it as "check the session reminder", which
+#     only contains MEMORY.md, and bailed on properly bootstrapped projects.
+#   - "Use the `Read` tool to load `~/.claude/projects/...`" — the Read tool
+#     does not expand `~/`, so passing the literal `~/...` string fails with
+#     "file not found" and the precheck bails the same way.
+@test "every kit-coupled command Precheck resolves absolute path via Bash before Read" {
   for cmd in "${KIT_COUPLED_COMMANDS[@]}"; do
     f="$KIT_ROOT/$cmd"
-    if ! grep -q 'Use the `Read` tool to load `~/\.claude/projects/' "$f"; then
-      echo "missing explicit Read-tool wording in: $cmd"
+    # Must include the $HOME-based echo command for path resolution.
+    if ! grep -q 'echo "\$HOME/\.claude/projects/' "$f"; then
+      echo "missing \$HOME-based path resolution Bash command in: $cmd"
       return 1
     fi
+    # Must explicitly direct the model to NOT pass ~/ to Read.
+    if ! grep -q 'do not pass `~/` to Read' "$f"; then
+      echo "missing 'do not pass ~/ to Read' guidance in: $cmd"
+      return 1
+    fi
+    # Old ambiguous wording must be gone.
     if grep -q "Look up \`reference_ai_working_folder\.md\` in this project's auto-memory" "$f"; then
-      echo "regression — old ambiguous wording still present in: $cmd"
+      echo "regression — original ambiguous wording still present in: $cmd"
+      return 1
+    fi
+    # Old tilde-passing wording must also be gone.
+    if grep -q 'Use the `Read` tool to load `~/\.claude/projects/' "$f"; then
+      echo "regression — tilde-path wording still present in: $cmd"
       return 1
     fi
   done
@@ -87,11 +102,15 @@ KIT_COUPLED_AGENTS=(
   done
 }
 
-@test "kit-coupled agents Precheck uses unambiguous Read-tool wording" {
+@test "kit-coupled agents Precheck resolves absolute path via Bash before Read" {
   for agent in "${KIT_COUPLED_AGENTS[@]}"; do
     f="$KIT_ROOT/$agent"
-    if ! grep -q 'Use the `Read` tool to load `~/\.claude/projects/' "$f"; then
-      echo "missing explicit Read-tool wording in: $agent"
+    if ! grep -q 'echo "\$HOME/\.claude/projects/' "$f"; then
+      echo "missing \$HOME-based path resolution Bash command in: $agent"
+      return 1
+    fi
+    if grep -q 'Use the `Read` tool to load `~/\.claude/projects/' "$f"; then
+      echo "regression — tilde-path wording still present in: $agent"
       return 1
     fi
   done


### PR DESCRIPTION
Closes #190. Follow-up to #188.

## Summary

The precheck rewording in #188 still bails on properly bootstrapped projects. Root cause: the Claude Code `Read` tool does not expand `~/` — it requires absolute paths. When the model passes the literal string `~/.claude/projects/<KEY>/...` to `Read`, the call returns "file not found" and the precheck correctly bails on the (false) inference that no pointer exists.

This PR rewrites step 1 of the precheck to resolve the absolute path via Bash *before* the `Read` call.

## What changed

Step 1 (replaces the `~/`-tilde Read directive from #188):

> 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
>    ```bash
>    echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
>    ```
>    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.

`$HOME` + `$PWD` get expanded by the shell during `echo`; the printed string starts with `/` and is an absolute path the `Read` tool accepts unconditionally. The "do not pass `~/` to Read" warning is explicit so future re-readings of the precheck don't regress to the same bug.

## Audit

Confirmed no other places in commands/agents direct Claude to `Read` a `~/`-prefixed path. All other `~/` references in `SETUP.md`, `PROMPTS.md`, etc. are in shell-command examples for human readers, not Read-tool directives.

## Surfaces touched

- 10 commands × 2 mirrors + 1 agent × 2 mirrors = 22 files (same set as #188 — `templates/.claude/commands/*.md`, `templates/.claude/agents/session-summarizer.md`, plus dogfood mirrors under `.claude/`)
- `tests/precheck_in_commands.bats` — strengthened regression-guard tests:
  - Asserts the new `echo "$HOME/.claude/projects/...` Bash command is present
  - Asserts the explicit "do not pass `~/` to Read" warning is present
  - Asserts neither prior wording (original ambiguous "Look up …" from #142 nor the `~/`-tilde Read from #188) is anywhere in the file

No bootstrap, sync, or template-installation logic changes.

## Once shipped

Existing adopters re-run `upgrade.sh --force-commands` on each kit-bootstrapped repo to pick up the fix. No `MEMORY.md` edits required.

## Test plan

- [x] **`bats tests/` passes** — 281 / 281
- [x] **Dogfood pairs byte-identical** — `diff -r templates/.claude .claude` produces empty output
- [x] **Verified live in the failing Claude session**: same model that bailed on the `~/.claude/...` path successfully reads the absolute `/Users/<user>/.claude/...` path. Once this ships and the user re-upgrades, `/session-start` should pass on first try.
- [ ] **CI green on this PR**