### PR TITLE
fix(precheck): walk up from worktree to parent repo before sanitizing path

### DIFF
--- a/.claude/agents/session-summarizer.md
+++ b/.claude/agents/session-summarizer.md
@@ -10,7 +10,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell the user:

--- a/.claude/commands/close-phase.md
+++ b/.claude/commands/close-phase.md
@@ -9,7 +9,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -16,7 +16,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/pull-ticket.md
+++ b/.claude/commands/pull-ticket.md
@@ -9,7 +9,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/refresh-context.md
+++ b/.claude/commands/refresh-context.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -15,7 +15,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/run-acceptance.md
+++ b/.claude/commands/run-acceptance.md
@@ -9,7 +9,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/session-end.md
+++ b/.claude/commands/session-end.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/session-handoff.md
+++ b/.claude/commands/session-handoff.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/session-start.md
+++ b/.claude/commands/session-start.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/.claude/commands/session-verify.md
+++ b/.claude/commands/session-verify.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
@@ -28,10 +29,13 @@ Read-only. No writebacks, no fixes — just report what you find.
 Run this Bash command to print the absolute path of the auto-memory directory the precheck resolves to, plus a directory listing:
 
 ```bash
-MEM_DIR="$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory"
+REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+MEM_DIR="$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory"
 echo "$MEM_DIR"
 ls -1 "$MEM_DIR" 2>/dev/null || echo "(directory does not exist)"
 ```
+
+The `git rev-parse` step makes the resolution worktree-aware: from inside a `git worktree`, it walks up to the parent repo's `.git` directory before sanitizing, matching where bootstrap seeded auto-memory.
 
 ## Step 2 — compare on-disk MEMORY.md to runtime auto-memory
 

--- a/templates/.claude/agents/session-summarizer.md
+++ b/templates/.claude/agents/session-summarizer.md
@@ -10,7 +10,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell the user:

--- a/templates/.claude/commands/close-phase.md
+++ b/templates/.claude/commands/close-phase.md
@@ -9,7 +9,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/plan.md
+++ b/templates/.claude/commands/plan.md
@@ -16,7 +16,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/pull-ticket.md
+++ b/templates/.claude/commands/pull-ticket.md
@@ -9,7 +9,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/refresh-context.md
+++ b/templates/.claude/commands/refresh-context.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/research.md
+++ b/templates/.claude/commands/research.md
@@ -15,7 +15,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/run-acceptance.md
+++ b/templates/.claude/commands/run-acceptance.md
@@ -9,7 +9,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/session-end.md
+++ b/templates/.claude/commands/session-end.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/session-handoff.md
+++ b/templates/.claude/commands/session-handoff.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/session-start.md
+++ b/templates/.claude/commands/session-start.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:

--- a/templates/.claude/commands/session-verify.md
+++ b/templates/.claude/commands/session-verify.md
@@ -8,7 +8,8 @@ Before doing anything else:
 
 1. Run this Bash command to print the absolute path of this project's auto-memory pointer file, then use the `Read` tool on the **exact absolute path** the command prints (it will begin with `/`, not `~/` — do not pass `~/` to Read, it does not expand it):
    ```bash
-   echo "$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+   REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+   echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
    ```
    Do not rely on auto-memory recall — auto-memory loads only `MEMORY.md` into the session reminder, not the files it links to.
 2. If it isn't there, OR the working-folder path it points to doesn't have a `CONTEXT.md` file, **stop** and tell me:
@@ -28,10 +29,13 @@ Read-only. No writebacks, no fixes — just report what you find.
 Run this Bash command to print the absolute path of the auto-memory directory the precheck resolves to, plus a directory listing:
 
 ```bash
-MEM_DIR="$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/.]|-|g')/memory"
+REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) && REPO_ROOT=$(dirname "$REPO_ROOT") || REPO_ROOT="$PWD"
+MEM_DIR="$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory"
 echo "$MEM_DIR"
 ls -1 "$MEM_DIR" 2>/dev/null || echo "(directory does not exist)"
 ```
+
+The `git rev-parse` step makes the resolution worktree-aware: from inside a `git worktree`, it walks up to the parent repo's `.git` directory before sanitizing, matching where bootstrap seeded auto-memory.
 
 ## Step 2 — compare on-disk MEMORY.md to runtime auto-memory
 

--- a/tests/precheck_in_commands.bats
+++ b/tests/precheck_in_commands.bats
@@ -117,6 +117,51 @@ KIT_COUPLED_AGENTS=(
   done
 }
 
