### PR TITLE
chore: cut v1.0.0 — stability contract + post-1.0 semver

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Works the same for greenfield repos and ones you're adopting it on mid-stream �
 ├── SETUP.md                 ← step-by-step: starting a new project
 ├── FEATURES.md              ← feature-by-feature reference
 ├── CONVENTIONS.md           ← generic working rules (commits, PRs, etc.)
+├── STABILITY.md             ← what 1.x promises not to break
 ├── PROMPTS.md               ← ready-to-paste session-opening prompts
 ├── CHANGELOG.md             ← what's landed; upgrade notes for existing adopters
 ├── CONTRIBUTING.md          ← contributor onboarding
@@ -205,6 +206,7 @@ Works the same for greenfield repos and ones you're adopting it on mid-stream �
 | [FEATURES.md](FEATURES.md) | Feature-by-feature reference with example invocations |
 | [PROMPTS.md](PROMPTS.md) | Session-opening / session-end prompt library |
 | [CONVENTIONS.md](CONVENTIONS.md) | Commit / PR / CI rules the kit assumes |
+| [STABILITY.md](STABILITY.md) | What `1.x` promises not to break, and what can change in any release |
 | [CHANGELOG.md](CHANGELOG.md) | What's shipped, with **For existing adopters** notes per release |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Adding tracker / CI variants, running the Bats suite, PR shape |
 | [SECURITY.md](SECURITY.md) | Vulnerability reporting |

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -1,0 +1,36 @@
+# Stability contract
+
+As of **v1.0.0**, `claude-project-kit` commits to not breaking the surfaces below without a major version bump. This is the promise behind the `1.x` line: you can adopt the kit, build habits and tooling around it, and trust that a `1.x` upgrade won't silently change the things you depend on.
+
+Versioning follows [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** (`2.0.0`) — a breaking change to a stable surface below.
+- **MINOR** (`1.1.0`) — new, backward-compatible capability (a new flag, a new template, a new slash command).
+- **PATCH** (`1.0.1`) — backward-compatible fixes and editorial changes.
+
+Releases are cut automatically by [release-please](https://github.com/googleapis/release-please) from Conventional Commit history. From `1.0.0` on, `feat!:` / `BREAKING CHANGE:` commits trigger a major bump rather than being folded into a minor.
+
+---
+
+## Stable surfaces — what `1.x` will not break
+
+- **`bootstrap.sh` CLI** — flag names, default behavior, and what it writes where. Adding new flags is non-breaking; **removing or renaming** a flag, or changing a default's effect, is breaking.
+- **Helper script CLI surface** — `sync-templates.sh`, `sync-memory.sh`, `install-commands.sh` (incl. `--force-update`), `install-scripts.sh`, `rename-workspace.sh`, `pull-ticket.sh`, `upgrade.sh` (incl. `--force-commands` / `--force-scripts`). Same flag-rename-is-breaking rule as `bootstrap.sh`.
+- **Template field names + structure** — `CONTEXT.md`'s required sections (Project Overview, Working Rules, Current Phase Status, …); `phase-N-checklist.md`'s `## Acceptance testing` and `## Phase exit` blocks; `acceptance-test-results.md`'s Goal / Setup / Steps / Expected / Actual / Result fields; the workspace templates' `workspace-CONTEXT.md` and `ticket.md` shapes.
+- **Auto-memory schema** — frontmatter fields (`name`, `description`, `type`), the four `type` values (`user` / `feedback` / `project` / `reference`), and the `MEMORY.md` index-line format.
+- **Slash command names** — `/session-start`, `/session-end`, `/session-handoff`, `/session-verify`, `/refresh-context`, `/close-phase`, `/pull-ticket`, `/run-acceptance`, `/research`, `/plan`, plus any added after `1.0.0`. Renames or removals are breaking; adding new prechecks or enforcement *within* a command is not.
+- **Working-folder location convention** — the working folder lives **outside** the repo, with its parent dir trustable via `permissions.additionalDirectories`. The kit doesn't promise a specific path, but it does promise the "separate from the repo" model.
+
+## Explicitly NOT covered — may change in any release
+
+- Editorial wording in `README.md` / `CONVENTIONS.md` / `FEATURES.md` / `SETUP.md` and other prose docs.
+- Internal helper functions inside `bootstrap.sh` and the `scripts/lib/` helpers.
+- Bats test names and structure (kit-internal).
+- The specific entries shipped in `memory-templates/` — adding, removing, or renaming a starter memory file is allowed; the auto-memory **schema** is what's stable, not the particular starter set.
+- The **prose body** of a slash command (the `.md` Claude follows) — the contract is on the command's name and invocation, not the exact instructions inside it.
+
+---
+
+## How to read a release
+
+Each release's `CHANGELOG.md` entry carries a **For existing adopters** note when an upgrade needs any action. A `1.x → 1.y` upgrade should never require changing your filled-in templates, memory, or scripts to keep working. If you ever hit one that does, that's a bug — please [open an issue](https://github.com/IamMrCupp/claude-project-kit/issues).

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "include-component-in-tag": false,
-  "bump-minor-pre-major": true,
+  "bump-minor-pre-major": false,
   "bump-patch-for-minor-pre-major": false,
   "packages": {
     ".": {


### PR DESCRIPTION
## Summary

Closes #157. Per your call to tag 1.0.0 now, this prepares the major release following the exact mechanism #157 specifies.

**What's in the PR:**
- **`STABILITY.md`** (new) — the stability contract from #157, adopter-facing: what `1.x` promises not to break (bootstrap + helper-script CLIs, template field names, auto-memory schema, slash-command names, working-folder-outside-repo model) and what can change in any release (prose, internal helpers, test names, the specific starter memory set, slash-command prose bodies).
- **`release-please-config.json`** — `bump-minor-pre-major: true → false`, so from 1.0.0 on, `feat!:` / `BREAKING CHANGE:` trigger proper major bumps instead of being folded into minors.
- **`README.md`** — `STABILITY.md` added to the Related-docs table and the "What's in here" file tree (front-door audit).
- **`chore: release 1.0.0` empty commit** carrying a `Release-As: 1.0.0` footer — the documented trigger that makes release-please cut exactly 1.0.0 on its next run.

## How the release actually cuts (merge order)

This PR does **not** itself tag anything. After it merges, release-please sees the `Release-As: 1.0.0` footer and opens/updates its release PR as **1.0.0**, bundling everything unreleased since 0.41.0.

Suggested order so the P0 fix + cleanups ship inside 1.0.0:
1. Merge #222 (#204 P0 branch-first), #223 (#216 labels), #224 (#221 sync-memory drift) — any order.
2. Merge **this** PR.
3. release-please opens a **"release 1.0.0"** PR — merge that to cut the tag.

(Because of the `Release-As` footer, the version is 1.0.0 regardless of merge order; ordering only affects what's bundled in the changelog.)

## Note on the commit format
The `chore: release 1.0.0` commit intentionally carries a `Release-As: 1.0.0` footer — the one sanctioned multi-line commit, since that's the only way to force release-please to a specific version. All other commits stay single-line per CONVENTIONS.md.

## Gate status (from #157)
- [x] `#153` + `#154` merged (acceptance-test discipline)
- [x] Stability contract documented → `STABILITY.md`
- [x] Launch week executed (Slack 5/15, public socials 5/19, awesome-claude-code 5/20, retro 5/25) — confirmed
- [x] No backward-incompat pending — the 9-repo dogfood upgrade to v0.41.0 held with zero template/CLI breaks
- [~] 2-week organic-adoption window — launch was 5/19, so ~1 week elapsed; **proceeding now is a conscious call** (kit shape validated by the multi-repo dogfood rather than waiting the full window)

## Test plan
- [x] `python3 -c json.load` — `release-please-config.json` still valid
- [x] `bats tests/*.bats` — 338/338, no failures
- [x] `git show HEAD` confirms the `Release-As: 1.0.0` footer is present
- [ ] Render check: `STABILITY.md` renders; README Related-docs + file-tree links resolve — Aaron to verify on GitHub
- [ ] After merge: release-please opens a **1.0.0** release PR (not a minor) — Aaron to verify

Closes #157