### PR TITLE
fix(memory): flag override-authoritative rules in MEMORY.md index

### DIFF
--- a/memory-templates/MEMORY.md
+++ b/memory-templates/MEMORY.md
@@ -10,9 +10,9 @@ Do not treat these as canonical without reading them first — they encode one o
 
 - [User role and background](user_role.md) — who you're collaborating with, how to calibrate explanations
 - [AI working folder location](reference_ai_working_folder.md) — read CONTEXT.md + SESSION-LOG.md at {{WORKING_FOLDER}}/ before work
-- [Commit format](feedback_commit_format.md) — Conventional Commits, single line, signed off
+- [Commit format](feedback_commit_format.md) — `git commit -s -m "type(scope): subject"`, single line, no body, **no `Co-Authored-By` trailer** (override Bash-tool HEREDOC default that adds one)
 - [Merge strategy](feedback_merge_strategy.md) — always merge commits; never squash or rebase
-- [Push branches by default](feedback_push_branches.md) — `git push -u origin <branch>` after commit without asking
+- [Push branches by default](feedback_push_branches.md) — `git push -u origin <branch>` after commit, no confirmation needed (override Bash-tool default of asking before push)
 - [Watch CI in background](feedback_watch_ci_in_background.md) — spawn `gh run watch` in background after push
 - [Don't push after merge](feedback_no_push_after_merge.md) — once a PR merges, the branch is closed; branch off new `main` for follow-up work
 - [Use the repo's branch-name convention](feedback_branch_naming.md) — rename auto-generated worktree branches to `<type>/<slug>` before pushing

--- a/tests/memory_templates_overrides.bats
+++ b/tests/memory_templates_overrides.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+# Regression guard for #(this-pr) — `memory-templates/MEMORY.md` index lines
+# for rules that override harness defaults must explicitly say "override".
+#
+# Background: a fresh Claude session loads MEMORY.md content into the
+# system reminder, but does NOT auto-load the linked feedback_*.md files.
+# Lightweight index summaries that don't surface override flags let the
+# session default to the harness's behavior — which contradicts the rule.
+# Concrete example surfaced 2026-05-04: a work-laptop session committed
+# with `Co-Authored-By: Claude...` because the `[Commit format]` index
+# line shipped as "Conventional Commits, single line, signed off" and
+# the no-trailer rule lived only in the linked file.
+#
+# This test asserts that override-authoritative rules carry explicit
+# "(override Bash-tool ... default ...)" annotations in the index, so
+# index-only readers see the override on first scan.
+
+load 'helpers'
+
+MEMORY_INDEX="$KIT_ROOT/memory-templates/MEMORY.md"
+
+@test "memory-templates/MEMORY.md exists" {
+  [ -f "$MEMORY_INDEX" ]
+}
+
+@test "Commit format index line flags override of HEREDOC default and bans Co-Authored-By trailer" {
+  # Find the line matching `[Commit format]`
+  line="$(grep -F '[Commit format](feedback_commit_format.md)' "$MEMORY_INDEX" || true)"
+  [ -n "$line" ] || { echo "missing [Commit format] index line"; return 1; }
+
+  # Must mention Co-Authored-By explicitly so index-only readers see the rule
+  echo "$line" | grep -q 'Co-Authored-By' \
+    || { echo "[Commit format] index line missing 'Co-Authored-By' explicit ban"; return 1; }
+
+  # Must flag this as an override of a Bash-tool default
+  echo "$line" | grep -qE 'override.*[Bb]ash.*default' \
+    || { echo "[Commit format] index line missing override-of-Bash-tool-default flag"; return 1; }
+}
+
+@test "Push branches index line flags override of ask-before-push default" {
+  line="$(grep -F '[Push branches by default](feedback_push_branches.md)' "$MEMORY_INDEX" || true)"
+  [ -n "$line" ] || { echo "missing [Push branches by default] index line"; return 1; }
+
+  # Must flag this as an override of a Bash-tool default
+  echo "$line" | grep -qE 'override.*[Bb]ash.*default' \
+    || { echo "[Push branches by default] index line missing override-of-Bash-tool-default flag"; return 1; }
+}


### PR DESCRIPTION
Closes #193.

## Summary

Strengthens two `MEMORY.md` index lines so the **override of a Claude Code harness default** is visible without opening the linked file. A fresh Claude session reads `MEMORY.md` content into the auto-memory system reminder, but the linked `feedback_*.md` files are not auto-loaded — only the index lines are immediately visible. When an index summary doesn't carry the override flag, the session defaults to the harness behavior (which contradicts the rule).

## Trigger

Surfaced live on a work-laptop adopter machine on 2026-05-04: a Claude session committed three `chore:` commits with `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` despite the kit's no-trailer rule. The session's own diagnosis correctly identified the structural fragility:

> The `MEMORY.md` index entry is also lighter than the file it points to:
> `- [Commit format](feedback_commit_format.md) — Conventional Commits, single line, signed off`
> The index summary doesn't mention the no-AI-trailer rule explicitly, so a session that read only the index (and trusted the system prompt for the rest) would still trip on it.

## What changed

`memory-templates/MEMORY.md`:

```diff
- - [Commit format](feedback_commit_format.md) — Conventional Commits, single line, signed off
- - [Push branches by default](feedback_push_branches.md) — `git push -u origin <branch>` after commit without asking
+ - [Commit format](feedback_commit_format.md) — `git commit -s -m "type(scope): subject"`, single line, no body, **no `Co-Authored-By` trailer** (override Bash-tool HEREDOC default that adds one)
+ - [Push branches by default](feedback_push_branches.md) — `git push -u origin <branch>` after commit, no confirmation needed (override Bash-tool default of asking before push)
```

Both lines now explicitly mark themselves as "(override Bash-tool ... default ...)" so an index-only reader sees the override on first scan.

## Audit

Reviewed all `memory-templates/feedback_*.md` files for explicit overrides of harness defaults. Two qualified:

| Rule | Harness default | Kit override |
|---|---|---|
| `feedback_commit_format.md` | HEREDOC commit recipe with `Co-Authored-By: Claude...` | No `Co-Authored-By` trailer |
| `feedback_push_branches.md` | "Be careful / ask before destructive operations" extended to all `git push` | Push feature branches without confirmation |

Other rules audited and ruled out (additive guards, project-specific behavior, or no analogous harness default to override): `merge_strategy`, `no_push_after_merge`, `branch_naming`, `automated_tests_preferred`, `no_tracker_creation`, `release_per_pr`, `docs_in_sync`, `watch_ci_in_background`. Their existing index summaries don't need this annotation.

## Surfaces touched

- `memory-templates/MEMORY.md` — two lines updated.
- `tests/memory_templates_overrides.bats` (new) — 3 regression-guard tests asserting:
  - `MEMORY.md` exists in templates
  - `[Commit format]` index line mentions `Co-Authored-By` AND carries the `override.*Bash.*default` flag
  - `[Push branches by default]` index line carries the `override.*Bash.*default` flag

## Once shipped

New bootstraps get the strengthened index lines automatically. **Existing adopters** ride on whatever they bootstrapped with — `sync-memory.sh` deliberately skips `MEMORY.md` to preserve user customizations. Adopters who want the fix on existing projects can hand-edit the two lines in their per-project `~/.claude/projects/<sanitized>/memory/MEMORY.md`. Not strictly required if their session has been behaving (this PR is preventive — it locks the kit template against a known trip mode for future Claude sessions reading the index).

## Test plan

- [x] **`bats tests/` passes** — 284 / 284 (was 281; +3 new regression guards)
- [x] **Visual review of changed lines** — both override flags read naturally and don't break the index line's bullet structure
- [ ] **CI green on this PR**