### PR TITLE
chore(ci): bump actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -18,7 +18,7 @@ jobs:
   bats:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install bats + expect
         run: sudo apt-get update && sudo apt-get install -y bats expect

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run lychee
         uses: lycheeverse/lychee-action@v2

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Closes #107. GitHub forces Actions to Node 24 by default on **2026-06-02** (Node 20 removed from runners 2026-09-16). Bumps our pinned actions to Node-24 majors ahead of the flip.

Verified each upstream's runtime via the GitHub API (`action.yml` → `runs.using` at the target tag):

| Action | Was | Now | Runtime check |
|---|---|---|---|
| `actions/checkout` | `@v4` (node20) | `@v6` | `v6` → `using: node24`, no required inputs |
| `googleapis/release-please-action` | `@v4` (node20) | `@v5` | `v5` → `using: node24`; `config-file` + `manifest-file` inputs unchanged |
| `lycheeverse/lychee-action` | `@v2` | `@v2` (unchanged) | `composite` action — not a JS action, so the Node deprecation doesn't apply |

No behavior change for adopters — the kit doesn't ship `.github/workflows/` (bootstrap doesn't copy them). `chore(ci):` per the issue, so it's hidden from release notes and triggers no release.

## Test plan
- [x] `actions/checkout@v6` and `release-please-action@v5` confirmed `node24` via `gh api .../action.yml`
- [x] `release-please-action@v5` still exposes `config-file` / `manifest-file` (our only inputs) — release just cut v1.0.0 on v4, so input compatibility matters
- [ ] Bats + link-check pass on this PR with `checkout@v6` — CI on this PR
- [ ] After merge: next `release-please` run on `main` uses `@v5` with no Node-20 deprecation annotation — Aaron to confirm on the post-merge run

Closes #107