### PR TITLE
feat(bootstrap): manage adopter .gitignore with --no-gitignore opt-out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,13 @@
 .idea/
 *.swp
 
+# Local-only Claude Code state — the kit's repo dogfoods .claude/commands/
+# and .claude/agents/ (those ARE tracked above), but settings.local.json
+# accumulates per-user allowlists and worktrees/ holds chip-spawned scratch
+# checkouts. Both are local-user state and never belong in git.
+.claude/settings.local.json
+.claude/worktrees/
+
 # VHS-rendered demos — sources committed under demo/, renders hosted via
 # GitHub user-attachments and embedded by URL in README.md (see demo/README.md).
 demo/*.gif

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -69,6 +69,18 @@ Bootstrap detects Terraform-shaped repos (signals: `*.tf`, `*.tfvars`, `.terrafo
 
 The signal list comes from [ADR-0001 §A.6](docs/adr/0001-multi-repo-folder-model.md). Pulumi (`Pulumi.yaml`) and CDK (`cdk.json`) are deferred — promote in a follow-up if the demand surfaces.
 
+### Managed `.gitignore` block
+
+Bootstrap appends a marker-bracketed managed block to the target repo's `.gitignore` covering local-user state that doesn't belong in source control:
+
+- `.claude/` — local-only Claude Code state (`settings.local.json` permissions allowlist, `worktrees/` chip-spawned scratch checkouts, optional per-project commands installed via `install-commands.sh --project`)
+- macOS junk: `.DS_Store`, `._*`, `.AppleDouble`, `.LSOverride`
+- Editors / IDEs: `.vscode/`, `.idea/`, `*.swp`, `*.swo`, `*~`
+
+Idempotent — re-runs detect the existing `# claude-project-kit — managed block START` / `END` markers and skip. Creates `.gitignore` if absent; preserves any pre-existing entries when the file already exists. Honors `--dry-run` (preview only) and `--no-gitignore` (opt out entirely; you manage your own).
+
+The kit's stance: **`.claude/` stays local to the user — never committed to the source-code repo it's being used on.** The kit's own repo is the one exception; it dogfoods `.claude/commands/` + `.claude/agents/` (those *are* tracked here) and only gitignores `.claude/settings.local.json` + `.claude/worktrees/`.
+
 ---
 
 ## Workspace mode (multi-repo)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ That kicks off interactive mode: it asks for the working-folder path, project na
 
 ## Features
 
-- **Idempotent bootstrap** — write-once by default, with `--dry-run` (preview), `--force` (override the empty-folder check), and `--skip-memory` (working folder only).
+- **Idempotent bootstrap** — write-once by default, with `--dry-run` (preview), `--force` (override the empty-folder check), `--skip-memory` (working folder only), and `--no-gitignore` (skip the `.gitignore` step).
 - **Workspace mode** — `--workspace <path>` sets up a multi-repo initiative folder (workspace-CONTEXT.md + per-repo subfolders + shared `tickets/`). Detects Terraform / Terragrunt repos and prompts about sibling envs/modules repos.
 - **Issue tracker awareness** — `--tracker {github,jira,linear,gitlab,shortcut,other,none}` seeds tracker-specific memory AND fills `{{TRACKER_TYPE}}` / `{{TRACKER_KEY}}` in `CONTEXT.md`. JIRA and Linear take a project / team key.
 - **Per-ticket scratchpads** — `/pull-ticket <KEY>` slash command + `pull-ticket.sh` helper script fetch ticket data via tracker MCPs / CLIs and seed `tickets/<KEY>-<slug>.md`. **Read-only** against the tracker — never creates, edits, transitions, or comments.
@@ -77,10 +77,11 @@ That kicks off interactive mode: it asks for the working-folder path, project na
 - **SEED-PROMPT auto-fill** — point Claude at one file and it deep-reads your repo, fills `CONTEXT.md`, drafts `research.md`, flags inferences, and stops for your review.
 - **Starter agents** — `code-reviewer` (universal) and `session-summarizer` (kit-aware), staged in the working folder; copy into your repo to activate.
 - **Starter slash commands** — `/session-start`, `/refresh-context`, `/close-phase`, `/session-end`, `/session-handoff`, `/pull-ticket`, `/run-acceptance`, `/research`, `/plan`. Install once globally with `scripts/install-commands.sh --global` (recommended) or per-repo with `--project <path>`.
+- **Managed `.gitignore` block** — bootstrap appends a marker-bracketed block to `<repo>/.gitignore` covering `.claude/` (local-only Claude Code state), macOS junk (`.DS_Store` etc.), and editor / IDE files (`.vscode/`, `.idea/`, `*.swp`, ...). Idempotent on re-runs; opt out with `--no-gitignore`. Kit's stance: `.claude/` stays local to the user, never committed.
 - **Upgrade helpers** — `scripts/sync-memory.sh`, `scripts/sync-templates.sh`, and `scripts/rename-workspace.sh` keep auto-memory, working-folder templates, and workspace paths in sync with the latest kit release without overwriting your filled-in content. See [SETUP.md §Upgrading](SETUP.md#upgrading-an-existing-project).
 - **Worked examples** — `examples/widget-tracker/` (fictional Go CLI, single-repo, mid-Phase 1) and `examples/acme-platform/` (fictional Terraform multi-repo workspace, JIRA-driven, **long-running with multiple initiatives** — one completed, one active — plus `workspace-plan.md`, `workspace-phase-N-checklist.md`, and active + archived ticket scratchpads).
 - **Conventions baseline** — Conventional Commits, merge-only PRs, ticket-driven branch / PR / commit shape, test-plan format, etc. Read once, drop or keep per project.
-- **No surprises** — MIT licensed, no telemetry, no network calls, kit never modifies your target repo.
+- **No surprises** — MIT licensed, no telemetry, no network calls. The only file bootstrap writes to your target repo is `.gitignore` (managed block, opt-out via `--no-gitignore`); everything else lands in the out-of-tree working folder.
 
 See [FEATURES.md](FEATURES.md) for one-paragraph-per-feature detail with example invocations.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -48,18 +48,24 @@ Whatever you pick, the **repo stays the repo; the working folder stays separate*
 >
 > **If you use the kit on more than one machine** (work laptop + personal desktop, etc.), repeat the setup on each. `~/.claude/settings.json` is local user config, not part of the kit repo, so cloning the kit on a new machine won't bring it along.
 
-> **Heads-up: `<repo>/.claude/settings.local.json`.** Claude Code writes this file in every project where you grant Bash / MCP / read-path permissions interactively. It is **per-project, machine-specific, and Claude-Code-managed** — the kit doesn't create or edit it. **Add it to your `.gitignore`** so machine-specific permissions don't get committed and follow the repo around. Two equivalent forms:
+> **Heads-up: `<repo>/.claude/` is local-user state, never committed.** The whole `.claude/` directory in your project repo holds machine-specific Claude Code data — `settings.local.json` (per-project permission allowlist), `worktrees/` (chip-spawned scratch checkouts), and any per-project commands/agents you install via `install-commands.sh --project`. **None of it belongs in git.** The kit's stance: `.claude/` stays local to you and never follows the repo around.
+>
+> **`bootstrap.sh` handles this for you by default** — it appends a marker-bracketed managed block to your repo's `.gitignore` covering `.claude/`, macOS junk (`.DS_Store` etc.), and common editor / IDE files (`.vscode/`, `.idea/`, `*.swp`, ...). The block is idempotent on re-runs and can be opted out with `--no-gitignore` if you'd rather manage your own.
+>
+> **Manual alternative** (if you opted out, or want a once-globally form covering every repo):
 >
 > ```bash
 > # Per-repo (add this line to <repo>/.gitignore)
-> .claude/settings.local.json
+> .claude/
 >
 > # Once globally — covers every repo on this machine
 > # (add this line to ~/.config/git/ignore)
-> **/.claude/settings.local.json
+> **/.claude/
 > ```
 >
 > If a permission is one you want allowed in *every* kit project (e.g. `Bash(gh run *)` for CI watchers), graduate it from the per-project `.claude/settings.local.json` to the global `~/.claude/settings.json` by hand. The kit doesn't sync this for the same reason it doesn't write to `~/.claude/settings.json` for you — global config is yours to curate.
+>
+> **The kit's own repo is the one exception.** It dogfoods `.claude/commands/` and `.claude/agents/` (those *are* tracked here), and only the always-local `.claude/settings.local.json` + `.claude/worktrees/` are gitignored.
 
 > Throughout this guide, `<framework-dir>` means wherever you've cloned/extracted this kit (e.g. `~/Code/claude-project-kit`), and `<working-folder>` means the path you just picked above.
 
@@ -86,6 +92,7 @@ Both modes create the working folder, copy the templates, rename `phase-N-checkl
 
 Flags:
 - `--skip-memory` — skip the memory-seeding step (leaves `~/.claude/projects/…` alone)
