### PR TITLE
feat(sync-memory): report kit-template drift without overwriting

### DIFF
--- a/memory-templates/MEMORY.md
+++ b/memory-templates/MEMORY.md
@@ -11,6 +11,7 @@ Do not treat these as canonical without reading them first — they encode one o
 - [User role and background](user_role.md) — who you're collaborating with, how to calibrate explanations
 - [AI working folder location](reference_ai_working_folder.md) — read CONTEXT.md + SESSION-LOG.md at {{WORKING_FOLDER}}/ before work
 - [Commit format](feedback_commit_format.md) — `git commit -s -m "type(scope): subject"`, single line, no body, **no `Co-Authored-By` trailer** (override Bash-tool HEREDOC default that adds one)
+- [No AI co-author trailers](feedback_no_ai_coauthor.md) — commits attributed to the human committer only; never append `Co-Authored-By: Claude …` (override Bash-tool HEREDOC default)
 - [Merge strategy](feedback_merge_strategy.md) — always merge commits; never squash or rebase
 - [Push branches by default](feedback_push_branches.md) — `git push -u origin <branch>` after commit, no confirmation needed (override Bash-tool default of asking before push)
 - [Watch CI in background](feedback_watch_ci_in_background.md) — spawn `gh run watch` in background after push

--- a/scripts/sync-memory.sh
+++ b/scripts/sync-memory.sh
@@ -7,6 +7,12 @@
 # memory dir, never overwrites existing files, and never touches user-curated
 # files (MEMORY.md, project_current.md, user_role.md).
 #
+# Files that already exist but differ from the kit's current template are
+# reported as "outdated" (with a diff hint) and left untouched — memory files
+# are designed to be edited and grown, so a local copy almost always differs
+# on purpose. Detect-and-report only; never overwrite. (Counterpart to the
+# same behavior in scripts/sync-templates.sh.)
+#
 # Run after pulling kit updates if you want to absorb new starter rules.
 # Idempotent — re-running is a no-op once everything is in sync.
 set -euo pipefail
