### PR TITLE
fix(precheck): walk up from worktree to parent repo before sanitizing path

### DIFF
--- a/.claude/agents/session-summarizer.md
+++ b/.claude/agents/session-summarizer.md
@@ -10,7 +10,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell the user:

--- a/.claude/commands/close-phase.md
+++ b/.claude/commands/close-phase.md
@@ -9,7 +9,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -16,7 +16,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/pull-ticket.md
+++ b/.claude/commands/pull-ticket.md
@@ -9,7 +9,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/refresh-context.md
+++ b/.claude/commands/refresh-context.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -15,7 +15,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/run-acceptance.md
+++ b/.claude/commands/run-acceptance.md
@@ -9,7 +9,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/session-end.md
+++ b/.claude/commands/session-end.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/session-handoff.md
+++ b/.claude/commands/session-handoff.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/session-start.md
+++ b/.claude/commands/session-start.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/session-verify.md
+++ b/.claude/commands/session-verify.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
@@ -28,10 +29,13 @@ Read-only. No writebacks, no fixes — just report what you find.
 Run this Bash command to print the absolute path of the auto-memory directory the precheck resolves to, plus a directory listing:
 
 ```bash
-MEM_DIR="$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory"
+REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+MEM_DIR="$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory"
 echo "$MEM_DIR"
 ls -1 "$MEM_DIR" 2>/dev/null || echo "(directory does not exist)"
 ```
+
+The `git rev-parse` step makes the resolution worktree-aware: from inside a `git worktree`, it walks up to the parent repo's `.git` directory before sanitizing, matching where bootstrap seeded auto-memory.
 
 ## Step 2 — compare on-disk MEMORY.md to runtime auto-memory
 

--- a/templates/.claude/agents/session-summarizer.md
+++ b/templates/.claude/agents/session-summarizer.md
@@ -10,7 +10,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell the user:

--- a/templates/.claude/commands/close-phase.md
+++ b/templates/.claude/commands/close-phase.md
@@ -9,7 +9,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/plan.md
+++ b/templates/.claude/commands/plan.md
@@ -16,7 +16,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/pull-ticket.md
+++ b/templates/.claude/commands/pull-ticket.md
@@ -9,7 +9,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/refresh-context.md
+++ b/templates/.claude/commands/refresh-context.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/research.md
+++ b/templates/.claude/commands/research.md
@@ -15,7 +15,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/run-acceptance.md
+++ b/templates/.claude/commands/run-acceptance.md
@@ -9,7 +9,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/session-end.md
+++ b/templates/.claude/commands/session-end.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/session-handoff.md
+++ b/templates/.claude/commands/session-handoff.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/session-start.md
+++ b/templates/.claude/commands/session-start.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/session-verify.md
+++ b/templates/.claude/commands/session-verify.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
@@ -28,10 +29,13 @@ Read-only. No writebacks, no fixes — just report what you find.
 Run this Bash command to print the absolute path of the auto-memory directory the precheck resolves to, plus a directory listing:
 
 ```bash
-MEM_DIR="$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory"
+REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+MEM_DIR="$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory"
 echo "$MEM_DIR"
 ls -1 "$MEM_DIR" 2>/dev/null || echo "(directory does not exist)"
 ```
+
+The `git rev-parse` step makes the resolution worktree-aware: from inside a `git worktree`, it walks up to the parent repo's `.git` directory before sanitizing, matching where bootstrap seeded auto-memory.
 
 ## Step 2 — compare on-disk MEMORY.md to runtime auto-memory
 

--- a/tests/precheck_in_commands.bats
+++ b/tests/precheck_in_commands.bats
@@ -117,6 +117,51 @@ KIT_COUPLED_AGENTS=(
   done
 }
 
