### PR TITLE
docs: add discussion issue template + point CONTRIBUTING at it

### DIFF
--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,0 +1,28 @@
+---
+name: Discussion / proposal
+about: Open-ended question or proposal — gather adopter signal before any implementation
+title: '[discussion] '
+labels: 'type:discussion'
+---
+
+## Topic
+
+<!-- One paragraph: what's the question or proposal? Concrete scenario beats abstract pitch. -->
+
+## Options considered
+
+<!-- List the shapes you've thought about. Use letters A, B, C… — easier to reference in comments. -->
+
+## Vote with reactions
+
+<!--
+Optional. If you want to gauge adopter interest, propose a reaction key, e.g.:
+
+- 👍 — please ship something
+- 👎 — leave it alone
+- 🚀 — option C specifically
+-->
+
+## Additional context
+
+<!-- Links, prior issues, related ADRs. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,8 @@ The repo has a [pull request template](.github/pull_request_template.md). The se
 Use the closest-fit template:
 
 - **Bug report** — something doesn't work as documented
-- **Feature request** — open-ended idea
+- **Feature request** — open-ended idea with a concrete change in mind
+- **Discussion / proposal** — open-ended question or proposal where the right shape isn't decided yet; gathers adopter signal before any implementation
 - **Tracker variant request** — request a new `--tracker <name>` variant
 - **CI variant request** — request a new `--ci <name>` variant
 
@@ -134,4 +135,4 @@ GitHub's Sponsor button does NOT render from `FUNDING.yml` alone — the repo al
 
 ## Questions
 
-Open an issue with the closest-fit template (often "Feature request") and add the `question` label if there's no actionable change requested.
+Use the **Discussion / proposal** template — it carries the `type:discussion` label and is the right shape for any question, open-ended proposal, or "should the kit have an opinion on X?" prompt that doesn't yet have a concrete change in mind.


### PR DESCRIPTION
## Summary

- New `.github/ISSUE_TEMPLATE/discussion.md` carrying the new `type:discussion` label, with Topic / Options / Vote-with-reactions / Additional-context sections.
- `CONTRIBUTING.md` — added the new template to the "Issue templates" list; rewrote the "Questions" section to point at it instead of "Feature request + `question` label".

## Motivation

Followup to [#214](https://github.com/IamMrCupp/claude-project-kit/issues/214) — that issue introduced the first `type:discussion`-shaped item. Created the matching repo label (`type:discussion`, `#8957e5`) alongside the existing `type:bug/docs/feature/chore` family. This PR completes the loop so adopters filing the same kind of open-ended proposal land on a purpose-built template instead of repurposing "Feature request".

## Design notes

- **Label, not GitHub Discussions.** Discussions is the right answer once activity warrants splitting "is this a bug?" from "let's chat about an idea." With ~5 stars pre-launch, splitting the surface is premature — keeping everything in Issues preserves the kit's existing "issue-first" workflow, roadmap project board references, and `Closes #N` linking.
- **Existing template label drift is out of scope.** `bug_report.md` uses `labels: bug`, `feature_request.md` uses `labels: enhancement`, the variant templates use `enhancement, ci-variant`/`tracker-variant` — none of which match the `type:*` family on the repo. Real drift; separate followup issue rather than bloating this PR.
- **Two commits, not bundled.** `docs:` for the new template file, `docs(contributing):` for the CONTRIBUTING edit. Bundled into one release-please patch bump but split for CHANGELOG readability per kit convention.

## Test plan

Pure-docs PR; no runtime change. Verification is CI (`lychee --offline` link-check on the CONTRIBUTING edit) plus a manual GitHub-side check that the new template appears in the "New issue" picker.

- [ ] CI green (link-check on `*.md`; bats not triggered — no template/script/test changes).
- [ ] After merge, "New issue" picker on the kit repo shows **Discussion / proposal** alongside the existing four templates.
- [ ] Filing a test issue from the new template applies `type:discussion` automatically (visible without manual labeling).

## CHANGELOG

Two `docs:` commits → one patch bump via release-please. Both lines should appear under Documentation in the next CHANGELOG entry.