+- `--no-gitignore` — skip appending the kit-managed block to `<repo>/.gitignore`. By default bootstrap appends a marker-bracketed block covering `.claude/` (local-only Claude Code state), macOS junk (`.DS_Store`, `._*`, ...), and editor / IDE files (`.vscode/`, `.idea/`, `*.swp`, ...). Idempotent — re-runs detect the existing block and skip.
 - `--project-name NAME` — override the auto-derived project name
 - `--tracker TYPE` — issue tracker: `github`, `jira`, `linear`, `gitlab`, `shortcut`, `other`, or `none`. Skipped if omitted in non-interactive mode.
 - `--jira-project KEY` — JIRA project key (e.g. `INFRA`). Implies `--tracker jira` if `--tracker` isn't also passed.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -50,6 +50,14 @@ Options:
                      See ADR-0001 in the kit for the workspace folder model.
   --skip-memory      Skip copying memory-templates/ into the auto-memory
                      folder. Only the working folder will be seeded.
+  --no-gitignore     Skip appending the kit-managed block to the repo's
+                     .gitignore. By default bootstrap appends a block
+                     covering .claude/ (local-only Claude Code state),
+                     macOS junk (.DS_Store etc.), and common editor / IDE
+                     files (.vscode/, .idea/, *.swp, ...). Idempotent —
+                     re-runs detect the existing block and skip. The kit's
+                     stance: .claude/ stays local to the user, never
+                     committed to the source-code repo.
   --project-name NAME
                      Override the auto-derived project name used to fill
                      {{PROJECT_NAME}} placeholders in seeded memory files.