@@ -33,8 +39,10 @@ usage() {
 Usage: sync-memory.sh [options] [memory-dir]
 
 Sync missing memory-templates/*.md into the auto-memory directory. Never
-overwrites existing files. Never touches MEMORY.md, project_current.md,
-or user_role.md (those are user-customized).
+overwrites existing files. Reports files that exist but differ from the
+kit's current template ("outdated") so you can merge by hand if desired.
+Never touches MEMORY.md, project_current.md, or user_role.md (those are
+user-customized).
 
 Arguments:
   [memory-dir]   Optional. Absolute path to an auto-memory directory.
@@ -149,6 +157,7 @@ echo
 COPIED=()
 SKIPPED_EXISTING=()
 SKIPPED_RESERVED=()
+OUTDATED=()
 
 for src in "$TEMPLATES_DIR"/*.md; do
   [ -e "$src" ] || continue
@@ -160,7 +169,11 @@ for src in "$TEMPLATES_DIR"/*.md; do
   fi
 
   if [ -e "$TARGET/$name" ]; then
-    SKIPPED_EXISTING+=("$name")
+    if cmp -s "$src" "$TARGET/$name"; then
+      SKIPPED_EXISTING+=("$name")
+    else
+      OUTDATED+=("$name")
+    fi
     continue
   fi
 
@@ -174,30 +187,50 @@ for src in "$TEMPLATES_DIR"/*.md; do
 done
 
 echo
-if [ "${#COPIED[@]}" -eq 0 ]; then
-  echo "Already in sync — no files to copy."
+if [ "${#COPIED[@]}" -eq 0 ] && [ "${#OUTDATED[@]}" -eq 0 ]; then
+  echo "Already in sync — no files to copy, no outdated content."
   if [ "${#SKIPPED_RESERVED[@]}" -gt 0 ]; then
     echo "Skipped (user-customized, never auto-synced): ${SKIPPED_RESERVED[*]}"
   fi
   exit 0
 fi
 
-if [ "$DRY_RUN" -eq 1 ]; then
-  echo "Would copy ${#COPIED[@]} file(s). Re-run without --dry-run to apply."
-else
-  echo "Copied ${#COPIED[@]} file(s) into $TARGET."
+if [ "${#COPIED[@]}" -gt 0 ]; then
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "Would copy ${#COPIED[@]} file(s). Re-run without --dry-run to apply."
+  else
+    echo "Copied ${#COPIED[@]} file(s) into $TARGET."
+  fi
+
+  echo
+  echo "Suggested MEMORY.md additions (paste the ones you want):"
+  echo
+  for name in "${COPIED[@]}"; do
+    line="$(suggested_index_line "$name")"
+    if [ -n "$line" ]; then
+      echo "  $line"
+    else
+      echo "  - [TITLE]($name) — TODO: write a one-line hook"
+    fi
+  done
+  echo
+  echo "MEMORY.md is user-curated; this script does not edit it directly."
 fi
 
-echo
-echo "Suggested MEMORY.md additions (paste the ones you want):"
-echo
-for name in "${COPIED[@]}"; do
-  line="$(suggested_index_line "$name")"
-  if [ -n "$line" ]; then
-    echo "  $line"
-  else
-    echo "  - [TITLE]($name) — TODO: write a one-line hook"
-  fi
-done
-echo
-echo "MEMORY.md is user-curated; this script does not edit it directly."
+if [ "${#OUTDATED[@]}" -gt 0 ]; then
+  echo
+  echo "Outdated files (exist locally but differ from kit's current template):"
+  for name in "${OUTDATED[@]}"; do
+    echo "  - $name"
+  done
+  echo
+  echo "These were NOT modified. Memory files are meant to be edited and grown,"
+  echo "so a local copy almost always differs on purpose — this script never"
+  echo "overwrites them. Review the kit's version and merge by hand if you want"
+  echo "a wording or rule update. Compare with:"
+  echo
+  for name in "${OUTDATED[@]}"; do
+    echo "    diff $TEMPLATES_DIR/$name $TARGET/$name"
+    break  # show one example, the user can extrapolate
+  done
+fi

--- a/tests/sync_memory.bats
+++ b/tests/sync_memory.bats
@@ -154,6 +154,56 @@ EOF
   [[ "$output" == *"copied feedback_push_branches.md"* ]]
 }
 
+# ─── Drift detection (issue #221) ─────────────────────────────────────────
+
+@test "sync-memory.sh reports an outdated file when the local copy differs" {
+  # Seed a divergent copy of a shipped template
+  printf 'DIVERGED LOCAL CONTENT\n' > "$TARGET/feedback_commit_format.md"
+
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Outdated files"* ]]
+  [[ "$output" == *"feedback_commit_format.md"* ]]
+  [[ "$output" == *"diff "* ]]
+
+  # Never overwritten — local content preserved
+  grep -q "DIVERGED LOCAL CONTENT" "$TARGET/feedback_commit_format.md"
+}
+
+@test "sync-memory.sh reports no outdated files when local copies are identical" {
+  # Fully populate target with identical kit content
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+
+  # Second run: everything identical → no drift report
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Outdated files"* ]]
+  [[ "$output" == *"Already in sync"* ]]
+}
+
+@test "sync-memory.sh --dry-run still reports outdated files and writes nothing" {
+  printf 'DIVERGED\n' > "$TARGET/feedback_commit_format.md"
+
+  run "$SYNC" --dry-run "$TARGET"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY RUN"* ]]
+  [[ "$output" == *"Outdated files"* ]]
+  [[ "$output" == *"feedback_commit_format.md"* ]]
+
+  # Divergent file untouched
+  grep -q "DIVERGED" "$TARGET/feedback_commit_format.md"
+}
+
+@test "sync-memory.sh suggests a real index line for every shipped template" {
+  run "$SYNC" "$TARGET"
+  [ "$status" -eq 0 ]
+  # Regression guard for the suggested_index_line gap class (#221 chip):
+  # a shipped template with no matching MEMORY.md index line emits the
+  # "TODO: write a one-line hook" placeholder. None should.
+  [[ "$output" != *"TODO: write a one-line hook"* ]]
+}
+
 # ─── Inference tests (issue #163) ─────────────────────────────────────────
 
 @test "sync-memory.sh inferred mode works when run from a kit-bootstrapped repo" {


### PR DESCRIPTION
## Summary

Closes #221 and folds in the spawned `suggested_index_line` chip from the 2026-05-26 dogfood session.

`sync-memory.sh` was additive-only: it copied templates that didn't exist and silently `continue`d past any that did — no content comparison, no report. So when a kit release improved a template you already had, you'd never know your local copy had drifted. `sync-templates.sh` already solved this for working-folder templates; this gives `sync-memory.sh` the same treatment.

**Drift detection (#221)** — mirrors `sync-templates.sh`:
- New `OUTDATED` array; for each template that already exists locally, `cmp -s` against the kit's version.
- Differing files are listed under an "Outdated files (exist locally but differ…)" section with a `diff <kit> <local>` hint.
- **Never overwrites.** Memory files are designed to be edited and grown, so local divergence is almost always intentional — detect-and-report only. Reserved files (`MEMORY.md`, `project_current.md`, `user_role.md`) stay excluded; additive copy behavior unchanged.
- Works under `--dry-run` too (reports drift, writes nothing).

**`suggested_index_line` chip** — root cause: `feedback_no_ai_coauthor.md` ships as a file but had **no index line** in `memory-templates/MEMORY.md`, so the function returned empty and emitted the `[TITLE](…) — TODO: write a one-line hook` placeholder. Audited the whole table — that was the only gap. Added the missing index line (with the override annotation, since the rule overrides the Bash HEREDOC default).

## Test plan
- [x] `bats tests/sync_memory.bats` — 19/19 (4 new: outdated-when-differs + no-overwrite, no-drift-when-identical, dry-run-reports-drift, every-template-has-a-real-index-line)
- [x] `bats tests/*.bats` — 342/342, no failures
- [x] The new "every shipped template suggests a real index line" guard fails if any copyable template lacks a `MEMORY.md` index line (caught the `feedback_no_ai_coauthor.md` gap pre-fix)
- [ ] Render check: `MEMORY.md` index renders with the new co-author line — Aaron to verify on GitHub

Closes #221