### PR TITLE
docs(seed-prompt): surface IaC state/secrets/migration decisions

### DIFF
--- a/templates/SEED-PROMPT.md
+++ b/templates/SEED-PROMPT.md
@@ -151,6 +151,8 @@ Output a summary in this exact shape:
 
 **GitHub Projects:** <recommendation — see the decision note below; default "skip" for solo devs>
 
+**IaC decisions** (only if Terraform / Pulumi / Helm-with-state detected): <state backend / secrets-at-runtime / migration plan — see the decision note below>
+
 ## Questions (≤5)
 
 1. ...
@@ -165,6 +167,18 @@ Surface this one-time decision in the summary — **don't enable anything automa
 - **Flag "consider enabling" when** any of these hold: a second collaborator joins, you run more than one repo and want a cross-repo view, or you want filtered status views beyond what `is:open label:phase-N` saved searches give you.
 
 This is a decision tree, not an action — enabling Projects (and wiring its API) stays the user's explicit call.
+
+### On the IaC decisions line
+
+**Only when Step 1 detected Terraform / Pulumi / Helm-with-state** (or similar stateful IaC). For these repos, *"where does state live?"* is load-bearing — get it wrong and you risk committing important state to a single laptop disk, and it has to be settled before any bulk-import or apply-at-scale work. Surface these (or get an explicit deferral) rather than letting them sink into a generic "open question":
+
+- **State backend** — local-only-during-bootstrap is a fine *start*, but if deferred, say so and recommend filing a tracking issue that **gates bulk-apply / bulk-import** until it's resolved.
+- **Secrets-at-runtime** — 1Password CLI / sops / direnv / CI secret. Drives `op run`-style wrapper conventions, env-var naming, and downstream CI design.
+- **State migration plan** — if starting local, what's the migration trigger and the target backend?
+
+**Recommended escape hatch:** *"local backend for bootstrap, migrate later, gated by a tracking issue."* It lets work start without pretending the decision is made — the tracking issue keeps the deferral honest and blocks the operations (bulk import / apply) that would be unsafe against laptop-local state. The same shape generalizes to other stateful IaC (Helm release secrets, Pulumi stack secrets).
+
+This is a decision-surfacing prompt, not an action — don't pick a backend or wire secrets yourself.
 
 ### Question rules
 


### PR DESCRIPTION
## Summary

Closes #60. For IaC repos, *"where does state live?"* is load-bearing and must be settled before bulk-import / apply-at-scale — but SEED-PROMPT.md didn't prompt for it, so it sank into a generic "open question" during the discord-iac validation (#38).

Adds an IaC-flavored decision block to `SEED-PROMPT.md`, surfaced **only when Step 1 detects Terraform / Pulumi / Helm-with-state**:
- a `**IaC decisions**` line in the seed-prompt summary
- an "On the IaC decisions line" guidance subsection covering **state backend**, **secrets-at-runtime**, and **state-migration plan**, plus the recommended escape hatch: *"local for bootstrap, migrate later, gated by a tracking issue"* (so deferral stays honest and blocks unsafe bulk ops). Decision-surfacing only — never picks a backend or wires secrets.

Same pattern as the GitHub Projects decision (#59) added in v1.1.0.

## Test plan
- [x] `bats tests/*.bats` — 361/361, no failures (templates/** path triggers the Bats workflow)
- [ ] Render check: SEED-PROMPT.md summary block + guidance subsection read cleanly — Aaron to verify

Closes #60