### PR TITLE
fix(memory): sanitize dots in auto-memory path key (closes #205)

### DIFF
--- a/.claude/agents/session-summarizer.md
+++ b/.claude/agents/session-summarizer.md
@@ -10,7 +10,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell the user:

--- a/.claude/commands/close-phase.md
+++ b/.claude/commands/close-phase.md
@@ -9,7 +9,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -16,7 +16,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/pull-ticket.md
+++ b/.claude/commands/pull-ticket.md
@@ -9,7 +9,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/refresh-context.md
+++ b/.claude/commands/refresh-context.md
@@ -8,7 +8,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -15,7 +15,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/run-acceptance.md
+++ b/.claude/commands/run-acceptance.md
@@ -9,7 +9,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/session-end.md
+++ b/.claude/commands/session-end.md
@@ -8,7 +8,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/session-handoff.md
+++ b/.claude/commands/session-handoff.md
@@ -8,7 +8,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/session-start.md
+++ b/.claude/commands/session-start.md
@@ -8,7 +8,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -744,7 +744,7 @@ if [ ! -d "$KIT_ROOT/templates" ] || [ ! -d "$KIT_ROOT/memory-templates" ]; then
   exit 1
 fi
 
-SANITIZED="$(echo "$REPO_ROOT" | sed 's|/|-|g')"
+SANITIZED="$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')"
 MEMORY_DIR="$HOME/.claude/projects/${SANITIZED}/memory"
 
 WORKSPACE_DIR=""

--- a/scripts/lib/infer.sh
+++ b/scripts/lib/infer.sh
@@ -8,7 +8,7 @@
 # Functions are pure (no side effects, no exits) so the calling script
 # decides how to handle empty returns. All return paths use absolute,
 # unresolved-symlink form to match bootstrap.sh's sanitization rule
-# (sed 's|/|-|g').
+# (sed 's|[/.]|-|g').
 #
 # Conventions:
 #   - All functions take an optional first arg (defaults to $PWD).
@@ -16,10 +16,13 @@
 #   - Functions never error / never call exit. Caller decides.
 
 # Sanitize a filesystem path the way the Claude harness keys auto-memory:
-# replace `/` with `-`. Result is the directory name under
-# ~/.claude/projects/.
+# replace `/` and `.` with `-`. Result is the directory name under
+# ~/.claude/projects/. The dot replacement matters for any user with a `.`
+# in their `$HOME` (e.g. macOS username `firstname.lastname`) or repo path
+# — without it, the kit seeds memory at one path and Claude Code's runtime
+# auto-loads from a different one.
 sanitize_path_for_memory() {
-  echo "$1" | sed 's|/|-|g'
+  echo "$1" | sed 's|[/.]|-|g'
 }
 
 # Walk up from $1 (default $PWD) to find a directory that contains .git.

--- a/templates/.claude/agents/session-summarizer.md
+++ b/templates/.claude/agents/session-summarizer.md
@@ -10,7 +10,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell the user:

--- a/templates/.claude/commands/close-phase.md
+++ b/templates/.claude/commands/close-phase.md
@@ -9,7 +9,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/plan.md
+++ b/templates/.claude/commands/plan.md
@@ -16,7 +16,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/pull-ticket.md
+++ b/templates/.claude/commands/pull-ticket.md
@@ -9,7 +9,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/refresh-context.md
+++ b/templates/.claude/commands/refresh-context.md
@@ -8,7 +8,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/research.md
+++ b/templates/.claude/commands/research.md
@@ -15,7 +15,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/run-acceptance.md
+++ b/templates/.claude/commands/run-acceptance.md
@@ -9,7 +9,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/session-end.md
+++ b/templates/.claude/commands/session-end.md
@@ -8,7 +8,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/session-handoff.md
+++ b/templates/.claude/commands/session-handoff.md
@@ -8,7 +8,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/session-start.md
+++ b/templates/.claude/commands/session-start.md
@@ -8,7 +8,7 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory/reference_ai_working_folder.md"
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -32,7 +32,7 @@ bootstrap_teardown() {
 # Echo the auto-memory path bootstrap will derive for the current TEST_REPO.
 memory_dir() {
   local sanitized
-  sanitized="$(echo "$TEST_REPO" | sed 's|/|-|g')"
+  sanitized="$(echo "$TEST_REPO" | sed 's|[/.]|-|g')"
   echo "$TEST_HOME/.claude/projects/${sanitized}/memory"
 }
 

--- a/tests/sanitize_dotted_paths.bats
+++ b/tests/sanitize_dotted_paths.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+# Regression check — auto-memory path sanitization must replace BOTH `/` and
+# `.` with `-`. Closes #205. Claude Code's runtime auto-memory normalizes
+# both characters; if the kit only replaces `/`, any user with a `.` in their
+# `$HOME` (e.g. macOS username `firstname.lastname`) or repo path gets a
+# split where bootstrap seeds memory at one directory and Claude Code's
+# runtime auto-loads `MEMORY.md` from a different one.
+
+load 'helpers'
+
+# Source the inference helper for behavioral tests.
+source "$KIT_ROOT/scripts/lib/infer.sh"
+
+# Files that embed the sanitization sed inline (slash-command prechecks +
+# session-summarizer agent + the kit's own dogfooded copies).
+KIT_COUPLED_FILES=(
+  bootstrap.sh
+  scripts/lib/infer.sh
+  tests/helpers.bash
+  tests/sync_memory.bats
+  tests/sync_templates.bats
+  templates/.claude/commands/session-start.md
+  templates/.claude/commands/session-end.md
+  templates/.claude/commands/session-handoff.md
+  templates/.claude/commands/refresh-context.md
+  templates/.claude/commands/close-phase.md
+  templates/.claude/commands/pull-ticket.md
+  templates/.claude/commands/run-acceptance.md
+  templates/.claude/commands/plan.md
+  templates/.claude/commands/research.md
+  templates/.claude/agents/session-summarizer.md
+  .claude/commands/session-start.md
+  .claude/commands/session-end.md
+  .claude/commands/session-handoff.md
+  .claude/commands/refresh-context.md
+  .claude/commands/close-phase.md
+  .claude/commands/pull-ticket.md
+  .claude/commands/run-acceptance.md
+  .claude/commands/plan.md
+  .claude/commands/research.md
+  .claude/agents/session-summarizer.md
+)
+
+@test "sanitize_path_for_memory replaces / with -" {
+  run sanitize_path_for_memory "/Users/aaroncupp/Code/myproj"
+  [ "$status" -eq 0 ]
+  [ "$output" = "-Users-aaroncupp-Code-myproj" ]
+}
+
+@test "sanitize_path_for_memory replaces . in dotted username with -" {
+  # Real-world trigger: macOS work account with a dotted username.
+  run sanitize_path_for_memory "/Users/aaron.cupp/Code/myproj"
+  [ "$status" -eq 0 ]
+  [ "$output" = "-Users-aaron-cupp-Code-myproj" ]
+}
+
+@test "sanitize_path_for_memory replaces . in repo path with -" {
+  # Less common but possible: a repo whose path includes a dot
+  # (e.g. a worktree under .claude/worktrees/).
+  run sanitize_path_for_memory "/Users/foo/Code/myproj/.claude/worktrees/abc"
+  [ "$status" -eq 0 ]
+  [ "$output" = "-Users-foo-Code-myproj--claude-worktrees-abc" ]
+}
+
+@test "infer_memory_dir produces dot-stripped path for dotted home" {
+  HOME="/Users/aaron.cupp"
+  run infer_memory_dir "/Users/aaron.cupp/Code/myproj"
+  [ "$status" -eq 0 ]
+  [ "$output" = "/Users/aaron.cupp/.claude/projects/-Users-aaron-cupp-Code-myproj/memory" ]
+}
+
+@test "no kit-tracked file uses the old slash-only sanitization" {
+  # Old buggy form: sed 's|/|-|g' — must be gone everywhere.
+  for f in "${KIT_COUPLED_FILES[@]}"; do
+    full="$KIT_ROOT/$f"
+    [ -f "$full" ]
+    if grep -qF "sed 's|/|-|g'" "$full"; then
+      echo "regression — old slash-only sanitization still present in: $f"
+      return 1
+    fi
+  done
+}
+
+@test "every sanitization site uses the dot-and-slash form" {
+  # New correct form: sed 's|[/.]|-|g' — must be present in every file
+  # that embeds the sanitization sed inline.
+  for f in "${KIT_COUPLED_FILES[@]}"; do
+    full="$KIT_ROOT/$f"
+    [ -f "$full" ]
+    if ! grep -qF "sed 's|[/.]|-|g'" "$full"; then
+      echo "missing dot-and-slash sanitization in: $f"
+      return 1
+    fi
+  done
+}

--- a/tests/sync_memory.bats
+++ b/tests/sync_memory.bats
@@ -27,7 +27,7 @@ inferred_setup() {
   git -C "$TEST_REPO" init -q
   export HOME="$TEST_HOME"
   local sanitized
-  sanitized="$(echo "$TEST_REPO" | sed 's|/|-|g')"
+  sanitized="$(echo "$TEST_REPO" | sed 's|[/.]|-|g')"
   INFERRED_MEMORY="$HOME/.claude/projects/${sanitized}/memory"
   mkdir -p "$INFERRED_MEMORY"
 }

--- a/tests/sync_templates.bats
+++ b/tests/sync_templates.bats
@@ -173,7 +173,7 @@ inferred_setup() {
   git -C "$TEST_REPO" init -q
   export HOME="$TEST_HOME"
   local sanitized
-  sanitized="$(echo "$TEST_REPO" | sed 's|/|-|g')"
+  sanitized="$(echo "$TEST_REPO" | sed 's|[/.]|-|g')"
   INFERRED_MEMORY="$HOME/.claude/projects/${sanitized}/memory"
   mkdir -p "$INFERRED_MEMORY"
   cat > "$INFERRED_MEMORY/reference_ai_working_folder.md" <<REF


### PR DESCRIPTION
## Summary

- Replace `sed 's|/|-|g'` with `sed 's|[/.]|-|g'` everywhere the kit derives the auto-memory project key (bootstrap, slash-command prechecks, session-summarizer agent, helper scripts, test harness).
- Add `tests/sanitize_dotted_paths.bats` (6 tests) locking in the new behavior + asserting no file regresses to the old slash-only form.

## Why

Claude Code's runtime auto-memory normalizes both `/` and `.` to `-`. The kit was only normalizing `/`. For any user with a `.` in their `$HOME` (e.g. macOS username `firstname.lastname`) or repo path, bootstrap seeded memory at one directory and Claude Code's runtime auto-loaded `MEMORY.md` from a different one — so kit-seeded conventions, references, and feedback rules never reached the session reminder.

Empirical proof in any existing `~/.claude/projects/` listing: worktrees under `.claude/worktrees/` show up with a `--` (double hyphen) where the `.` of `.claude` was replaced. The kit's old sed left that `.` literal — different path.

Same fragility shape as #193/#194: invisible to the maintainer's dogfood (no dot in my username), surfaced on first dotted-username adopter run.

## Adopter migration

Auto-memory is keyed **per repo**, not per workspace — `MEMORY_DIR` is derived from `REPO_ROOT` at [bootstrap.sh:747-748](https://github.com/IamMrCupp/claude-project-kit/blob/main/bootstrap.sh#L747-L748) regardless of mode. So the migration is the same shape in single-repo and workspace modes; in workspace mode you just have one stale dir per repo in the workspace.

### 1. List candidates

```bash
ls -d ~/.claude/projects/-Users-*-Code-* 2>/dev/null
```

You're affected if you see two dirs per repo — one with a literal `.` in the username segment (the stale, kit-seeded one) and one with a `-` in its place (the active one Claude Code's runtime uses).

### 2. Merge each pair

`mv src/* dst/` does **not** work here — `mv` can't merge a non-empty `memory/` directory into an existing one. Use `rsync` instead. For each affected repo, replace `<repo>` and the dotted/dotless username segments with your actual values:

```bash
SRC=~/.claude/projects/-Users-firstname.lastname-Code-<repo>
DST=~/.claude/projects/-Users-firstname-lastname-Code-<repo>

rsync -a "$SRC/memory/" "$DST/memory/" && rm -rf "$SRC"
```

What this does:

- `rsync -a src/memory/ dst/memory/` (note the trailing slashes) merges contents into the existing `memory/`, overwriting same-named files. The kit-seeded `MEMORY.md` wins over the slim runtime-created one — which is what you want.
- Only `memory/` is touched. The dot-stripped parent contains Claude Code's session jsonl transcripts; leaving that alone preserves session history. The dot-preserved parent has nothing but `memory/`, so `rm -rf` on it is safe.

### 3. Sanity check

```bash
ls ~/.claude/projects/-Users-firstname-lastname-Code-<repo>/memory/
# should now show MEMORY.md + your seeded rule files
```

After this fix lands and you upgrade, future bootstraps and `/session-start` prechecks will use the dot-stripped path directly — no further surgery needed.

## Test plan

- [x] `bats tests/sanitize_dotted_paths.bats` — all 6 new tests pass
- [x] `bats tests/` — full suite green (302 tests)
- [x] `grep -rn "sed 's|/|-|g'"` returns 0 hits in tracked files
- [x] `grep -rn "sed 's|\[/\.\]|-|g'"` returns 25 hits across the expected files
- [x] CI link-check + bats workflows green on push
- [ ] Adopter confirmation on the affected work machine (pending — Aaron, both single-repo and workspace cases if applicable)

Closes #205