### PR TITLE
fix: surface no-work-on-main rule so fresh sessions don't edit main

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -73,6 +73,7 @@ Required sections, in this order:
 
 - File path
 - 3–5 bullet summary covering: the goal in one sentence, the major approach steps, the riskiest open question, and the count of todo items
+- **Branch-first guard.** Run `git branch --show-current`. If it returns `main` (or the repo's default branch), add a closing line to the hand-back: *"When you say go, I'll start a `<type>/<slug>` branch first — implementation won't begin on `main`."* Name a concrete branch for todo item 1. This catches the common "ok, go ahead and implement" reply that would otherwise edit `main` directly — the kit's rule is *branch name first, then code* (`CONVENTIONS.md` → Git & commits).
 - Then **wait**. Don't ask "should I start implementing?" — assume no until told yes.
 
 ## Iterating on the plan

--- a/.claude/commands/pull-ticket.md
+++ b/.claude/commands/pull-ticket.md
@@ -112,4 +112,4 @@ Print:
 2. First three lines of the file: key + title, tracker link, status.
 3. A reminder: "Tracker is source of truth — re-run `/pull-ticket <KEY>` if the tracker changes. This file is the local working scratchpad."
 
-Then stop. Don't propose a branch name, don't open a worktree, don't start work. The user drives next — typically by checking the kit's CONVENTIONS.md (Ticket-driven workflows section) for the branch / PR / commit shape and starting from there.
+Then stop. Don't open a worktree or start work yet. **But check `git branch --show-current` first:** if it returns `main` (or the repo's default branch), flag in the hand-back that ticket work must start on a `<type>/<KEY>-<slug>` branch — implementation won't begin on `main`. Naming the exact branch and creating it is the user's next step per the kit's CONVENTIONS.md (Ticket-driven workflows section); this guard just stops a "go ahead" reply from silently editing `main`.

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -70,6 +70,10 @@ and cross-project conventions.
 - **Follow `CONVENTIONS.md` for this repo's own work** — Conventional Commits
   single-line with `-s` sign-off, branch name proposed before coding,
   merge-commit PR strategy, detailed manual test plans where applicable.
+- **Never edit on `main`.** Before the first edit to a tracked file, check
+  `git branch --show-current`; if it's `main` / the default branch, propose a
+  `<type>/<slug>` branch and switch to it first. (Read-only exploration on
+  `main` is fine — the rule is about edits.)
 - If I ask for something that contradicts the kit's own conventions, flag it.
   A kit that preaches X while itself doing Y is a credibility leak.
 - This repo is docs + templates — no runtime code — so "test plans" usually

--- a/memory-templates/MEMORY.md
+++ b/memory-templates/MEMORY.md
@@ -15,6 +15,7 @@ Do not treat these as canonical without reading them first — they encode one o
 - [Push branches by default](feedback_push_branches.md) — `git push -u origin <branch>` after commit, no confirmation needed (override Bash-tool default of asking before push)
 - [Watch CI in background](feedback_watch_ci_in_background.md) — spawn `gh run watch` in background after push
 - [Don't push after merge](feedback_no_push_after_merge.md) — once a PR merges, the branch is closed; branch off new `main` for follow-up work
+- [Branch first — never work on main](feedback_no_work_on_main.md) — propose a `<type>/<slug>` branch before editing tracked files (override Bash-tool default of editing whatever branch is checked out)
 - [Use the repo's branch-name convention](feedback_branch_naming.md) — rename auto-generated worktree branches to `<type>/<slug>` before pushing
 - [Prefer automated tests over manual smoke](feedback_automated_tests_preferred.md) — default to bats / expect / integration runners; don't ship manual procedures as steady state
 - [Tracker authority decides the default](feedback_no_tracker_creation.md) — issue-first when you own the tracker; read/reference only for externally-owned trackers

--- a/memory-templates/feedback_no_work_on_main.md
+++ b/memory-templates/feedback_no_work_on_main.md
@@ -1,0 +1,19 @@
+---
+name: Branch first — never start work on main
+description: Before editing tracked files, check the current branch; if it's main / the default branch, propose a `<type>/<slug>` branch and switch to it before writing any code.
+type: feedback
+---
+
+Before editing any tracked file, check the current branch (`git branch --show-current`). If it's `main` (or the repo's default branch), **stop** — propose a `<type>/<slug>` branch name, create it, and only then start editing.
+
+```bash
+git checkout -b <type>/<slug>   # feat/…, fix/…, docs/…, ci/…, chore/…
+```
+
+**Why:** the harness edits whatever branch is checked out, and a fresh session usually opens on `main`. Editing on `main` means no PR, no review, no CI gate, and a dirty default branch that has to be unwound by hand. Naming the branch *before* writing code also forces the "is this one PR or two?" decision up front, instead of discovering mid-session that the work should have been split. The rule lives in `CONVENTIONS.md` ("Branch name first, then code"), but a session that only loads the memory index — not the linked files — needs it surfaced here. See also [[feedback_branch_naming]] (naming convention) and [[feedback_push_branches]] (pushing once a branch exists).
+
+**How to apply:**
+- First edit of a work session: if `git branch --show-current` is the default branch, propose a branch name and switch *before* touching tracked files. Don't ask permission to *check* the branch — just check, and propose if needed.
+- Read-only work (reading files, `git log`, `git diff`, `gh` queries) is fine on `main` — the rule is about *edits* to tracked files.
+- Working-folder files (the private `CONTEXT.md` / `SESSION-LOG.md` outside the repo) aren't tracked repo files — editing those doesn't require a branch.
+- If the user explicitly authorizes a direct commit to `main` for a specific one-off, that's their call — but surface the branch option first and let them override.

--- a/templates/.claude/commands/plan.md
+++ b/templates/.claude/commands/plan.md
@@ -73,6 +73,7 @@ Required sections, in this order:
 
 - File path
 - 3–5 bullet summary covering: the goal in one sentence, the major approach steps, the riskiest open question, and the count of todo items
+- **Branch-first guard.** Run `git branch --show-current`. If it returns `main` (or the repo's default branch), add a closing line to the hand-back: *"When you say go, I'll start a `<type>/<slug>` branch first — implementation won't begin on `main`."* Name a concrete branch for todo item 1. This catches the common "ok, go ahead and implement" reply that would otherwise edit `main` directly — the kit's rule is *branch name first, then code* (`CONVENTIONS.md` → Git & commits).
 - Then **wait**. Don't ask "should I start implementing?" — assume no until told yes.
 
 ## Iterating on the plan

--- a/templates/.claude/commands/pull-ticket.md
+++ b/templates/.claude/commands/pull-ticket.md
@@ -112,4 +112,4 @@ Print:
 2. First three lines of the file: key + title, tracker link, status.
 3. A reminder: "Tracker is source of truth — re-run `/pull-ticket <KEY>` if the tracker changes. This file is the local working scratchpad."
 
-Then stop. Don't propose a branch name, don't open a worktree, don't start work. The user drives next — typically by checking the kit's CONVENTIONS.md (Ticket-driven workflows section) for the branch / PR / commit shape and starting from there.
+Then stop. Don't open a worktree or start work yet. **But check `git branch --show-current` first:** if it returns `main` (or the repo's default branch), flag in the hand-back that ticket work must start on a `<type>/<KEY>-<slug>` branch — implementation won't begin on `main`. Naming the exact branch and creating it is the user's next step per the kit's CONVENTIONS.md (Ticket-driven workflows section); this guard just stops a "go ahead" reply from silently editing `main`.

--- a/tests/memory_templates_overrides.bats
+++ b/tests/memory_templates_overrides.bats
@@ -45,3 +45,13 @@ MEMORY_INDEX="$KIT_ROOT/memory-templates/MEMORY.md"
   echo "$line" | grep -qE 'override.*[Bb]ash.*default' \
     || { echo "[Push branches by default] index line missing override-of-Bash-tool-default flag"; return 1; }
 }