@@ -488,7 +496,75 @@ PY
   return 0
 }
 
+gitignore_block_start_marker() { echo "# claude-project-kit — managed block START"; }
+gitignore_block_end_marker()   { echo "# claude-project-kit — managed block END"; }
+
+emit_gitignore_block() {
+  # Emit the managed block contents (markers + entries) to stdout. Single
+  # source of truth so the real-write path and the dry-run preview can't drift.
+  gitignore_block_start_marker
+  echo "# Local-only Claude Code state — installed globally via install-commands.sh"
+  echo "# or scoped per-project, but never committed to the source-code repo."
+  echo ".claude/"
+  echo
+  echo "# macOS"
+  echo ".DS_Store"
+  echo "._*"
+  echo ".AppleDouble"
+  echo ".LSOverride"
+  echo
+  echo "# Editors / IDEs"
+  echo ".vscode/"
+  echo ".idea/"
+  echo "*.swp"
+  echo "*.swo"
+  echo "*~"
+  gitignore_block_end_marker
+}
+
+update_repo_gitignore() {
+  # Append a managed block to <repo>/.gitignore covering local-only Claude
+  # Code state (.claude/), macOS junk, and common editor/IDE files. Idempotent
+  # — re-runs detect the existing block via marker comments and skip.
+  # Creates .gitignore if absent. Caller is responsible for honoring
+  # --no-gitignore and --dry-run; this function only does the real write.
+  #
+  # args: repo_root
+  local repo="$1"
+  local gitignore="$repo/.gitignore"
+  local marker
+  marker="$(gitignore_block_start_marker)"
+
+  if [ -f "$gitignore" ] && grep -Fq "$marker" "$gitignore"; then
+    echo "  ✓ .gitignore already has kit-managed block — no change"
+    return 0
+  fi
+
+  local existed=0
+  if [ -f "$gitignore" ]; then
+    existed=1
+    if [ -s "$gitignore" ]; then
+      # Ensure file ends with a newline before appending.
+      if [ -n "$(tail -c 1 "$gitignore")" ]; then
+        printf '\n' >> "$gitignore"
+      fi
+      # Blank-line separator before our block.
+      printf '\n' >> "$gitignore"
+    fi
+  fi
+
+  emit_gitignore_block >> "$gitignore"
+
+  if [ "$existed" -eq 1 ]; then
+    echo "  ✓ Appended kit-managed block to $gitignore"
+  else
+    echo "  ✓ Created $gitignore with kit-managed block"
+  fi
+  return 0
+}
+
 SKIP_MEMORY=0
