### PR TITLE
docs(seed-prompt): add GitHub Projects decision prompt

### DIFF
--- a/templates/SEED-PROMPT.md
+++ b/templates/SEED-PROMPT.md
@@ -149,11 +149,22 @@ Output a summary in this exact shape:
 
 **research.md drafted:** <one-line what it covers, e.g. "5 entry points, 8 modules, Postgres + Redis as external deps">
 
+**GitHub Projects:** <recommendation — see the decision note below; default "skip" for solo devs>
+
 ## Questions (≤5)
 
 1. ...
 2. ...
 ```
+
+### On the GitHub Projects line
+
+Surface this one-time decision in the summary — **don't enable anything automatically**, just flag the call:
+
+- **Default: skip for solo developers.** `phase-N-checklist.md` already fills the kanban role, so a Project board is usually duplicative.
+- **Flag "consider enabling" when** any of these hold: a second collaborator joins, you run more than one repo and want a cross-repo view, or you want filtered status views beyond what `is:open label:phase-N` saved searches give you.
+
+This is a decision tree, not an action — enabling Projects (and wiring its API) stays the user's explicit call.
 
 ### Question rules
 


### PR DESCRIPTION
## Summary

Closes #59. The SEED-PROMPT flow surfaced provider / branch-naming / secrets decisions but never mentioned GitHub Projects, leaving users to stumble into the question. Adds it as a surfaced decision (not an auto-action):

- A `**GitHub Projects:**` line in the seed-prompt summary block (default recommendation: skip for solo devs).
- An "On the GitHub Projects line" guidance note with the decision tree: skip when solo (`phase-N-checklist.md` covers kanban); consider enabling when a collaborator joins, you run >1 repo, or you want filtered views beyond `is:open label:phase-N`.

Enabling Projects stays the user's explicit call — the kit never wires it automatically (consistent with the no-structural-creation stance).

## Test plan
- [x] `bats tests/*.bats` — 343/343, no failures (templates/** path triggers the Bats workflow)
- [ ] Render check: SEED-PROMPT.md renders, summary block + guidance note read cleanly — Aaron to verify

Closes #59