+
+@test "Branch-first index line exists and flags override of edit-on-current-branch default" {
+  line="$(grep -F '(feedback_no_work_on_main.md)' "$MEMORY_INDEX" || true)"
+  [ -n "$line" ] || { echo "missing [Branch first — never work on main] index line"; return 1; }
+
+  # Must flag this as an override of a Bash-tool default so index-only readers
+  # see the no-work-on-main rule on first scan (the #204 regression shape).
+  echo "$line" | grep -qE 'override.*[Bb]ash.*default' \
+    || { echo "[Branch first] index line missing override-of-Bash-tool-default flag"; return 1; }
+}


### PR DESCRIPTION
## Summary

Fixes the P0 in #204: fresh Claude sessions on a kit-bootstrapped repo start editing files directly on `main` instead of proposing a branch first. The rule lives in `CONVENTIONS.md` ("Branch name first, then code") but wasn't surfaced anywhere a session-only-loads-the-index reader would see it. This is the same fragility shape as #193/#194 — a rule that exists in `CONVENTIONS.md` but isn't in the session-loaded memory index.

Implements the issue's **A + B** floor (skips the optional **C** PreToolUse hook):

**A. Memory-side**
- New `memory-templates/feedback_no_work_on_main.md` (rule + Why + How to apply), cross-linked to `feedback_branch_naming` / `feedback_push_branches`.
- New `MEMORY.md` index line carrying the override annotation pattern established by #194: `… (override Bash-tool default of editing whatever branch is checked out)`.
- `sync-memory.sh::suggested_index_line` is data-driven (greps `MEMORY.md`), so the new index line *is* the hook — no script change needed.
- New row in `tests/memory_templates_overrides.bats` locking the override flag in.

**B. Slash-command-side**
- `/plan` hand-back now runs `git branch --show-current` and, if on the default branch, appends a branch-first reminder naming a concrete branch for todo item 1.
- `/pull-ticket` step 6 reworked: still doesn't start work, but now flags if you're on `main` so a "go ahead" reply can't silently edit the default branch.
- Both `.claude/commands/` (dogfood) and `templates/.claude/commands/` (shipped) copies updated identically; `dogfood_claude_in_sync.bats` stays green.
- `PROMPTS.md` Prompt 2 "Rules of engagement" (the kit's own start-work prompt — where the dogfood regression was observed) gets an explicit "never edit on `main`" bullet.

### Design note — why the check is in the hand-back, not "early"
`/plan` and `/pull-ticket` only write to the **private working folder** (outside the repo), so neither edits tracked repo files. The branch matters at the *implementation handoff*, not at command start — so the guard lives in the hand-back, right where a "go ahead and implement" reply lands. This diverges slightly from the issue's "early check" wording but targets the actual moment of risk.

## Test plan
- [x] `bats tests/*.bats` — 339/339 pass (was 338 + 1 new override test)
- [x] `bats tests/memory_templates_overrides.bats` — new "Branch-first index line" test passes; existing override tests unaffected
- [x] `bats tests/dogfood_claude_in_sync.bats` — command copies still byte-identical
- [x] `bats tests/sync_memory.bats` — `suggested_index_line` resolves the new entry (no TODO placeholder)
- [ ] Render check on GitHub: new memory file + MEMORY.md index line render; `(feedback_no_work_on_main.md)` link resolves — Aaron to verify
- [ ] Live: a fresh session on a kit-bootstrapped repo, asked to make a change, proposes a branch before editing — Aaron to verify against acceptance criterion 4

Closes #204