### PR TITLE
docs(issue-templates): align labels with type:* family

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Something doesn't work as documented
 title: '[bug] '
-labels: bug
+labels: 'type:bug'
 ---
 
 ## What happened

--- a/.github/ISSUE_TEMPLATE/ci_variant_request.md
+++ b/.github/ISSUE_TEMPLATE/ci_variant_request.md
@@ -2,7 +2,7 @@
 name: CI variant request
 about: Request a new --ci <name> variant
 title: '[ci] add <name> variant'
-labels: 'enhancement, ci-variant'
+labels: 'type:feature'
 ---
 
 ## CI platform

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Open-ended idea or improvement
 title: '[feature] '
-labels: enhancement
+labels: 'type:feature'
 ---
 
 ## Problem

--- a/.github/ISSUE_TEMPLATE/tracker_variant_request.md
+++ b/.github/ISSUE_TEMPLATE/tracker_variant_request.md
@@ -2,7 +2,7 @@
 name: Tracker variant request
 about: Request a new --tracker <name> variant
 title: '[tracker] add <name> variant'
-labels: 'enhancement, tracker-variant'
+labels: 'type:feature'
 ---
 
 ## Tracker name


### PR DESCRIPTION
## Summary

Fixes #216. The four older issue templates still set the legacy GitHub default labels (`bug` / `enhancement`) on new issues, even though the repo migrated to the scoped `type:*` family (`type:bug`, `type:feature`, `type:docs`, `type:chore`, `type:discussion`). The newest template (`discussion.md`) already uses `type:discussion`; this brings the rest in line.

Changes (frontmatter `labels:` only):

| Template | Before | After |
|---|---|---|
| `bug_report.md` | `bug` | `type:bug` |
| `feature_request.md` | `enhancement` | `type:feature` |
| `ci_variant_request.md` | `enhancement, ci-variant` | `type:feature` |
| `tracker_variant_request.md` | `enhancement, tracker-variant` | `type:feature` |

### Note — dropped `ci-variant` / `tracker-variant`
Neither `ci-variant` nor `tracker-variant` exists as a repo label (`gh label list`), so they silently no-op when GitHub applies the template — and the kit's convention is to never auto-create labels. The `[ci]` / `[tracker]` title prefixes already categorize these requests, so nothing is lost. If you'd rather keep dedicated variant labels, create them in the repo and I'll re-add them.

## Test plan
- [x] No test asserts template label values (`grep -rn 'ci-variant\|tracker-variant\|labels:' tests/` — only the unrelated `04-ci-variant.exp` bootstrap fixture)
- [x] `CONTRIBUTING.md` doesn't reference the dropped variant labels
- [x] All four `labels:` values map to labels that exist in `gh label list`
- [ ] Render check: New-issue picker shows the four templates applying `type:*` labels — Aaron to verify on GitHub

Closes #216