### PR TITLE
docs(context): free-tier branch-protection limits + two-tier issue tracking

### DIFF
--- a/templates/CONTEXT.md
+++ b/templates/CONTEXT.md
@@ -70,6 +70,7 @@ This folder uses a layered documentation system. Reuse this pattern when startin
 - {{Template location if any}}
 - {{Required reviewers, required checks}}
 - Manual test plan required for runtime changes — see CONVENTIONS.md
+- **Branch protection on free-tier private repos:** as of 2026, GitHub gates BOTH legacy branch protection and rulesets enforcement behind paid plans (Pro for personal, Team for orgs). On a free private repo neither enforces — rulesets can be *created* but won't take effect. Fall back to manual discipline: never force-push to `main`, never delete `main`, wait for green CI before merging. A local `pre-push` git hook can add belt-and-suspenders if desired.
 
 ### Shell / build
 - {{Shell in use — bash / zsh / fish / pwsh}}
@@ -113,9 +114,11 @@ This folder uses a layered documentation system. Reuse this pattern when startin
 
 ## Open Questions
 
-| # | Question | Status |
-|---|---|---|
-| 1 | {{…}} | ⏳ Open / ✅ Resolved — see §X |
+> **Two-tier tracking:** promote a question to a GitHub Issue (and link both ways via the **Tracked as** column) *when work is about to commit that depends on its resolution* — that's when public visibility and PR cross-linking earn their keep. Pure "still thinking" items stay here in the private working folder; promoting everything is noise, promoting nothing loses traceability the moment a deferred decision starts gating real work.
+
+| # | Question | Status | Tracked as |
+|---|---|---|---|
+| 1 | {{…}} | ⏳ Open / ✅ Resolved — see §X | {{#N once promoted, else —}} |
 
 ---
 


### PR DESCRIPTION
## Summary

Two small docs notes added to the `CONTEXT.md` template, both surfaced during the discord-iac live-validation (#38).

- **#64** — Working Rules → PRs now notes that GitHub gates *both* legacy branch protection and rulesets enforcement behind paid plans on free-tier private repos; neither enforces, so fall back to manual discipline (no force-push/delete `main`, wait for green CI). Sets expectations so users don't assume branch protection is available.
- **#57** — Open Questions now documents the two-tier tracking pattern (promote a question to a GitHub Issue only when committed work depends on it) and adds a **Tracked as** column to the table for the issue link.

## Test plan
- [x] `bats tests/*.bats` — 343/343, no failures (placeholder substitution + bootstrap unaffected)
- [ ] Render check: CONTEXT.md template renders, the 4-column Open Questions table is valid — Aaron to verify on GitHub

Closes #64
Closes #57