+SKIP_GITIGNORE=0
 FORCE=0
 DRY_RUN=0
 WORKSPACE_MODE=0
@@ -503,6 +579,7 @@ CI_TOOL=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --skip-memory) SKIP_MEMORY=1; shift ;;
+    --no-gitignore) SKIP_GITIGNORE=1; shift ;;
     --force) FORCE=1; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     --workspace) WORKSPACE_MODE=1; shift ;;
@@ -844,6 +921,20 @@ if [ "$DRY_RUN" -eq 1 ]; then
     echo "Memory seeding skipped (--skip-memory)."
   fi
   echo
+  if [ "$SKIP_GITIGNORE" -eq 0 ]; then
+    GITIGNORE_PATH="$REPO_ROOT/.gitignore"
+    if [ -f "$GITIGNORE_PATH" ] && grep -Fq "$(gitignore_block_start_marker)" "$GITIGNORE_PATH"; then
+      echo "Repo .gitignore: $GITIGNORE_PATH"
+      echo "  ✓ kit-managed block already present — no change"
+    elif [ -f "$GITIGNORE_PATH" ]; then
+      echo "Would update repo .gitignore: $GITIGNORE_PATH"
+      echo "  + append kit-managed block (.claude/, macOS junk, IDE files)"
+    else
+      echo "Would create repo .gitignore: $GITIGNORE_PATH"
+      echo "  + write kit-managed block (.claude/, macOS junk, IDE files)"
+    fi
+    echo
+  fi
   echo "No changes made. Re-run without --dry-run to apply."
   exit 0
 fi
@@ -951,6 +1042,10 @@ fi
 
 write_initial_session_log_entry
 echo "  ✓ Wrote initial Bootstrap entry to $WORKING_FOLDER/SESSION-LOG.md"
+
+if [ "$SKIP_GITIGNORE" -eq 0 ]; then
+  update_repo_gitignore "$REPO_ROOT"
+fi
 
 if [ "$TRUST_WORKING_FOLDER_ROOT" -eq 1 ]; then
   TRUSTED_ROOT_PATH="$(trusted_root_for_working_folder)"