+# Regression guard for #210 — precheck must walk up from worktree to parent
+# repo before sanitizing. Sanitizing $PWD directly produces a key that
+# includes the worktree subdir name, but bootstrap only ever seeded auto-
+# memory at the parent repo's path. Claude Code's runtime walks up; the
+# precheck must too. Use `git rev-parse --git-common-dir` (returns the
+# parent repo's .git for both regular and worktree sessions) → `dirname`
+# → sanitize. Falls back to $PWD outside a git repo.
+@test "every kit-coupled command Precheck is worktree-aware (uses git rev-parse)" {
+  for cmd in "${KIT_COUPLED_COMMANDS[@]}"; do
+    f="$KIT_ROOT/$cmd"
+    if ! grep -q 'git rev-parse --path-format=absolute --git-common-dir' "$f"; then
+      echo "missing worktree-aware git rev-parse in: $cmd"
+      return 1
+    fi
+    # Must sanitize REPO_ROOT (worktree-resolved), not raw $PWD.
+    if ! grep -q 'echo "\$REPO_ROOT" | sed' "$f"; then
+      echo "must sanitize \$REPO_ROOT (not raw \$PWD): $cmd"
+      return 1
+    fi
+    # The old raw-PWD sanitization must be gone.
+    if grep -q 'echo "\$PWD" | sed' "$f"; then
+      echo "regression — old raw-\$PWD sanitization still present in: $cmd"
+      return 1
+    fi
+  done
+}
+
+@test "every kit-coupled agent Precheck is worktree-aware (uses git rev-parse)" {
+  for agent in "${KIT_COUPLED_AGENTS[@]}"; do
+    f="$KIT_ROOT/$agent"
+    if ! grep -q 'git rev-parse --path-format=absolute --git-common-dir' "$f"; then
+      echo "missing worktree-aware git rev-parse in: $agent"
+      return 1
+    fi
+    if ! grep -q 'echo "\$REPO_ROOT" | sed' "$f"; then
+      echo "must sanitize \$REPO_ROOT (not raw \$PWD): $agent"
+      return 1
+    fi
+    if grep -q 'echo "\$PWD" | sed' "$f"; then
+      echo "regression — old raw-\$PWD sanitization still present in: $agent"
+      return 1
+    fi
+  done
+}
+
 @test "code-reviewer agent does NOT include the kit Precheck (universal agent)" {
   f="$KIT_ROOT/templates/.claude/agents/code-reviewer.md"
   [ -f "$f" ]

--- a/tests/precheck_worktree_handling.bats
+++ b/tests/precheck_worktree_handling.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+# Behavioral check — the worktree-aware precheck Bash (extracted from
+# session-start.md) must resolve to the parent repo's auto-memory path
+# regardless of whether the session is running in the main worktree, a
+# linked worktree under <repo>/.claude/worktrees/, or a linked worktree
+# elsewhere on disk. Closes #210.
+#
+# This test runs the actual Bash one-liner the precheck instructs Claude
+# to execute, against real `git worktree add`-created worktrees.
+
+load 'helpers'
+
+setup() {
+  # macOS resolves /var/folders/... -> /private/var/folders/... via symlink.
+  # `git rev-parse` returns the resolved path, so we need TEST_TMP to be the
+  # resolved form for string comparisons to work.
+  TEST_TMP="$(cd "$(mktemp -d)" && pwd -P)"
+  TEST_HOME="$TEST_TMP/home"
+  PARENT_REPO="$TEST_TMP/parent-repo"
+  mkdir -p "$TEST_HOME" "$PARENT_REPO"
+  export HOME="$TEST_HOME"
+
+  git -C "$PARENT_REPO" init -q
+  git -C "$PARENT_REPO" -c user.email=t@t.t -c user.name=t commit \
+    --allow-empty -m "init" -q
+}
+
+teardown() {
+  [ -n "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"
+}
+
+# Run the precheck Bash from inside $1 and echo the resolved memory pointer
+# path. Mirrors the snippet embedded in every kit-coupled slash command.
+run_precheck_in() {
+  local cwd="$1"
+  ( cd "$cwd" && \
+    REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) \
+      && REPO_ROOT=$(dirname "$REPO_ROOT") \
+      || REPO_ROOT="$PWD"
+    echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+  )
+}
+
+@test "precheck inside the main worktree resolves to the parent repo's memory path" {
+  expected="$HOME/.claude/projects/$(echo "$PARENT_REPO" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+  run run_precheck_in "$PARENT_REPO"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+@test "precheck inside a nested .claude/worktrees/ worktree resolves to the parent repo's memory path" {
+  # Worktree under <parent>/.claude/worktrees/<name> — the kit's own chip
+  # mechanism creates worktrees here.
+  WT="$PARENT_REPO/.claude/worktrees/feature-x"
+  mkdir -p "$(dirname "$WT")"
+  git -C "$PARENT_REPO" worktree add -q "$WT" 2>/dev/null
+
+  expected="$HOME/.claude/projects/$(echo "$PARENT_REPO" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+  run run_precheck_in "$WT"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+@test "precheck inside a worktree elsewhere on disk resolves to the parent repo's memory path" {
+  # Worktree at an arbitrary location, not nested under the parent repo.
+  WT="$TEST_TMP/detached-worktree"
+  git -C "$PARENT_REPO" worktree add -q "$WT" 2>/dev/null
+
+  expected="$HOME/.claude/projects/$(echo "$PARENT_REPO" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+  run run_precheck_in "$WT"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+@test "precheck outside any git repo falls back to PWD" {
+  # No git repo — should sanitize PWD itself.
+  NON_GIT="$TEST_TMP/not-a-repo"
+  mkdir -p "$NON_GIT"
+
+  expected="$HOME/.claude/projects/$(echo "$NON_GIT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+  run run_precheck_in "$NON_GIT"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+@test "precheck handles dotted username + worktree (combined #205 + #210 case)" {
+  # Real-world case that surfaced #210: Aaron's `aaron.cupp` work account
+  # plus a chip-spawned worktree. The dot in the username must still be
+  # sanitized (#205), and the worktree must still walk up (#210).
+  DOTTED="$TEST_TMP/Users/aaron.cupp/Code/myrepo"
+  mkdir -p "$DOTTED"
+  git -C "$DOTTED" init -q
+  git -C "$DOTTED" -c user.email=t@t.t -c user.name=t commit \
+    --allow-empty -m "init" -q
+
+  WT="$DOTTED/.claude/worktrees/feature-y"
+  mkdir -p "$(dirname "$WT")"
+  git -C "$DOTTED" worktree add -q "$WT" 2>/dev/null
+
+  expected="$HOME/.claude/projects/$(echo "$DOTTED" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+  run run_precheck_in "$WT"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+  # Sanity check: the resolved path must NOT contain the worktree subdir name
+  # (i.e. the precheck successfully walked up before sanitizing).
+  [[ "$output" != *"feature-y"* ]]
+  # And the dot in `aaron.cupp` must have become a `-`.
+  [[ "$output" == *"aaron-cupp"* ]]
+  [[ "$output" != *"aaron.cupp"* ]]
+}


### PR DESCRIPTION
> **Stacked on [#208](https://github.com/IamMrCupp/claude-project-kit/pull/208).** Base = `feat/session-verify-slash-command`. Once #208 merges, GitHub auto-retargets this PR to `main` and CI re-runs against the clean diff.

## Summary

- All 10 slash commands + the session-summarizer agent (× 2 — both `templates/.claude/` and dogfooded `.claude/`) now resolve the auto-memory key from the **parent repo** rather than `$PWD`. From inside a `git worktree`, `git rev-parse --path-format=absolute --git-common-dir` returns the parent repo's `.git` for both regular and worktree sessions; `dirname` + sanitize gives the right key.
- New behavioral test file `tests/precheck_worktree_handling.bats` (5 tests) extracts the precheck Bash and runs it inside real `git worktree add`-created worktrees: nested under `<repo>/.claude/worktrees/`, detached elsewhere on disk, plus a combined "dotted username + worktree" case (the exact shape that surfaced this).
- New regression assertions in `precheck_in_commands.bats`: every kit-coupled command and agent must include `git rev-parse --path-format=absolute --git-common-dir`, must sanitize `$REPO_ROOT` (not raw `$PWD`), and must not contain the old raw-PWD form.

## Why

Surfaced today via `/session-verify` (#208) running inside a worktree at `<repo>/.claude/worktrees/<chip-name>`. The verify command reported MISMATCH:

- precheck path: `~/.claude/projects/-Users-<user>-Code-<repo>--claude-worktrees-<chip>/memory` → does not exist
- runtime auto-load path: `~/.claude/projects/-Users-<user>-Code-<repo>/memory` → exists, full content

Disk and runtime MEMORY.md actually matched (same 17 entries, same first 3 titles). The mismatch was purely in the precheck's path resolution. Claude Code's runtime walks up from the worktree to the parent repo before keying auto-memory; the kit's inline-Bash prechecks didn't.

This is **not** a regression of #205/#206 — that fix is in. This is a separate, longer-standing bug that v0.39.2 just made more visible because the dotted-username case is finally working end-to-end. Same fragility shape as #193/#204/#205: invisible to the maintainer's standard dogfood, surfaces on a common adopter usage pattern (chip-spawned worktrees, manual worktrees, etc.).

## Worktree resolution

The new precheck Bash:

```bash
REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
```

`git rev-parse --git-common-dir` returns the **main** worktree's `.git` for both:
- Main worktree session — returns `<repo>/.git`
- Linked worktree session (anywhere on disk) — returns `<repo>/.git`, NOT the worktree's `<wt>/.git` file

`dirname` → parent repo path. Sanitize → matches what bootstrap seeded.

`--path-format=absolute` requires Git 2.31+ (March 2021 — five years old, safe to require).

## What's NOT changed

- `bootstrap.sh` — takes `REPO_ROOT` explicitly from arg or `$PWD`. If a user runs `bootstrap.sh` from inside a worktree, today's behavior keys memory off the worktree path. Worth fixing in a follow-up but out of scope here — adopters typically run bootstrap from the main checkout, not a worktree.
- `scripts/lib/infer.sh::find_repo_root()` — already walks up correctly for nested worktrees (it looks for a `.git` *directory*, which skips the worktree's `.git` *file* and finds the parent's). Detached worktrees (worktree dir not nested under parent) would still break this helper, but that's also out of scope here.

## No data migration

Unlike #205, this fix doesn't require any user-side migration. The on-disk auto-memory is already in the right place; the precheck was just looking in the wrong place. Upgrade and the precheck fix takes effect.

## Test plan

- [x] `bats tests/precheck_worktree_handling.bats` — 5/5 green (main, nested worktree, detached worktree, non-git-repo fallback, dotted-username + worktree)
- [x] `bats tests/precheck_in_commands.bats` — 9/9 green (existing 7 + 2 new worktree-aware assertions)
- [x] `bats tests/` — full suite 309/309 (was 302; +5 worktree-handling, +2 worktree-aware regression)
- [x] `diff -r templates/.claude/commands .claude/commands` — dogfood in sync
- [x] CI link-check + bats workflows green on push (watching)
- [x] Adopter confirmation on the work-machine worktree (Aaron — re-run `/session-verify` after upgrade)

Closes #210