+# Regression guard for #210 — precheck must walk up from worktree to parent
+# repo before sanitizing. Sanitizing $PWD directly produces a key that
+# includes the worktree subdir name, but bootstrap only ever seeded auto-
+# memory at the parent repo's path. Claude Code's runtime walks up; the
+# precheck must too. Use `git rev-parse --git-common-dir` (returns the
+# parent repo's .git for both regular and worktree sessions) → `dirname`
+# → sanitize. Falls back to $PWD outside a git repo.
+@test "every kit-coupled command Precheck is worktree-aware (uses git rev-parse)" {
+  for cmd in "${KIT_COUPLED_COMMANDS[@]}"; do
+    f="$KIT_ROOT/$cmd"
+    if ! grep -q 'git rev-parse --path-format=absolute --git-common-dir' "$f"; then
+      echo "missing worktree-aware git rev-parse in: $cmd"
+      return 1
+    fi
+    # Must sanitize REPO_ROOT (worktree-resolved), not raw $PWD.
+    if ! grep -q 'echo "\$REPO_ROOT" | sed' "$f"; then
+      echo "must sanitize \$REPO_ROOT (not raw \$PWD): $cmd"
+      return 1
+    fi
+    # The old raw-PWD sanitization must be gone.
+    if grep -q 'echo "\$PWD" | sed' "$f"; then
+      echo "regression — old raw-\$PWD sanitization still present in: $cmd"
+      return 1
+    fi
+  done
+}
+
+@test "every kit-coupled agent Precheck is worktree-aware (uses git rev-parse)" {
+  for agent in "${KIT_COUPLED_AGENTS[@]}"; do
+    f="$KIT_ROOT/$agent"
+    if ! grep -q 'git rev-parse --path-format=absolute --git-common-dir' "$f"; then
+      echo "missing worktree-aware git rev-parse in: $agent"
+      return 1
+    fi
+    if ! grep -q 'echo "\$REPO_ROOT" | sed' "$f"; then
+      echo "must sanitize \$REPO_ROOT (not raw \$PWD): $agent"
+      return 1
+    fi
+    if grep -q 'echo "\$PWD" | sed' "$f"; then
+      echo "regression — old raw-\$PWD sanitization still present in: $agent"
+      return 1
+    fi
+  done
+}
+
 @test "code-reviewer agent does NOT include the kit Precheck (universal agent)" {
   f="$KIT_ROOT/templates/.claude/agents/code-reviewer.md"
   [ -f "$f" ]

--- a/tests/precheck_worktree_handling.bats
+++ b/tests/precheck_worktree_handling.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+# Behavioral check — the worktree-aware precheck Bash (extracted from
+# session-start.md) must resolve to the parent repo's auto-memory path
+# regardless of whether the session is running in the main worktree, a
+# linked worktree under <repo>/.claude/worktrees/, or a linked worktree
+# elsewhere on disk. Closes #210.
+#
+# This test runs the actual Bash one-liner the precheck instructs Claude
+# to execute, against real `git worktree add`-created worktrees.
+
+load 'helpers'
+
+setup() {
+  # macOS resolves /var/folders/... -> /private/var/folders/... via symlink.
+  # `git rev-parse` returns the resolved path, so we need TEST_TMP to be the
+  # resolved form for string comparisons to work.
+  TEST_TMP="$(cd "$(mktemp -d)" && pwd -P)"
+  TEST_HOME="$TEST_TMP/home"
+  PARENT_REPO="$TEST_TMP/parent-repo"
+  mkdir -p "$TEST_HOME" "$PARENT_REPO"
+  export HOME="$TEST_HOME"
+
+  git -C "$PARENT_REPO" init -q
+  git -C "$PARENT_REPO" -c user.email=t@t.t -c user.name=t commit \
+    --allow-empty -m "init" -q
+}
+
+teardown() {
+  [ -n "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"
+}
+
+# Run the precheck Bash from inside $1 and echo the resolved memory pointer
+# path. Mirrors the snippet embedded in every kit-coupled slash command.
+run_precheck_in() {
+  local cwd="$1"
+  ( cd "$cwd" && \
+    REPO_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) \
+      && REPO_ROOT=$(dirname "$REPO_ROOT") \
+      || REPO_ROOT="$PWD"
+    echo "$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+  )
+}
+
+@test "precheck inside the main worktree resolves to the parent repo's memory path" {
+  expected="$HOME/.claude/projects/$(echo "$PARENT_REPO" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+  run run_precheck_in "$PARENT_REPO"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+@test "precheck inside a nested .claude/worktrees/ worktree resolves to the parent repo's memory path" {
+  # Worktree under <parent>/.claude/worktrees/<name> — the kit's own chip
+  # mechanism creates worktrees here.
+  WT="$PARENT_REPO/.claude/worktrees/feature-x"
+  mkdir -p "$(dirname "$WT")"
+  git -C "$PARENT_REPO" worktree add -q "$WT" 2>/dev/null
+
+  expected="$HOME/.claude/projects/$(echo "$PARENT_REPO" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+  run run_precheck_in "$WT"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+@test "precheck inside a worktree elsewhere on disk resolves to the parent repo's memory path" {
+  # Worktree at an arbitrary location, not nested under the parent repo.
+  WT="$TEST_TMP/detached-worktree"
+  git -C "$PARENT_REPO" worktree add -q "$WT" 2>/dev/null
+
+  expected="$HOME/.claude/projects/$(echo "$PARENT_REPO" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+  run run_precheck_in "$WT"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+@test "precheck outside any git repo falls back to PWD" {
+  # No git repo — should sanitize PWD itself.
+  NON_GIT="$TEST_TMP/not-a-repo"
+  mkdir -p "$NON_GIT"
+
+  expected="$HOME/.claude/projects/$(echo "$NON_GIT" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+  run run_precheck_in "$NON_GIT"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+@test "precheck handles dotted username + worktree (combined #205 + #210 case)" {
+  # Real-world case that surfaced #210: Aaron's `aaron.cupp` work account
+  # plus a chip-spawned worktree. The dot in the username must still be
+  # sanitized (#205), and the worktree must still walk up (#210).
+  DOTTED="$TEST_TMP/Users/aaron.cupp/Code/myrepo"
+  mkdir -p "$DOTTED"
+  git -C "$DOTTED" init -q
+  git -C "$DOTTED" -c user.email=t@t.t -c user.name=t commit \
+    --allow-empty -m "init" -q
+
+  WT="$DOTTED/.claude/worktrees/feature-y"
+  mkdir -p "$(dirname "$WT")"
+  git -C "$DOTTED" worktree add -q "$WT" 2>/dev/null
+
+  expected="$HOME/.claude/projects/$(echo "$DOTTED" | sed 's|[/.]|-|g')/memory/reference_ai_working_folder.md"
+  run run_precheck_in "$WT"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+  # Sanity check: the resolved path must NOT contain the worktree subdir name
+  # (i.e. the precheck successfully walked up before sanitizing).
+  [[ "$output" != *"feature-y"* ]]
+  # And the dot in `aaron.cupp` must have become a `-`.
+  [[ "$output" == *"aaron-cupp"* ]]
+  [[ "$output" != *"aaron.cupp"* ]]
+}


### PR DESCRIPTION
## Why this PR exists

[PR #211](https://github.com/IamMrCupp/claude-project-kit/pull/211) was opened with base = `feat/session-verify-slash-command` (stacked on #208). When #208 merged to main, GitHub snapshotted the feature branch at that moment. #211 was merged afterward, but **into the feature branch, not into main** — so #211's commits never reached `origin/main`. Issue #210 is still open because GitHub only auto-closes issues for PRs into the default branch.

This PR cherry-picks #211's fix commit onto `main`. Same content, fresh hash. No new logic.

## Summary

(Mirrors #211's body — see [PR #211](https://github.com/IamMrCupp/claude-project-kit/pull/211) for the full discussion.)

- All 10 slash commands + the session-summarizer agent (× 2 — `templates/.claude/` + dogfooded `.claude/`) now resolve the auto-memory key from the parent repo via `git rev-parse --path-format=absolute --git-common-dir` → `dirname` → sanitize. Falls back to `$PWD` outside a git repo.
- New behavioral test `tests/precheck_worktree_handling.bats` (5 tests) creates real `git worktree`s and asserts the precheck Bash resolves to the parent repo's path — including a combined "dotted username + worktree" case.
- New regression assertions in `tests/precheck_in_commands.bats`: every kit-coupled command and agent must include the worktree-aware `git rev-parse` line and must sanitize `$REPO_ROOT` (not raw `$PWD`).

## Test plan

- [x] `bats tests/` — 309/309 green locally on this branch
- [x] `git log origin/main..HEAD --oneline` — single cherry-picked commit, no surprises
- [x] CI bats + link-check green on push
- [ ] Adopter confirmation: `/session-verify` from a worktree on Aaron's work machine returns OK after upgrade

Closes #210