--- a/tests/bootstrap_gitignore.bats
+++ b/tests/bootstrap_gitignore.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+# Bootstrap manages the target repo's .gitignore by appending a marker-bracketed
+# block covering local-only Claude Code state (.claude/), macOS junk, and common
+# editor / IDE files. Idempotent. --no-gitignore opts out.
+
+load 'helpers'
+
+setup() { bootstrap_setup; }
+teardown() { bootstrap_teardown; }
+
+@test "creates .gitignore with kit-managed block when absent" {
+  [ ! -f "$TEST_REPO/.gitignore" ]
+  run "$BOOTSTRAP" --skip-memory "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_REPO/.gitignore" ]
+  grep -Fq "# claude-project-kit — managed block START" "$TEST_REPO/.gitignore"
+  grep -Fq "# claude-project-kit — managed block END" "$TEST_REPO/.gitignore"
+  grep -Fq ".claude/" "$TEST_REPO/.gitignore"
+  grep -Fq ".DS_Store" "$TEST_REPO/.gitignore"
+  grep -Fq ".vscode/" "$TEST_REPO/.gitignore"
+  grep -Fq ".idea/" "$TEST_REPO/.gitignore"
+}
+
+@test "appends kit-managed block to existing .gitignore preserving prior content" {
+  printf 'node_modules/\n*.log\n' > "$TEST_REPO/.gitignore"
+  run "$BOOTSTRAP" --skip-memory "$TEST_WF"
+  [ "$status" -eq 0 ]
+  # Pre-existing entries still present
+  grep -Fxq "node_modules/" "$TEST_REPO/.gitignore"
+  grep -Fxq "*.log" "$TEST_REPO/.gitignore"
+  # Kit block appended
+  grep -Fq "# claude-project-kit — managed block START" "$TEST_REPO/.gitignore"
+  grep -Fq ".claude/" "$TEST_REPO/.gitignore"
+  # Pre-existing content appears before the kit block
+  pre_line="$(grep -nFx 'node_modules/' "$TEST_REPO/.gitignore" | head -1 | cut -d: -f1)"
+  block_line="$(grep -nF '# claude-project-kit — managed block START' "$TEST_REPO/.gitignore" | head -1 | cut -d: -f1)"
+  [ "$pre_line" -lt "$block_line" ]
+}
+
+@test "is idempotent — re-running does not duplicate the block" {
+  run "$BOOTSTRAP" --skip-memory "$TEST_WF"
+  [ "$status" -eq 0 ]
+  count_first="$(grep -cF '# claude-project-kit — managed block START' "$TEST_REPO/.gitignore")"
+  [ "$count_first" -eq 1 ]
+  # Second run must succeed and leave the file untouched.
+  run "$BOOTSTRAP" --skip-memory --force "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already has kit-managed block"* ]]
+  count_second="$(grep -cF '# claude-project-kit — managed block START' "$TEST_REPO/.gitignore")"
+  [ "$count_second" -eq 1 ]
+}
+
+@test "--no-gitignore opt-out skips creation entirely" {
+  [ ! -f "$TEST_REPO/.gitignore" ]
+  run "$BOOTSTRAP" --skip-memory --no-gitignore "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [ ! -f "$TEST_REPO/.gitignore" ]
+  [[ "$output" != *"kit-managed block"* ]]
+}
+
+@test "--no-gitignore opt-out leaves existing .gitignore untouched" {
+  printf 'node_modules/\n*.log\n' > "$TEST_REPO/.gitignore"
+  before="$(cat "$TEST_REPO/.gitignore")"
+  run "$BOOTSTRAP" --skip-memory --no-gitignore "$TEST_WF"
+  [ "$status" -eq 0 ]
+  after="$(cat "$TEST_REPO/.gitignore")"
+  [ "$before" = "$after" ]
+}
+
+@test "--dry-run previews kit-managed block creation when .gitignore absent" {
+  [ ! -f "$TEST_REPO/.gitignore" ]
+  run "$BOOTSTRAP" --dry-run --skip-memory "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Would create repo .gitignore"* ]]
+  [[ "$output" == *"kit-managed block"* ]]
+  [ ! -f "$TEST_REPO/.gitignore" ]
+}
+
+@test "--dry-run previews append when .gitignore exists without kit block" {
+  printf 'node_modules/\n' > "$TEST_REPO/.gitignore"
+  run "$BOOTSTRAP" --dry-run --skip-memory "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Would update repo .gitignore"* ]]
+  [[ "$output" == *"append kit-managed block"* ]]
+  # No write happened.
+  [ "$(cat "$TEST_REPO/.gitignore")" = "$(printf 'node_modules/\n')" ]
+}
+
+@test "--dry-run reports already-managed when kit block is present" {
+  "$BOOTSTRAP" --skip-memory "$TEST_WF" >/dev/null
+  run "$BOOTSTRAP" --dry-run --skip-memory --force "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"kit-managed block already present"* ]]
+}
+
+@test "--dry-run with --no-gitignore prints no gitignore preview lines" {
+  run "$BOOTSTRAP" --dry-run --skip-memory --no-gitignore "$TEST_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *".gitignore"* ]]
+}
+
+@test "block uses em-dash markers consistent with rest of kit" {
+  run "$BOOTSTRAP" --skip-memory "$TEST_WF"
+  [ "$status" -eq 0 ]
+  # Em-dash (U+2014), not hyphen.
+  grep -Fq "claude-project-kit — managed block" "$TEST_REPO/.gitignore"
+}
+
+@test "--help mentions --no-gitignore flag" {
+  run "$BOOTSTRAP" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--no-gitignore"* ]]
+}
+
+@test "appended block normalizes spacing when prior file lacks trailing newline" {
+  # File without a final newline is a common real-world shape (e.g. printf-only
+  # or hand-edited). Bootstrap should still produce a clean separation rather
+  # than concatenating onto the last line.
+  printf 'node_modules/' > "$TEST_REPO/.gitignore"
+  run "$BOOTSTRAP" --skip-memory "$TEST_WF"
+  [ "$status" -eq 0 ]
+  # The "node_modules/" entry must remain a standalone line, not glued to "#".
+  grep -Fxq "node_modules/" "$TEST_REPO/.gitignore"
+}


