### PR TITLE
feat(hooks): commit-format enforcement hook (#204 Option C)

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -21,6 +21,8 @@ Project-agnostic habits that have proven out across real work. Start from these,
 - **Push branches to origin by default** after committing (`git push -u origin <branch>`). Still confirm before force-push or push-to-main.
 - **Git from the Claude sandbox is fine** for read-only ops (`git status`, `git log`, `git diff`, `gh`). Confirm before destructive ops: `push --force`, `reset --hard`, `branch -D`, `clean -f`.
 
+**Hook-side enforcement (recommended).** Memory and prose are guidance — Claude *usually* honors the rules above, but the kit ships an optional `PreToolUse` Bash hook (`scripts/block-forbidden-commit-patterns.sh`) that **blocks** commands carrying forbidden commit-format patterns at the harness level (Co-Authored-By trailers, "Generated with Claude Code" / 🤖 markers, `--no-verify` / `--no-gpg-sign` / `commit.gpgsign=false` bypasses). Memory is a suggestion; the hook is the structural guarantee. Wire it once per machine — see [SETUP.md → Optional: commit-format enforcement hook](SETUP.md#optional-commit-format-enforcement-hook).
+
 ## PRs
 
 - **Provide PR title + body proactively** when a branch is ready — don't wait to be asked.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -300,6 +300,12 @@ Read, don't copy.
 
 The kit's own development follows these conventions, so the repo is a worked example of the conventions in action.
 
+### Commit-format enforcement hook (optional, recommended)
+
+For the commit-format subset of `CONVENTIONS.md` (no `Co-Authored-By: Claude` trailers, no `--no-verify` / `--no-gpg-sign` / `commit.gpgsign=false` bypasses, no "Generated with Claude Code" / 🤖 markers), memory and prose are guidance — they're not always enough across long or fresh sessions. The kit ships `scripts/block-forbidden-commit-patterns.sh` as a Claude Code `PreToolUse` hook that **blocks** forbidden Bash commands at the harness level, before they reach your repo. The model sees the denial reason (which pattern matched + the canonical commit form) and corrects.
+
+Opt-in, per machine: `scripts/install-scripts.sh --global` installs the script, then wire a one-time hook entry into `~/.claude/settings.json` (copy-pasteable snippet in [SETUP.md → Optional: commit-format enforcement hook](SETUP.md#optional-commit-format-enforcement-hook)). The hook explicitly allows `gh issue|pr|release` write-subcommands so describing the rules in issue/PR bodies isn't a false positive. Closes #236 (the deferred Option C from #204).
+
 ---
 
 ## Manual mode

--- a/SETUP.md
+++ b/SETUP.md
@@ -222,6 +222,60 @@ If acceptance tests are still pending, `/close-phase` will offer to run **`/run-
 
 ---
 
+## Optional: commit-format enforcement hook
+
+The kit's commit-format rules (no `Co-Authored-By: Claude` trailers, no `--no-verify` / `--no-gpg-sign` / `commit.gpgsign=false` bypasses, no "Generated with Claude Code" / 🤖 markers) live in `CONVENTIONS.md` and the auto-memory `feedback_commit_format` entry. Memory and prose are guidance — Claude *usually* honors them, but slip-ups happen, especially across long sessions or fresh ones that haven't fully internalized the rules.
+
+**The structural fix is a Claude Code [hook](https://docs.claude.com/en/docs/claude-code/hooks).** Hooks run on the harness side, so they reject forbidden commands *before* they reach your repo. The kit ships a ready-to-wire one as `scripts/block-forbidden-commit-patterns.sh` (installed to `~/.claude/scripts/` by `install-scripts.sh --global`).
+
+**Wire it once, on this machine:**
+
+1. Install the script (idempotent; skipped if already present):
+
+   ```bash
+   <kit-dir>/scripts/install-scripts.sh --global
+   ```
+
+2. Add a `PreToolUse` hook entry to `~/.claude/settings.json` pointing at the installed script. **Back up first**, then merge — don't replace any existing `permissions`/`hooks` blocks:
+
+   ```bash
+   cp ~/.claude/settings.json ~/.claude/settings.json.bak.$(date +%Y%m%d-%H%M%S)
+   ```
+
+   Snippet to merge into the file (combine with existing top-level keys):
+
+   ```json
+   {
+     "hooks": {
+       "PreToolUse": [
+         {
+           "matcher": "Bash",
+           "hooks": [
+             {
+               "type": "command",
+               "command": "/Users/<you>/.claude/scripts/block-forbidden-commit-patterns.sh"
+             }
+           ]
+         }
+       ]
+     }
+   }
+   ```
+
+   The `command` path must be absolute — Claude Code's hook matcher does not expand `~/` or `$HOME`. Substitute your actual home path.
+
+3. Reload settings. New sessions pick up the hook automatically; in an existing session, open `/hooks` once to refresh, or restart.
+
+**What it does.** Any `Bash` call whose command string contains a forbidden pattern is **denied** by the harness with a clear message naming which pattern matched and pointing at the canonical commit form. The model sees the denial and corrects (it doesn't retry blindly).
+
+**False-positive avoidance.** The hook explicitly *allows* `gh issue create / edit / comment`, `gh pr create / edit / comment`, and `gh release create / edit` — those write commands legitimately *describe* the forbidden patterns in their `--body` / `--notes` args (issue and PR bodies often document the rules they enforce). Everything else still goes through pattern detection.
+
+**Review / disable.** `/hooks` in Claude Code shows every wired hook and lets you toggle it for a session. To revert entirely: `mv ~/.claude/settings.json.bak.<timestamp> ~/.claude/settings.json`.
+
+This hook is the structural enforcement layer behind `feedback_commit_format` and the equivalent CONVENTIONS rules — it's the answer to ["A + B from #204 aren't always enough"](https://github.com/IamMrCupp/claude-project-kit/issues/236).
+
+---
+
 ## Manual alternative
 
 If you can't run `bootstrap.sh` (no Bash available, restricted environment, or you just want to see what it does) **or** you'd rather fill the templates by hand instead of running the seed prompt, perform the same work manually.

--- a/scripts/block-forbidden-commit-patterns.sh
+++ b/scripts/block-forbidden-commit-patterns.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# claude-project-kit hook — block forbidden commit-format patterns.
+# Wired in ~/.claude/settings.json as a PreToolUse Bash hook.
+# Receives Claude Code tool input as JSON on stdin; outputs a deny decision
+# JSON on stdout if a forbidden pattern is matched, otherwise exits silently.
+#
+# Patterns blocked (see CONVENTIONS.md / feedback_commit_format memory):
+#   - Co-Authored-By: ...Claude (any variant)
+#   - Co-Authored-By: ...bot trailer
+#   - "Generated with Claude Code" / 🤖 markers
+#   - --no-verify           (bypassing pre-commit hooks)
+#   - --no-gpg-sign         (bypassing GPG signing)
+#   - commit.gpgsign=false  (same, via `git -c` override)
+#
+# Triggered by claude-project-kit issue #204's Option C: hooks are the only
+# structural enforcement for these rules — memory/preferences can't reach
+# the harness. Pattern surfaced as 6 violations across 4 repos in 2 days.
+
+set -uo pipefail
+
+cmd=$(jq -r '.tool_input.command // empty' 2>/dev/null || printf '')
+[ -n "$cmd" ] || exit 0
+
+# False-positive avoidance: gh write-subcommands legitimately carry the
+# forbidden patterns inside their --body / --notes args (issue/PR bodies and
+# release notes routinely DESCRIBE these rules — that's not a commit). Let
+# them through. Anything else (including `git commit ...`, `echo ...`,
+# direct shell writes) still goes through the pattern check.
+case "$cmd" in
+  *"gh issue create"*|*"gh issue edit"*|*"gh issue comment"*) exit 0 ;;
+  *"gh pr create"*|*"gh pr edit"*|*"gh pr comment"*)          exit 0 ;;
+  *"gh release create"*|*"gh release edit"*)                  exit 0 ;;
+esac
+
+patterns=(
+  'co-authored-by:.*claude'
+  'co-authored-by:.*bot'
+  'generated with claude'
+  '🤖'
+  'commit\.gpgsign=false'
+  '--no-gpg-sign'
+  '--no-verify'
+)
+labels=(
+  'Co-Authored-By: ...Claude trailer'
+  'Co-Authored-By: ...bot trailer'
+  '"Generated with Claude Code" marker'
+  '🤖 marker (typical of "🤖 Generated with..." trailer)'
+  'commit.gpgsign=false (bypasses GPG signing)'
+  '--no-gpg-sign (bypasses GPG signing)'
+  '--no-verify (bypasses pre-commit hooks)'
+)
+
+matched=""
+for i in "${!patterns[@]}"; do
+  # `--` terminates grep's option parsing so patterns starting with `--`
+  # (--no-verify, --no-gpg-sign) aren't read as grep flags. Without this,
+  # macOS BSD grep silently fails on those two patterns and the hook
+  # would let the most-violated commands through.
+  if printf '%s' "$cmd" | grep -qiE -- "${patterns[$i]}"; then
+    matched="${labels[$i]}"
+    break
+  fi
+done
+
+if [ -n "$matched" ]; then
+  reason="Blocked by claude-project-kit commit-format hook: $matched. The kit's CONVENTIONS.md and feedback_commit_format memory forbid this pattern. Use 'git commit -s -m \"type(scope): subject\"' — single line, no body, no co-author trailer, no --no-verify / --no-gpg-sign / commit.gpgsign=false bypass. If a pre-commit hook is failing, fix the underlying issue rather than bypassing it. If you genuinely need to bypass for a specific commit (very rare), ask the user to disable the hook temporarily."
+  jq -n --arg r "$reason" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+  exit 0
+fi
+
+exit 0

--- a/scripts/install-scripts.sh
+++ b/scripts/install-scripts.sh
@@ -2,11 +2,19 @@
 # Install the kit's runtime helper scripts at user-level (~/.claude/scripts/)
 # or per-project (<repo>/.claude/scripts/).
 #
-# Currently ships one script:
+# Currently ships two scripts:
 #   - kit-print-memory-pointer.sh — the precheck helper invoked by every
 #     kit-coupled slash command and the session-summarizer agent. Extracted
 #     from the inline precheck Bash so the call is matchable by Claude
 #     Code's permission system (closes #218; see also #16800).
+#   - block-forbidden-commit-patterns.sh — PreToolUse Bash hook that
+#     enforces the kit's commit-format rules (no Co-Authored-By, no
+#     --no-verify / --no-gpg-sign / commit.gpgsign=false bypasses, no
+#     "Generated with Claude Code" / 🤖 markers). Installing the script
+#     is half the work; the other half is wiring it into ~/.claude/
+#     settings.json as a hook entry — see SETUP.md → "Optional commit-
+#     format enforcement hook" for the copy-pasteable snippet
+#     (closes #236; #204 Option C).
 #
 # Default behavior is write-once: never overwrites an existing file in the
 # target. Pass --force-update to overwrite kit-shipped files (with backup +
@@ -29,6 +37,7 @@ KIT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # when the kit grows more user-facing runtime helpers.
 SHIPPED_SCRIPTS=(
   kit-print-memory-pointer.sh
+  block-forbidden-commit-patterns.sh
 )
 
 usage() {

--- a/tests/commit_format_hook.bats
+++ b/tests/commit_format_hook.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# scripts/block-forbidden-commit-patterns.sh — the PreToolUse Bash hook that
+# enforces the kit's commit-format rules (#236 / #204 Option C).
+#
+# Tests pipe a synthetic Claude Code hook-input JSON to the script and check
+# whether it emits a deny-decision JSON (block) or exits silently (allow).
+# Two regression guards are explicit because both bugs hit during local
+# install before the test suite existed:
+#
+#   1. macOS BSD grep silently fails on patterns starting with `--`
+#      (--no-verify, --no-gpg-sign) unless `--` end-of-options is passed.
+#      Without the guard the most-violated commands quietly bypass the hook.
+#
+#   2. `gh issue|pr|release create/edit/comment` legitimately carry the
+#      forbidden patterns in --body / --notes args (issue/PR bodies
+#      describe the very rules we're enforcing). The allowlist must let
+#      them through; without it the hook chokes on its own documentation.
+
+load 'helpers'
+
+HOOK="$KIT_ROOT/scripts/block-forbidden-commit-patterns.sh"
+
+# Helper: pipe a synthetic Bash hook-input JSON to the hook script and capture
+# both stdout (deny JSON, if any) and exit code.
+hook_decision() {
+  local cmd="$1"
+  printf '{"tool_name":"Bash","tool_input":{"command":%s}}' \
+    "$(printf '%s' "$cmd" | jq -Rs .)" \
+    | "$HOOK"
+}
+
+# Helper: extract the permissionDecision from the script's stdout (empty if
+# the script wrote nothing — i.e., allowed the command).
+decision() {
+  hook_decision "$1" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null
+}
+
+# --- Smoke ---
+
+@test "hook script exists and is executable" {
+  [ -x "$HOOK" ]
+}
+
+@test "hook outputs nothing and exits 0 on empty stdin" {
+  run bash -c "printf '' | $HOOK"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "hook outputs nothing on benign JSON with no command" {
+  run bash -c "printf '%s' '{}' | $HOOK"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- Forbidden patterns (DENY) ---
+
+@test "blocks Co-Authored-By: Claude trailer" {
+  [ "$(decision 'git commit -m foo -m "Co-Authored-By: Claude <noreply@anthropic.com>"')" = "deny" ]
+}
+
+@test "blocks Co-Authored-By with bot-flavored trailer" {
+  [ "$(decision 'git commit -m foo -m "Co-Authored-By: SomeBot <bot@x.com>"')" = "deny" ]
+}
+
+@test "blocks Generated with Claude Code marker" {
+  [ "$(decision 'git commit -m foo -m "Generated with Claude Code"')" = "deny" ]
+}
+
+@test "blocks the 🤖 marker" {
+  [ "$(decision 'git commit -m "🤖 some message"')" = "deny" ]
+}
+
+@test "blocks commit.gpgsign=false via git -c" {
+  [ "$(decision 'git -c commit.gpgsign=false commit -m foo')" = "deny" ]
+}
+
+@test "blocks --no-gpg-sign flag (regression: BSD grep --)" {
+  # Without `--` terminating grep options, macOS BSD grep treats --no-gpg-sign
+  # as a grep flag, errors out, and the hook silently allows the command.
+  [ "$(decision 'git commit -m foo --no-gpg-sign')" = "deny" ]
+}
+
+@test "blocks --no-verify flag (regression: BSD grep --)" {
+  # Same regression as --no-gpg-sign — `--` end-of-options must guard this.
+  [ "$(decision 'git commit -m foo --no-verify')" = "deny" ]
+}
+
+@test "block reason names which pattern matched" {
+  reason=$(hook_decision 'git commit --no-verify' | jq -r '.hookSpecificOutput.permissionDecisionReason')
+  [[ "$reason" == *"--no-verify"* ]]
+  [[ "$reason" == *"feedback_commit_format"* ]]
+  [[ "$reason" == *"git commit -s -m"* ]]
+}
+
+# --- Allow cases ---
+
+@test "allows a clean commit (no forbidden tokens)" {
+  [ -z "$(decision 'git commit -s -m \"feat(scope): clean message\"')" ]
+}
+
+@test "allows unrelated bash commands" {
+  [ -z "$(decision 'ls -la')" ]
+  [ -z "$(decision 'gh issue list')" ]
+  [ -z "$(decision 'git log --oneline -5')" ]
+}
+
+# --- gh-allowlist (REGRESSION: false-positive on issue/PR bodies) ---
+
+@test "allows 'gh issue create' even with forbidden patterns in the --body" {
+  # Issue bodies legitimately describe these patterns (the rules they enforce).
+  # The hook MUST NOT block these.
+  [ -z "$(decision 'gh issue create --title foo --body "describes --no-verify and Co-Authored-By: Claude"')" ]
+}
+
+@test "allows 'gh pr create' with forbidden patterns in the --body" {
+  [ -z "$(decision 'gh pr create --body "explains git commit --no-verify is forbidden"')" ]
+}
+
+@test "allows 'gh issue edit' / 'gh pr edit' / 'gh issue comment' / 'gh pr comment'" {
+  [ -z "$(decision 'gh issue edit 1 --body "Co-Authored-By: Claude"')" ]
+  [ -z "$(decision 'gh pr edit 1 --body "🤖 Generated with Claude Code"')" ]
+  [ -z "$(decision 'gh issue comment 1 --body "uses --no-verify"')" ]
+  [ -z "$(decision 'gh pr comment 1 --body "uses --no-gpg-sign"')" ]
+}
+
+@test "allows 'gh release create' with forbidden patterns in --notes" {
+  [ -z "$(decision 'gh release create v1.0.0 --notes "patches Co-Authored-By: bot"')" ]
+}
+
+@test "the allowlist does NOT cover 'gh issue view' or 'gh pr view' — but those have no body args, so safe" {
+  # Sanity: read-only gh commands aren't in the allowlist explicitly, but they
+  # don't carry --body so they can't match the patterns anyway.
+  [ -z "$(decision 'gh issue view 1')" ]
+}


### PR DESCRIPTION
## Summary

Closes #236. Memory and prose were not enforcing the kit's commit-format rules — 6 violations across 4 repos in 2 days surfaced the gap. This ships the structural fix #204 deferred as Option C: a Claude Code `PreToolUse` Bash hook that **blocks** forbidden commit-format patterns at the harness level, before they reach your repo.

### What lands

- **`scripts/block-forbidden-commit-patterns.sh`** — the hook script. Inspects the Bash command on stdin and outputs a `permissionDecision: "deny"` JSON if any forbidden pattern matches. Blocked patterns: Co-Authored-By trailers (Claude / bot variants), "Generated with Claude Code" / 🤖 markers, `commit.gpgsign=false`, `--no-gpg-sign`, `--no-verify`.
- **`scripts/install-scripts.sh`** — registers the new script in `SHIPPED_SCRIPTS` so existing adopters pick it up on `upgrade.sh` and `--force-update` keeps it current.
- **`tests/commit_format_hook.bats`** — 18 tests covering every forbidden pattern, allow cases, and the two regression guards below.
- **`SETUP.md` → new "Optional: commit-format enforcement hook" section** — copy-pasteable `~/.claude/settings.json` snippet with backup steps and `/hooks` review pointer.
- **`CONVENTIONS.md`** — short note in Git & commits pointing at the hook as the structural enforcement layer.
- **`FEATURES.md`** — subsection under Conventions baseline.

**Opt-in by design.** The kit installs the script via `install-scripts.sh`, but wiring the hook into `~/.claude/settings.json` is a documented copy-paste so users stay in explicit control — consistent with `--with-labels` and `--trust-kit-paths`.

### Two regression guards baked into the tests

Both surfaced during local install of this exact script — without the test suite they would have shipped silently:

1. **`--` end-of-options on grep.** macOS BSD grep silently fails when patterns start with `--` (`--no-verify`, `--no-gpg-sign`) and the hook lets the most-violated commands through. Fixed with `grep -qiE -- "$pattern"`. Two dedicated tests pin the fix.
2. **gh-write-subcommand allowlist.** `gh issue create` / `gh pr create` / `gh release create` (+ edit / comment) legitimately carry the forbidden patterns in `--body` / `--notes` — issue and PR bodies routinely *describe* the rules. Without the allowlist the hook blocks its own documentation. Five tests pin the allowlist; one negative test confirms read-only `gh issue view` (which has no body args) stays out of scope.

### Live proof

The hook is already wired on the dev machine that built this PR — it blocked an `echo "...--no-verify..."` test call live in-session, and its existence is the reason the PR-creation Bash above didn't itself trip the hook (the allowlist let `gh pr create` through despite the forbidden patterns in this PR body).

## Test plan

- [x] `bats tests/commit_format_hook.bats` — 18/18 (5 deny patterns + 3 smoke + 5 allow + 2 BSD-grep regression + 2 gh-allowlist regression + 1 negative-control)
- [x] `bats tests/install_scripts.bats` — 8/8 (new script in `SHIPPED_SCRIPTS` flows through write-once + `--force-update` + dry-run + backup paths)
- [x] `bats tests/*.bats` — 379/379, no failures
- [x] Local-install validation: hook wired on dev machine, blocked a Bash call live in this session
- [ ] Render check — Aaron to verify SETUP / CONVENTIONS / FEATURES sections read cleanly on GitHub
- [ ] Adopter-side validation (post-merge) — run `upgrade.sh` on the four work repos; confirm `block-forbidden-commit-patterns.sh` installs to `~/.claude/scripts/`; wire the hook per SETUP; confirm 0 commit-format violations in next-week's dogfood

## Out of scope

- Branch-first Edit/Write hook (sibling failure shape; separate follow-up).
- Auto-wiring `~/.claude/settings.json` from `bootstrap.sh` — keep opt-in.

Closes #236