### PR TITLE
feat(commands): add /session-verify for post-session-start verification

### DIFF
--- a/.claude/commands/session-verify.md
+++ b/.claude/commands/session-verify.md
@@ -1,0 +1,80 @@
+---
+description: Dump every kit-loaded resource — auto-memory dir, MEMORY.md disk-vs-runtime parity, working-folder files, workspace files — as a verification table. Use after `/session-start` (or when you suspect auto-memory is loading from the wrong path).
+---
+
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
+   > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
+This command runs a **verification dump** — it confirms what the kit has actually loaded for this session vs. what it should have loaded. The point is to catch silent drift (e.g. the v0.39.x dot-sanitization bug, where the runtime auto-loaded `MEMORY.md` from a path that didn't match the precheck's resolved path).
+
+Read-only. No writebacks, no fixes — just report what you find.
+
+## Step 1 — resolve the auto-memory directory
+
+Run this Bash command to print the absolute path of the auto-memory directory the precheck resolves to, plus a directory listing:
+
+```bash
+MEM_DIR="$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory"
+echo "$MEM_DIR"
+ls -1 "$MEM_DIR" 2>/dev/null || echo "(directory does not exist)"
+```
+
+## Step 2 — compare on-disk MEMORY.md to runtime auto-memory
+
+The system reminder for this session contains the auto-loaded `MEMORY.md` content. Compare it to the on-disk file at `$MEM_DIR/MEMORY.md`:
+
+1. Count index entries on disk:
+   ```bash
+   grep -c '^- \[' "$MEM_DIR/MEMORY.md" 2>/dev/null || echo 0
+   ```
+2. Count index entries in the system-reminder copy (the auto-loaded `MEMORY.md` you can already see in context).
+3. List the first 3 entry titles from each side. If they don't match, flag it.
+
+**Mismatch signal:** if the two counts differ, or the titles differ, the runtime is auto-loading from a different path than the precheck resolves to. That's the bug shape #205 fixed; it can also surface from a stale `~/.claude/projects/` directory left over from before the fix landed.
+
+## Step 3 — working-folder files
+
+From `reference_ai_working_folder.md` (already loaded above), extract the working-folder path. Then for each of these files, report absolute path + line count + a single signal line:
+
+- `<working-folder>/CONTEXT.md` — signal = the `**Last updated:**` line if present
+- `<working-folder>/SESSION-LOG.md` — signal = the date of the most recent `## Session:` heading
+- The current phase checklist (e.g. `<working-folder>/phase-N-checklist.md` — find via `CONTEXT.md`'s "Current Phase Status" or list all matching files) — signal = phase number + status
+
+Use `wc -l` and `grep` / `head` for the signal lines. Do not re-load the files into context — you only need their metadata for the dump.
+
+## Step 4 — workspace mode (only if applicable)
+
+If `<working-folder>/../workspace-CONTEXT.md` exists, also report:
+- `workspace-CONTEXT.md` — abs path, line count
+- `workspace-plan.md` (if present) — abs path, line count
+- `workspace-phase-N-checklist.md` (if present) — abs path, line count
+
+Skip this step entirely if not in workspace mode.
+
+## Hand back
+
+A single markdown table — one row per resource:
+
+| Resource | Path | Lines | Signal |
+
+Followed by a one-line verdict on the next line:
+
+- **OK** — disk MEMORY.md matches runtime auto-memory, all expected files present.
+- **MISMATCH** — disk MEMORY.md and runtime auto-memory differ; quote the specific signal (e.g. "disk has 22 entries, runtime has 4").
+- **MISSING** — one or more expected files not found at their resolved paths.
+
+Don't propose fixes. If MISMATCH or MISSING fires, tell me which one and let me decide next steps.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -251,9 +251,10 @@ These are **starters**. Edit the frontmatter (model, tool allowlist), customize 
 
 ## Starter slash commands
 
-Nine slash commands stage in `<working-folder>/.claude/commands/`. Same install path as agents — `scripts/install-commands.sh --global` (recommended, covers every project) or `--project <repo-path>` (scope to one repo).
+Ten slash commands stage in `<working-folder>/.claude/commands/`. Same install path as agents — `scripts/install-commands.sh --global` (recommended, covers every project) or `--project <repo-path>` (scope to one repo).
 
 - **`/session-start`** — packages Prompt 1 from `PROMPTS.md`. Loads `CONTEXT.md`, `SESSION-LOG.md`, and the current phase checklist; hands back a 3–5 bullet grounding summary. Use at the start of a fresh session.
+- **`/session-verify`** — packages Prompt 13 from `PROMPTS.md`. Dumps every kit-loaded resource — auto-memory dir path, MEMORY.md disk-vs-runtime parity, working-folder file metadata, workspace files — as a verification table. Use after `/session-start` (or when you suspect auto-memory is loading from the wrong path). Read-only.
 - **`/refresh-context`** — re-reads the working folder mid-session, after a `/close-phase` or `/session-end` writeback or when a long session has drifted. Hands back a delta read against the latest state.
 - **`/close-phase`** — packages Prompt 7 from `PROMPTS.md`. Runs the phase-close writeback (checklist tick, `plan.md` status bump, `CONTEXT.md` update, acceptance-results archive). Refuses to close without a non-empty `acceptance-test-results.md` or an explicit skip-rationale line — see [`CONVENTIONS.md`](CONVENTIONS.md) → "Acceptance tests at phase boundaries". Takes a phase number or infers from `CONTEXT.md`.
 - **`/session-end`** — packages Prompt 3 from `PROMPTS.md`. Drafts the four end-of-session updates (SESSION-LOG entry, CONTEXT bump, checklist scan, memory candidates) and waits for confirmation before writing.

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -599,6 +599,38 @@ Don't `git commit` — the user reviews the checklist diff and commits separatel
 
 ---
 
+## 13. Verifying session-start loaded the right context
+
+Use this after `/session-start` (or any time you suspect drift between the runtime auto-memory and the kit's seeded state) to dump every kit-loaded resource as a verification table. Pure read-only — no fixes proposed.
+
+The paired slash command is `/session-verify`. The full prompt:
+
+```
+Verification dump — list every file you read or referenced during /session-start. For each, report on one line:
+- absolute path
+- line count (run `wc -l` if needed)
+- first heading or signal line
+
+Also report, separately:
+- the resolved auto-memory dir path, derived the same way the precheck does:
+    `$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory`
+- whether the on-disk MEMORY.md at that path matches the auto-loaded MEMORY.md you see in the system reminder (compare the index entry count and a couple of sample bullet titles)
+- the count of `- [...]` index entries currently in MEMORY.md
+
+In workspace mode, include any workspace-level files (workspace-CONTEXT.md, workspace-plan.md, workspace-phase-N-checklist.md).
+
+Output as a single markdown table. End with a one-line verdict:
+- OK — disk MEMORY.md matches runtime auto-memory, all expected files present
+- MISMATCH — quote the diff signal (e.g. "disk has 22 entries, runtime has 4")
+- MISSING — one or more expected files not found
+
+Don't propose fixes.
+```
+
+The MISMATCH verdict is the smoking gun for the v0.39.x dot-sanitization bug — the runtime auto-loads `MEMORY.md` from a different path than the precheck resolves to, so the on-disk file (kit-seeded, full) and the system-reminder copy (slim, runtime-created) diverge.
+
+---
+
 ## When to write a new prompt
 
 Add one here whenever you find yourself typing similar setup instructions into a fresh session for the third time. A good prompt is:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ That kicks off interactive mode: it asks for the working-folder path, project na
 - **Phase-based planning docs** — `plan.md` + per-phase checklist + `implementation.md` give Claude scoped, numbered tasks instead of a wall of intent.
 - **SEED-PROMPT auto-fill** — point Claude at one file and it deep-reads your repo, fills `CONTEXT.md`, drafts `research.md`, flags inferences, and stops for your review.
 - **Starter agents** — `code-reviewer` (universal) and `session-summarizer` (kit-aware), staged in the working folder; copy into your repo to activate.
-- **Starter slash commands** — `/session-start`, `/refresh-context`, `/close-phase`, `/session-end`, `/session-handoff`, `/pull-ticket`, `/run-acceptance`, `/research`, `/plan`. Install once globally with `scripts/install-commands.sh --global` (recommended) or per-repo with `--project <path>`.
+- **Starter slash commands** — `/session-start`, `/session-verify`, `/refresh-context`, `/close-phase`, `/session-end`, `/session-handoff`, `/pull-ticket`, `/run-acceptance`, `/research`, `/plan`. Install once globally with `scripts/install-commands.sh --global` (recommended) or per-repo with `--project <path>`.
 - **Managed `.gitignore` block** — bootstrap appends a marker-bracketed block to `<repo>/.gitignore` covering `.claude/` (local-only Claude Code state), macOS junk (`.DS_Store` etc.), and editor / IDE files (`.vscode/`, `.idea/`, `*.swp`, ...). Idempotent on re-runs; opt out with `--no-gitignore`. Kit's stance: `.claude/` stays local to the user, never committed.
 - **Upgrade helpers** — `scripts/sync-memory.sh`, `scripts/sync-templates.sh`, and `scripts/rename-workspace.sh` keep auto-memory, working-folder templates, and workspace paths in sync with the latest kit release without overwriting your filled-in content. See [SETUP.md §Upgrading](SETUP.md#upgrading-an-existing-project).
 - **Worked examples** — `examples/widget-tracker/` (fictional Go CLI, single-repo, mid-Phase 1) and `examples/acme-platform/` (fictional Terraform multi-repo workspace, JIRA-driven, **long-running with multiple initiatives** — one completed, one active — plus `workspace-plan.md`, `workspace-phase-N-checklist.md`, and active + archived ticket scratchpads).
@@ -87,7 +87,7 @@ See [FEATURES.md](FEATURES.md) for one-paragraph-per-feature detail with example
 
 ## What this is / isn't
 
-- **Is:** a workflow scaffold layered on top of Claude Code — templates, memory starters, conventions, two starter agents, six starter slash commands.
+- **Is:** a workflow scaffold layered on top of Claude Code — templates, memory starters, conventions, two starter agents, ten starter slash commands.
 - **Isn't:** a Claude Code plugin, a replacement for `CLAUDE.md`, or a project tracker. It complements all three.
 
 ## Why this works
@@ -173,7 +173,7 @@ Works the same for greenfield repos and ones you're adopting it on mid-stream �
 │   │   └── ticket.md              ← per-ticket scratchpad shape
 │   └── .claude/             ← starter agents + slash commands (staged in WF)
 │       ├── agents/          ← code-reviewer, session-summarizer
-│       ├── commands/        ← /session-start, /refresh-context, /close-phase, /session-end, /session-handoff, /pull-ticket, /run-acceptance, /research, /plan
+│       ├── commands/        ← /session-start, /session-verify, /refresh-context, /close-phase, /session-end, /session-handoff, /pull-ticket, /run-acceptance, /research, /plan
 │       └── README.md        ← how to copy into your target repo
 ├── examples/                ← filled-in reference — read, don't copy
 │   ├── widget-tracker/      ← fictional Go CLI, single-repo, mid-Phase-1 snapshot

--- a/templates/.claude/commands/session-verify.md
+++ b/templates/.claude/commands/session-verify.md
@@ -1,0 +1,80 @@
+---
+description: Dump every kit-loaded resource — auto-memory dir, MEMORY.md disk-vs-runtime parity, working-folder files, workspace files — as a verification table. Use after `/session-start` (or when you suspect auto-memory is loading from the wrong path).
+---
+
+## Precheck — is this a kit project?
+
+Before doing anything else:
+
+1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
+   ```bash
+   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   ```
+   Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
+2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
+   > "No kit working folder found for this project. To use this command, either run `bootstrap.sh` from the kit (https://github.com/IamMrCupp/claude-project-kit) to create one, or `cd` into a kit-bootstrapped repo. If a working folder exists at a non-default path, tell me and I'll load from there."
+3. Don't load partial state. If any required file is missing, treat the project as not-bootstrapped and bail with the message above.
+
+If the precheck passes, continue.
+
+---
+
+This command runs a **verification dump** — it confirms what the kit has actually loaded for this session vs. what it should have loaded. The point is to catch silent drift (e.g. the v0.39.x dot-sanitization bug, where the runtime auto-loaded `MEMORY.md` from a path that didn't match the precheck's resolved path).
+
+Read-only. No writebacks, no fixes — just report what you find.
+
+## Step 1 — resolve the auto-memory directory
+
+Run this Bash command to print the absolute path of the auto-memory directory the precheck resolves to, plus a directory listing:
+
+```bash
+MEM_DIR="$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory"
+echo "$MEM_DIR"
+ls -1 "$MEM_DIR" 2>/dev/null || echo "(directory does not exist)"
+```
+
+## Step 2 — compare on-disk MEMORY.md to runtime auto-memory
+
+The system reminder for this session contains the auto-loaded `MEMORY.md` content. Compare it to the on-disk file at `$MEM_DIR/MEMORY.md`:
+
+1. Count index entries on disk:
+   ```bash
+   grep -c '^- \[' "$MEM_DIR/MEMORY.md" 2>/dev/null || echo 0
+   ```
+2. Count index entries in the system-reminder copy (the auto-loaded `MEMORY.md` you can already see in context).
+3. List the first 3 entry titles from each side. If they don't match, flag it.
+
+**Mismatch signal:** if the two counts differ, or the titles differ, the runtime is auto-loading from a different path than the precheck resolves to. That's the bug shape #205 fixed; it can also surface from a stale `~/.claude/projects/` directory left over from before the fix landed.
+
+## Step 3 — working-folder files
+
+From `reference_ai_working_folder.md` (already loaded above), extract the working-folder path. Then for each of these files, report absolute path + line count + a single signal line:
+
+- `<working-folder>/CONTEXT.md` — signal = the `**Last updated:**` line if present
+- `<working-folder>/SESSION-LOG.md` — signal = the date of the most recent `## Session:` heading
+- The current phase checklist (e.g. `<working-folder>/phase-N-checklist.md` — find via `CONTEXT.md`'s "Current Phase Status" or list all matching files) — signal = phase number + status
+
+Use `wc -l` and `grep` / `head` for the signal lines. Do not re-load the files into context — you only need their metadata for the dump.
+
+## Step 4 — workspace mode (only if applicable)
+
+If `<working-folder>/../workspace-CONTEXT.md` exists, also report:
+- `workspace-CONTEXT.md` — abs path, line count
+- `workspace-plan.md` (if present) — abs path, line count
+- `workspace-phase-N-checklist.md` (if present) — abs path, line count
+
+Skip this step entirely if not in workspace mode.
+
+## Hand back
+
+A single markdown table — one row per resource:
+
+| Resource | Path | Lines | Signal |
+
+Followed by a one-line verdict on the next line:
+
+- **OK** — disk MEMORY.md matches runtime auto-memory, all expected files present.
+- **MISMATCH** — disk MEMORY.md and runtime auto-memory differ; quote the specific signal (e.g. "disk has 22 entries, runtime has 4").
+- **MISSING** — one or more expected files not found at their resolved paths.
+
+Don't propose fixes. If MISMATCH or MISSING fires, tell me which one and let me decide next steps.

--- a/tests/precheck_in_commands.bats
+++ b/tests/precheck_in_commands.bats
@@ -12,6 +12,7 @@ KIT_COUPLED_COMMANDS=(
   templates/.claude/commands/session-start.md
   templates/.claude/commands/session-end.md
   templates/.claude/commands/session-handoff.md
+  templates/.claude/commands/session-verify.md
   templates/.claude/commands/refresh-context.md
   templates/.claude/commands/close-phase.md
   templates/.claude/commands/pull-ticket.md

--- a/tests/sanitize_dotted_paths.bats
+++ b/tests/sanitize_dotted_paths.bats
@@ -22,6 +22,7 @@ KIT_COUPLED_FILES=(
   templates/.claude/commands/session-start.md
   templates/.claude/commands/session-end.md
   templates/.claude/commands/session-handoff.md
+  templates/.claude/commands/session-verify.md
   templates/.claude/commands/refresh-context.md
   templates/.claude/commands/close-phase.md
   templates/.claude/commands/pull-ticket.md
@@ -32,6 +33,7 @@ KIT_COUPLED_FILES=(
   .claude/commands/session-start.md
   .claude/commands/session-end.md
   .claude/commands/session-handoff.md
+  .claude/commands/session-verify.md
   .claude/commands/refresh-context.md
   .claude/commands/close-phase.md
   .claude/commands/pull-ticket.md


### PR DESCRIPTION
> **Stacked on [#206](https://github.com/IamMrCupp/claude-project-kit/pull/206).** Base = `fix/sanitize-dots-in-project-path`. Once #206 merges, GitHub auto-retargets this PR to `main` and the diff cleans up.

## Summary

- New `templates/.claude/commands/session-verify.md` slash command (+ dogfooded copy in `.claude/commands/`).
- Read-only verification dump: auto-memory dir path, on-disk vs runtime `MEMORY.md` parity check, working-folder file metadata, workspace files if applicable. One markdown table + a one-line verdict (`OK` / `MISMATCH` / `MISSING`).
- Extends `precheck_in_commands.bats` and `sanitize_dotted_paths.bats` (#206's regression file) to cover the new command.
- README + FEATURES front-door updates (slash-command list, count bump 9 → 10; also fixes a pre-existing "six starter slash commands" drift in README).
- New `## 13. Verifying session-start loaded the right context` section in PROMPTS.md, mirroring the existing slash-command ↔ Prompt pairing pattern.

`scripts/install-commands.sh` auto-discovers slash commands from a glob, so no changes there — adopters who run `upgrade.sh` (or `install-commands.sh`) post-merge get `/session-verify` for free.

## Why

Surfaced during the #205 dogfood investigation. When the runtime auto-memory and the kit's precheck resolve to different paths, symptoms are subtle — the session loads a different (often slim) `MEMORY.md` than the kit seeded, and Claude appears to start cleanly. A read-only verification command turns "is my context right?" into a one-line check the user can issue any time.

The smoking gun for the dot-sanitization bug specifically is the disk-vs-runtime `MEMORY.md` index entry count mismatch — the command surfaces that automatically.

## Test plan

- [x] `bats tests/` — full suite green (302/302 — extending arrays in existing tests doesn't add test count, but loops now cover the new file)
- [x] `diff -r templates/.claude/commands .claude/commands` — dogfood in sync
- [x] Manual sanity-read of `templates/.claude/commands/session-verify.md` — precheck block present, sed sanitization uses `[/.]|-|g` (post-#206 form)
- [ ] CI link-check + bats green on push (watching)
- [ ] Adopter use on the work machine (post-merge of both PRs + `upgrade.sh`)

Closes #207