### PR DESCRIPTION
## Summary

- Bootstrap appends a marker-bracketed managed block to `<repo>/.gitignore` covering `.claude/` (local-only Claude Code state), macOS junk (`.DS_Store`, `._*`, `.AppleDouble`, `.LSOverride`), and editor / IDE files (`.vscode/`, `.idea/`, `*.swp`, `*.swo`, `*~`). Idempotent on re-runs via `# claude-project-kit — managed block START` / `END` markers; creates `.gitignore` if absent; preserves prior content when appending.
- New `--no-gitignore` flag opts out for adopters who want to manage their own.
- `--dry-run` previews the change (create vs. append vs. already-managed).
- Kit-side: kit's own `.gitignore` now ignores `.claude/settings.local.json` + `.claude/worktrees/` so dogfood `git add -A` stops sweeping them up. Closes the open thread from the 2026-05-04 SESSION-LOG entry.

The kit's stance: **`.claude/` stays local to the user — never committed to the source-code repo it's being used on.** The kit's own repo is the one exception (it dogfoods `.claude/commands/` + `.claude/agents/`).

Closes #196.

## Test plan

- [x] `bats tests/bootstrap_gitignore.bats` — 12 new tests pass (create, append-preserves, idempotent, opt-out × 2, dry-run × 4, marker style, --help, no-trailing-newline edge case)
- [x] Full bats suite (293 tests) — no regressions
- [x] Manual smoke: scratch repo with no `.gitignore` → block created
- [x] Manual smoke: scratch repo with existing `node_modules/`, `*.log` → block appended, prior content preserved
- [x] Manual smoke: re-run on already-managed `.gitignore` → idempotent, "already has kit-managed block" message
- [x] Manual smoke: `--no-gitignore` → file untouched / not created
- [x] Manual smoke: `--dry-run` shows the right preview line for each of the three states (create / append / already-managed)
- [x] CI link-check (lychee offline) — watch in background

## Notes for reviewers

- The block is bracketed by em-dash (`—`) markers consistent with the rest of the kit's prose conventions.
- `bash -n bootstrap.sh` clean.
- `bootstrap.sh` is now the only place the kit writes to the target repo. `README.md`'s "No surprises" bullet was updated accordingly.