### PR TITLE
docs(demo): document GIF to MP4 conversion for social posts

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -23,6 +23,26 @@ vhs demo/bootstrap.tape
 
 Output lands at `demo/bootstrap.gif`.
 
+## Converting GIFs to MP4 for social posts
+
+GitHub's README renders animated GIFs inline natively, so the kit's `README.md` references them as-is. Most social-media composers (Threads, Bluesky, LinkedIn, etc.) **don't accept animated `.gif` uploads** — they want MP4 video for any motion content, and their file pickers filter `.gif` out at the OS level.
+
+If you're posting a launch / update thread and want the demo motion in the post itself (not just a link to the repo), convert the GIF to MP4 with `ffmpeg`:
+
+```sh
+cd demo
+ffmpeg -y -i bootstrap.gif -movflags faststart -pix_fmt yuv420p \
+  -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" bootstrap.mp4
+```
+
+The flags handle three things social platforms care about:
+
+- `-movflags faststart` — moves the video metadata to the front so the file plays without buffering.
+- `-pix_fmt yuv420p` — required pixel format for broad compatibility (Threads/Bluesky/LinkedIn all reject other formats).
+- `-vf "scale=trunc(iw/2)*2..."` — forces even dimensions, which H.264 requires (otherwise `ffmpeg` errors out).
+
+Output lands at `demo/bootstrap.mp4`. Like the GIFs, MP4 renders are git-ignored — generate locally as needed for posts.
+
 ## Why renders aren't committed
 
 `demo/*.gif` and `demo/*.mp4` are git-ignored. The kit is docs-and-templates only; binary artifacts would bloat the repo over time.


### PR DESCRIPTION
## Summary

- Adds a "Converting GIFs to MP4 for social posts" section to `demo/README.md` documenting the `ffmpeg` one-liner that converts the kit's VHS-rendered GIFs into MP4s for social-media composers.
- Captures **why** the conversion is needed (Threads / Bluesky / LinkedIn all reject `.gif` uploads at the OS file-picker level — they want MP4 for animated content) and **what each flag does** so future-me (or any forker) can re-run the conversion confidently.
- MP4 renders stay git-ignored alongside the GIFs — same convention, same rationale (kit is docs-and-templates only; binary artifacts would bloat the repo).

Surfaced from prep for the launch posts: file picker on Threads web silently filtered out the `.gif` from `demo/`, sending me down a "where's the upload button?" rabbit hole. Future-me will absolutely hit this again. Worth 20 lines of prose.

## Test plan

- [x] `demo/README.md` renders cleanly on GitHub — new section appears between "Rendering" and "Why renders aren't committed".
- [x] CI green (markdown-only change).