### PR TITLE
feat(bootstrap): --shared and --reference flags for shared repos (PR A of #199)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -515,51 +515,68 @@ Pass `--dry-run` to preview before committing:
 
 Some repos get pulled into more than one program of work — a shared `flux/k8s` config repo consumed by multiple platforms, an internal Terraform module repo touched by several initiatives, a Helm chart repo referenced from a handful of deployment programs. The kit's auto-memory keys to the **repo path**, so a single repo has exactly one canonical working folder; bootstrapping it twice under two different workspaces would clobber the auto-memory pointer each time.
 
-The current pattern (and the one [issue #199](https://github.com/IamMrCupp/claude-project-kit/issues/199) will turn into first-class tooling post-launch) is **standalone working folder + manual reference**: the shared repo gets its own canonical working folder outside any workspace, and each consuming workspace adds a reference pointer in its `workspace-CONTEXT.md` without creating a per-repo subfolder.
+The kit ships first-class support for this via two `bootstrap.sh` flags (PR A of [#199](https://github.com/IamMrCupp/claude-project-kit/issues/199)):
+
+- **`--shared`** — bootstraps the shared repo as a standalone working folder (no `--workspace`), and keeps an optional `## Referenced by` section in the seeded `CONTEXT.md` template so the shared repo's state can list which workspaces depend on it.
+- **`--workspace <ws> --reference <shared-wf>`** — bootstraps (or re-runs against) a workspace and declares that the workspace depends on the shared repo's standalone working folder. Adds a `## Shared repos` entry to the workspace's `workspace-CONTEXT.md` *without* creating a per-repo subfolder for the shared repo. **Read-only on the shared side** — never modifies the shared repo's working folder or auto-memory. Repeatable: pass `--reference` multiple times for several shared repos at once.
+
+The resulting layout:
 
 ```
 ~/Documents/Claude/Projects/
-├── shared-flux-config/              ← standalone working folder for the shared repo
+├── shared-flux-config/              ← standalone working folder (--shared)
 │   ├── CONTEXT.md                   ← canonical per-repo state lives here
+│   │   └── "## Referenced by" lists workspaces that use this repo
 │   ├── SESSION-LOG.md
 │   └── plan.md
 ├── platform-infra/                  ← workspace A
-│   ├── workspace-CONTEXT.md         ← "Shared repos" section pointing at shared-flux-config
-│   └── terraform-modules/
+│   ├── workspace-CONTEXT.md         ← "## Shared repos" entry → shared-flux-config
+│   └── terraform-modules/           ← per-repo subfolder for a non-shared repo
 └── data-platform/                   ← workspace B (same shared-repo reference)
     ├── workspace-CONTEXT.md
     └── ...
 ```
 
-**Bootstrap the shared repo as a standalone working folder** (no `--workspace`):
+**Step-by-step.** Bootstrap the shared repo once, then opt each workspace in:
 
 ```bash
-cd ~/Code/<shared-repo>
-~/Code/claude-project-kit/bootstrap.sh
-# Working folder lands at ~/Documents/Claude/Projects/<shared-repo-name>/
+# 1. Bootstrap the shared repo as a standalone working folder
+cd ~/Code/shared-flux-config
+~/Code/claude-project-kit/bootstrap.sh --shared
+# Working folder lands at ~/Documents/Claude/Projects/shared-flux-config/
+# CONTEXT.md gets the "## Referenced by" section ready for entries
+
+# 2. Bootstrap workspace A and declare the shared-repo reference
+cd ~/Code/platform-infra
+~/Code/claude-project-kit/bootstrap.sh \
+  --workspace ~/Documents/Claude/Projects/platform-infra/ \
+  --reference ~/Documents/Claude/Projects/shared-flux-config/
+
+# 3. Same for workspace B
+cd ~/Code/data-platform
+~/Code/claude-project-kit/bootstrap.sh \
+  --workspace ~/Documents/Claude/Projects/data-platform/ \
+  --reference ~/Documents/Claude/Projects/shared-flux-config/
 ```
 
-**Then add a "Shared repos" section by hand** to each consuming workspace's `workspace-CONTEXT.md`:
+After step 3, each workspace's `workspace-CONTEXT.md` has a populated `## Shared repos` section pointing at `shared-flux-config`. Edit the auto-generated entries to fill in the per-workspace "why" descriptions, and add matching entries to the shared repo's `## Referenced by` section by hand (the shared side stays user-curated).
 
-```markdown
-## Shared repos
+Re-running `bootstrap.sh --workspace <existing-ws> --reference <new-shared-wf>` from a different cwd against an existing workspace **appends** the new reference — useful when a workspace picks up dependency on another shared repo later.
 
-Repos referenced by this workspace whose canonical working folder lives elsewhere
-(see [issue #199](https://github.com/IamMrCupp/claude-project-kit/issues/199) for
-the formal `--reference` flag coming post-launch).
+**Why standalone + reference (and not symlinks or per-workspace copies):**
 
-- **shared-flux-config** — `~/Documents/Claude/Projects/shared-flux-config/`
-  - Used by this workspace for: cluster deployments + Argo manifests for current initiative
-  - Per-repo state (CONTEXT.md, SESSION-LOG.md, plan.md) is canonical at the standalone path; do not duplicate here
-```
-
-Why standalone+reference and not symlinks or per-workspace copies:
-
-- **One source of truth.** Branches, history, and SESSION-LOG entries for the shared repo live in one place. Per-workspace copies drift.
+- **One source of truth.** Branches, history, and SESSION-LOG entries for the shared repo live in one place. Per-workspace copies drift over time.
 - **Auto-memory stays consistent.** `reference_ai_working_folder.md` for the shared repo points at the standalone working folder regardless of which workspace you're working in.
 - **Symlinks are tooling-fragile.** Some tools don't follow them; future-you will be confused.
 
-When [#199](https://github.com/IamMrCupp/claude-project-kit/issues/199) lands post-launch, this becomes first-class with `--shared` and `--reference` flags + a `convert-to-shared.sh` migration helper. The manual pattern above will keep working — the migration helper formalizes it without breaking existing setups.
+#### Manual alternative
+
+If you can't run `bootstrap.sh` (no Bash available, restricted environment) or you prefer to wire the reference by hand:
+
+1. Bootstrap the shared repo as a regular single-repo working folder (no `--workspace`, no `--shared`).
+2. Add the `## Referenced by` and `## Shared repos` sections by hand using the template shape under the `<!-- BEGIN OPTIONAL: REFERENCED_BY -->` / `<!-- BEGIN OPTIONAL: SHARED_REPOS -->` markers in `templates/CONTEXT.md` and `templates/workspace/workspace-CONTEXT.md` respectively as the reference. Drop the marker comments — they're just there so `bootstrap.sh` knows what to strip when the flags aren't passed.
+
+For converting an existing per-repo subfolder under a workspace into a standalone shared working folder (the migration path), the upcoming `scripts/convert-to-shared.sh` helper from [#199 PR B](https://github.com/IamMrCupp/claude-project-kit/issues/199) will automate it. Until then, the manual flow is: `mv` the WF to its standalone path; edit `~/.claude/projects/<sanitized-repo-path>/memory/reference_ai_working_folder.md` to point at the new path; add a `## Shared repos` entry to the original workspace's `workspace-CONTEXT.md` referring to the new standalone path.
 
 ### What `--workspace` does NOT do (yet)
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -51,6 +51,25 @@ Options:
                      Subsequent runs against an existing workspace add new
                      repo subfolders without recreating workspace files.
                      See ADR-0001 in the kit for the workspace folder model.
+  --shared           Mark the working folder as a SHARED repo (a repo
+                     referenced by multiple workspaces — e.g. a flux/k8s
+                     config repo, shared Helm charts, shared Terraform
+                     modules). Seeds the CONTEXT.md template's optional
+                     "Referenced by" section so workspaces can be listed.
+                     Mutually exclusive with --workspace (a shared repo's
+                     working folder is itself standalone; workspaces opt
+                     into it via --reference, not by subfoldering it).
+                     See #199 / SETUP.md → "Shared repos across workspaces".
+  --reference PATH   Used with --workspace. Adds <PATH> (absolute path to a
+                     shared repo's working folder) to the workspace's
+                     workspace-CONTEXT.md "Shared repos" section so this
+                     workspace declares it depends on the shared repo
+                     without creating a per-repo subfolder for it. Read-only
+                     on the shared side — never modifies the shared repo's
+                     working folder or auto-memory. Repeatable: pass --reference
+                     multiple times to reference several shared repos at once.
+                     Works on first workspace creation AND on re-runs against
+                     an existing workspace (appends entries).
   --skip-memory      Skip copying memory-templates/ into the auto-memory
                      folder. Only the working folder will be seeded.
   --skip-scripts     Skip installing the kit's runtime helper scripts into
@@ -288,6 +307,73 @@ substitute_tracker_placeholders_in_dir() {
     fi
   done
   printf '%s' "$count"
+}
+
+# Optional-section management for shared-repos templates (#199).
+#
+# Templates carry `<!-- BEGIN OPTIONAL: <NAME> -->` ... `<!-- END OPTIONAL: <NAME> -->`
+# blocks around features that only apply in certain modes (shared-repo, workspace
+# with --reference). Default bootstrap strips the whole block; --shared / --reference
+# bootstrap keeps the content and strips just the markers.
+
+strip_optional_section() {
+  # Args: <file> <marker_name>
+  # Deletes everything from the BEGIN marker to the END marker inclusive.
+  local file="$1" name="$2"
+  sed "/<!-- BEGIN OPTIONAL: ${name} -->/,/<!-- END OPTIONAL: ${name} -->/d" \
+    "$file" > "$file.new" && mv "$file.new" "$file"
+}
+
+keep_optional_section() {
+  # Args: <file> <marker_name>
+  # Deletes just the BEGIN / END marker lines, keeping the content between them.
+  local file="$1" name="$2"
+  sed "/<!-- BEGIN OPTIONAL: ${name} -->/d; /<!-- END OPTIONAL: ${name} -->/d" \
+    "$file" > "$file.new" && mv "$file.new" "$file"
+}
+
+append_shared_repo_entries() {
+  # Args: <workspace-CONTEXT.md path> <shared-wf-path> [<shared-wf-path> ...]
+  # Inserts one bullet per shared-wf-path right after the placeholder bullet line
+  # (preferred), the "## Shared repos" header (fallback for hand-edited files), or
+  # appends a fresh section at EOF (for pre-#199 workspaces that have no section
+  # at all). No-op if no paths given.
+  local file="$1"; shift
+  [ $# -gt 0 ] || return 0
+  local paths=("$@")
+
+  local anchor=""
+  if grep -Fq -- '- {{SHARED_REPO_NAME}}' "$file"; then
+    anchor='- {{SHARED_REPO_NAME}}'
+  elif grep -Fq '## Shared repos' "$file"; then
+    anchor='## Shared repos'
+  else
+    # No section at all — append a fresh one at EOF (pre-#199 workspace path).
+    {
+      printf '\n---\n\n## Shared repos\n\n'
+      printf '%s\n\n' '<!-- Added by `bootstrap.sh --reference` (workspace pre-dates #199 template; section seeded at EOF). -->'
+      local path name
+      for path in "${paths[@]}"; do
+        name="$(basename "$path")"
+        printf -- '- %s — `%s` — TODO: describe why this workspace uses it\n' "$name" "$path"
+      done
+    } >> "$file"
+    return 0
+  fi
+
+  # Iterate in REVERSE so the final layout matches argument order. (awk's -v
+  # variables can't carry embedded newlines portably on macOS, so insert one
+  # entry per pass instead of batching.)
+  local i path name entry
+  for ((i = ${#paths[@]} - 1 ; i >= 0 ; i--)); do
+    path="${paths[$i]}"
+    name="$(basename "$path")"
+    entry="- ${name} — \`${path}\` — TODO: describe why this workspace uses it"
+    awk -v anchor="$anchor" -v entry="$entry" '
+      { print }
+      index($0, anchor) == 1 && !done { print entry; done = 1 }
+    ' "$file" > "$file.new" && mv "$file.new" "$file"
+  done
 }
 
 kit_version() {
@@ -740,6 +826,8 @@ DRY_RUN=0
 WORKSPACE_MODE=0
 TRUST_KIT_PATHS=0
 WITH_LABELS=0
+SHARED_MODE=0
+REFERENCE_PATHS=()
 WORKING_FOLDER=""
 PROJECT_NAME=""
 TRACKER=""
@@ -801,6 +889,16 @@ while [ $# -gt 0 ]; do
     --force) FORCE=1; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     --workspace) WORKSPACE_MODE=1; shift ;;
+    --shared) SHARED_MODE=1; shift ;;
+    --reference)
+      if [ $# -lt 2 ]; then
+        echo "error: --reference requires a path" >&2
+        usage >&2
+        exit 2
+      fi
+      REFERENCE_PATHS+=("$2")
+      shift 2
+      ;;
     --trust-kit-paths) TRUST_KIT_PATHS=1; shift ;;
     --trust-working-folder-root)
       echo "warning: --trust-working-folder-root is deprecated; use --trust-kit-paths (same combined behavior, plus adds the precheck script to permissions.allow)." >&2
@@ -866,6 +964,24 @@ while [ $# -gt 0 ]; do
       ;;
   esac
 done
+
+# --shared and --workspace are mutually exclusive: a shared repo's working
+# folder is standalone (not itself a workspace); workspaces reference it via
+# --reference. --reference requires --workspace because references are how
+# *workspaces* opt into a shared repo.
+if [ "$SHARED_MODE" -eq 1 ] && [ "$WORKSPACE_MODE" -eq 1 ]; then
+  echo "error: --shared and --workspace are mutually exclusive" >&2
+  echo "       A shared repo's working folder is standalone; workspaces reference it" >&2
+  echo "       via --workspace <ws> --reference <shared-wf>." >&2
+  exit 2
+fi
+if [ "${#REFERENCE_PATHS[@]}" -gt 0 ] && [ "$WORKSPACE_MODE" -eq 0 ]; then
+  echo "error: --reference requires --workspace" >&2
+  echo "       References are how a workspace opts into a shared repo's standalone" >&2
+  echo "       working folder. Without --workspace there's no workspace-CONTEXT.md" >&2
+  echo "       to add the reference to." >&2
+  exit 2
+fi
 
 if [ -n "$JIRA_PROJECT_KEY" ] && [ -z "$TRACKER" ]; then
   TRACKER="jira"
@@ -1092,17 +1208,36 @@ if [ "$DRY_RUN" -eq 1 ]; then
     echo "Workspace dir: $WORKSPACE_DIR"
     if [ -f "$WORKSPACE_DIR/workspace-CONTEXT.md" ]; then
       echo "  ✓ existing workspace (workspace-CONTEXT.md present) — no workspace-level changes"
+      if [ "${#REFERENCE_PATHS[@]}" -gt 0 ]; then
+        echo "  + append ${#REFERENCE_PATHS[@]} shared-repo reference(s) to workspace-CONTEXT.md:"
+        for ref in "${REFERENCE_PATHS[@]}"; do
+          echo "      - $(basename "$ref") — $ref"
+        done
+      fi
     else
       echo "  + create workspace dir + tickets/archive/"
       echo "  + copy $KIT_ROOT/templates/workspace/workspace-CONTEXT.md → workspace-CONTEXT.md"
       echo "  + copy $KIT_ROOT/templates/workspace/workspace-plan.md → workspace-plan.md"
       echo "  + copy $KIT_ROOT/templates/workspace/workspace-phase-N-checklist.md → workspace-phase-N-checklist.md"
+      if [ "${#REFERENCE_PATHS[@]}" -gt 0 ]; then
+        echo "  + keep workspace-CONTEXT.md 'Shared repos' section + populate ${#REFERENCE_PATHS[@]} entry/entries:"
+        for ref in "${REFERENCE_PATHS[@]}"; do
+          echo "      - $(basename "$ref") — $ref"
+        done
+      else
+        echo "  + strip optional 'Shared repos' section from workspace-CONTEXT.md (no --reference)"
+      fi
     fi
     echo
   fi
   echo "Would create working folder: $WORKING_FOLDER"
   echo "  + copy $KIT_ROOT/templates/*.md"
   echo "  + rename phase-N-checklist.md → phase-0-checklist.md"
+  if [ "$SHARED_MODE" -eq 1 ]; then
+    echo "  + keep CONTEXT.md 'Referenced by' section (--shared)"
+  else
+    echo "  + strip optional 'Referenced by' section from CONTEXT.md"
+  fi
   if [ -d "$KIT_ROOT/templates/.claude" ]; then
     echo "  + copy templates/.claude/ → $WORKING_FOLDER/.claude/ (starter agents + commands)"
   fi
@@ -1235,15 +1370,35 @@ if [ "$WORKSPACE_MODE" -eq 1 ]; then
     cp "$KIT_ROOT/templates/workspace/workspace-CONTEXT.md" "$WORKSPACE_DIR/"
     cp "$KIT_ROOT/templates/workspace/workspace-plan.md" "$WORKSPACE_DIR/"
     cp "$KIT_ROOT/templates/workspace/workspace-phase-N-checklist.md" "$WORKSPACE_DIR/"
+    # --reference (#199): keep the Shared repos section + populate; otherwise strip it.
+    if [ "${#REFERENCE_PATHS[@]}" -gt 0 ]; then
+      keep_optional_section "$WORKSPACE_DIR/workspace-CONTEXT.md" "SHARED_REPOS"
+      append_shared_repo_entries "$WORKSPACE_DIR/workspace-CONTEXT.md" "${REFERENCE_PATHS[@]}"
+    else
+      strip_optional_section "$WORKSPACE_DIR/workspace-CONTEXT.md" "SHARED_REPOS"
+    fi
     echo "  ✓ Created workspace at $WORKSPACE_DIR (workspace-CONTEXT.md, workspace-plan.md, workspace-phase-N-checklist.md, tickets/archive/)"
     WORKSPACE_FIRST_REPO=1
   else
     echo "  ✓ Existing workspace at $WORKSPACE_DIR — adding repo subfolder $WORKSPACE_REPO_NAME"
+    # --reference on a re-run against an existing workspace: append to whatever's there
+    # (post-#199 section, pre-#199 file with no section, or hand-edited).
+    if [ "${#REFERENCE_PATHS[@]}" -gt 0 ]; then
+      append_shared_repo_entries "$WORKSPACE_DIR/workspace-CONTEXT.md" "${REFERENCE_PATHS[@]}"
+      echo "  ✓ Added ${#REFERENCE_PATHS[@]} shared-repo reference(s) to workspace-CONTEXT.md"
+    fi
   fi
 fi
 
 cp "$KIT_ROOT/templates/"*.md "$WORKING_FOLDER/"
 mv "$WORKING_FOLDER/phase-N-checklist.md" "$WORKING_FOLDER/phase-0-checklist.md"
+# --shared (#199): keep the Referenced by section in the seeded CONTEXT.md;
+# otherwise strip it so non-shared repos don't see the optional content.
+if [ "$SHARED_MODE" -eq 1 ]; then
+  keep_optional_section "$WORKING_FOLDER/CONTEXT.md" "REFERENCED_BY"
+else
+  strip_optional_section "$WORKING_FOLDER/CONTEXT.md" "REFERENCED_BY"
+fi
 echo "  ✓ Copied template files to $WORKING_FOLDER"
 echo "  ✓ Renamed phase-N-checklist.md → phase-0-checklist.md"
 

--- a/templates/CONTEXT.md
+++ b/templates/CONTEXT.md
@@ -25,6 +25,21 @@ At the start of any new Claude session, say:
 
 ---
 
+<!-- BEGIN OPTIONAL: REFERENCED_BY -->
+## Referenced by
+
+<!-- Present when this repo is a **shared repo** used by multiple workspaces (seeded
+     by `bootstrap.sh --shared`). Each workspace's bootstrap (`--workspace … --reference
+     <this-wf>`) appends a row below. Edit by hand as workspaces are added/removed.
+     If this repo isn't shared across workspaces, remove this whole section. -->
+
+- {{WORKSPACE_NAME}} — `{{path/to/workspace-CONTEXT.md}}` — {{one-line context: why this workspace uses this repo}}
+
+See `SETUP.md` → *Shared repos across workspaces* for the pattern.
+
+---
+<!-- END OPTIONAL: REFERENCED_BY -->
+
 ## Tracker Configuration
 
 The external tracker for this project, used when work is ticket-driven. See `CONVENTIONS.md` (kit-level — `## Ticket-driven workflows`) for the branch / PR / commit conventions to use against a tracker.

--- a/templates/workspace/workspace-CONTEXT.md
+++ b/templates/workspace/workspace-CONTEXT.md
@@ -72,6 +72,23 @@ See `CONVENTIONS.md` (kit-level — `## Ticket-driven workflows`) for the branch
 
 ---
 
+<!-- BEGIN OPTIONAL: SHARED_REPOS -->
+## Shared repos
+
+<!-- Repos this workspace references but does NOT subfolder here — their working
+     folders live standalone (one canonical state, shared across workspaces). Seeded
+     by `bootstrap.sh --workspace <this> --reference <shared-wf>` (repeatable).
+     Each entry: name — absolute path to the shared repo's working folder — why
+     this workspace uses it. Edit by hand as references are added/removed.
+     If this workspace doesn't reference any shared repos, remove this whole section.
+
+     See `SETUP.md` → *Shared repos across workspaces* for the pattern. -->
+
+- {{SHARED_REPO_NAME}} — `{{absolute/path/to/shared-repo-working-folder}}` — {{why this workspace uses it}}
+
+---
+<!-- END OPTIONAL: SHARED_REPOS -->
+
 ## Tickets
 
 Active per-ticket scratchpads live under `tickets/<KEY>-<slug>.md`. Closed ticket files move to `tickets/archive/`.

--- a/tests/bootstrap_shared.bats
+++ b/tests/bootstrap_shared.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+# bootstrap.sh --shared / --reference flags (#199 PR A).
+#
+# Two new flags + two new optional template sections:
+#   --shared              — keeps CONTEXT.md "Referenced by" section in the seeded WF
+#   --workspace + --reference <path> — keeps workspace-CONTEXT.md "Shared repos"
+#                                       section and populates one bullet per --reference
+#
+# Default behavior (neither flag) strips both optional sections, so non-shared
+# repos and non-referencing workspaces don't see clutter from features that
+# don't apply to them.
+
+load 'helpers'
+
+setup() { bootstrap_setup; }
+teardown() { bootstrap_teardown; }
+
+# --- Help text ---
+
+@test "bootstrap.sh -h documents --shared and --reference" {
+  run "$BOOTSTRAP" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--shared"* ]]
+  [[ "$output" == *"--reference PATH"* ]]
+  [[ "$output" == *"Mutually exclusive with --workspace"* ]]
+}
+
+# --- Default (no --shared, no --reference) — both optional sections stripped ---
+
+@test "default bootstrap strips the 'Referenced by' section from CONTEXT.md" {
+  run "$BOOTSTRAP" "$TEST_WF" --skip-memory --skip-scripts --no-gitignore
+  [ "$status" -eq 0 ]
+  ! grep -q "BEGIN OPTIONAL: REFERENCED_BY" "$TEST_WF/CONTEXT.md"
+  ! grep -q "^## Referenced by$" "$TEST_WF/CONTEXT.md"
+}
+
+@test "default workspace bootstrap strips the 'Shared repos' section from workspace-CONTEXT.md" {
+  WS="$TEST_TMP/ws"
+  run "$BOOTSTRAP" --workspace "$WS" --skip-memory --skip-scripts --no-gitignore
+  [ "$status" -eq 0 ]
+  ! grep -q "BEGIN OPTIONAL: SHARED_REPOS" "$WS/workspace-CONTEXT.md"
+  ! grep -q "^## Shared repos$" "$WS/workspace-CONTEXT.md"
+}
+
+# --- --shared keeps the section ---
+
+@test "--shared keeps the 'Referenced by' section in CONTEXT.md (markers stripped, content retained)" {
+  run "$BOOTSTRAP" "$TEST_WF" --shared --skip-memory --skip-scripts --no-gitignore
+  [ "$status" -eq 0 ]
+  grep -q "^## Referenced by$" "$TEST_WF/CONTEXT.md"
+  ! grep -q "BEGIN OPTIONAL: REFERENCED_BY" "$TEST_WF/CONTEXT.md"
+  ! grep -q "END OPTIONAL: REFERENCED_BY" "$TEST_WF/CONTEXT.md"
+}
+
+# --- Mutual exclusion + dependency errors ---
+
+@test "--shared + --workspace errors with a clear message" {
+  WS="$TEST_TMP/ws"
+  run "$BOOTSTRAP" --shared --workspace "$WS"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--shared and --workspace are mutually exclusive"* ]]
+}
+
+@test "--reference without --workspace errors" {
+  run "$BOOTSTRAP" --reference "$TEST_TMP/shared-wf" "$TEST_WF"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--reference requires --workspace"* ]]
+}
+
+@test "--reference without a path argument errors" {
+  run "$BOOTSTRAP" --reference --workspace "$TEST_TMP/ws"
+  [ "$status" -eq 2 ]
+  # Either "requires a path" (preferred) or "unknown option" (fallback) is acceptable —
+  # both signal the same problem and exit non-zero. Just verify it doesn't silently swallow.
+}
+
+# --- --workspace --reference populates the Shared repos section ---
+
+@test "--workspace --reference populates the 'Shared repos' section with one entry" {
+  WS="$TEST_TMP/ws"
+  SHARED="$TEST_TMP/shared-flux-config"
+  run "$BOOTSTRAP" --workspace "$WS" --reference "$SHARED" --skip-memory --skip-scripts --no-gitignore
+  [ "$status" -eq 0 ]
+  grep -q "^## Shared repos$" "$WS/workspace-CONTEXT.md"
+  ! grep -q "BEGIN OPTIONAL: SHARED_REPOS" "$WS/workspace-CONTEXT.md"
+  grep -q "shared-flux-config — \`$SHARED\`" "$WS/workspace-CONTEXT.md"
+}
+
+@test "--reference is repeatable and preserves argument order" {
+  WS="$TEST_TMP/ws"
+  S1="$TEST_TMP/shared-alpha"
+  S2="$TEST_TMP/shared-bravo"
+  S3="$TEST_TMP/shared-charlie"
+  run "$BOOTSTRAP" --workspace "$WS" \
+    --reference "$S1" --reference "$S2" --reference "$S3" \
+    --skip-memory --skip-scripts --no-gitignore
+  [ "$status" -eq 0 ]
+  # Extract Shared repos bullet lines in file order
+  ORDER=$(grep -E '^- shared-' "$WS/workspace-CONTEXT.md" | awk -F' — ' '{print $1}' | tr '\n' ',')
+  [ "$ORDER" = "- shared-alpha,- shared-bravo,- shared-charlie," ]
+}
+
+# --- Re-run against an existing workspace appends new --reference entries ---
+
+@test "re-running --workspace --reference on an existing workspace appends new entries" {
+  WS="$TEST_TMP/ws"
+  S1="$TEST_TMP/shared-first"
+  S2="$TEST_TMP/shared-second"
+
+  # First run creates the workspace + populates S1
+  run "$BOOTSTRAP" --workspace "$WS" --reference "$S1" --skip-memory --skip-scripts --no-gitignore
+  [ "$status" -eq 0 ]
+  grep -q "shared-first" "$WS/workspace-CONTEXT.md"
+
+  # Second run from a different "repo" cwd adds S2 to the same workspace
+  OTHER="$TEST_TMP/other-repo"
+  mkdir -p "$OTHER" && git -C "$OTHER" init -q
+  cd "$OTHER"
+  run "$BOOTSTRAP" --workspace "$WS" --reference "$S2" --skip-memory --skip-scripts --no-gitignore
+  [ "$status" -eq 0 ]
+  grep -q "shared-first" "$WS/workspace-CONTEXT.md"
+  grep -q "shared-second" "$WS/workspace-CONTEXT.md"
+}
+
+# --- Dry-run shows the plan without writing ---
+
+@test "--shared --dry-run previews 'Referenced by' kept and writes nothing" {
+  run "$BOOTSTRAP" "$TEST_WF" --shared --dry-run --skip-memory --skip-scripts --no-gitignore
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"keep CONTEXT.md 'Referenced by' section"* ]]
+  [ ! -d "$TEST_WF" ] || [ -z "$(ls -A "$TEST_WF" 2>/dev/null)" ]
+}
+
+@test "default --dry-run mentions stripping the 'Referenced by' section" {
+  run "$BOOTSTRAP" "$TEST_WF" --dry-run --skip-memory --skip-scripts --no-gitignore
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"strip optional 'Referenced by' section"* ]]
+}
+
+@test "--workspace --reference --dry-run previews populated entries" {
+  WS="$TEST_TMP/ws"
+  SHARED="$TEST_TMP/shared-foo"
+  run "$BOOTSTRAP" --workspace "$WS" --reference "$SHARED" --dry-run \
+    --skip-memory --skip-scripts --no-gitignore
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Shared repos"* ]]
+  [[ "$output" == *"shared-foo"* ]]
+  [ ! -d "$WS" ]
+}


### PR DESCRIPTION
## Summary

First of three PRs implementing #199 — shared repos across workspaces — per the plan-and-stop artifact at `plan-shared-repos.md` in the working folder.

This PR is the **usable** half: new bootstrap flags + template sections make the pattern available for new projects. PR B (migration helper for existing per-repo subfolders) and PR C (/session-start awareness + ADR-0003) follow.

### What lands

- **`bootstrap.sh --shared`** — variant of single-repo bootstrap that keeps an optional `## Referenced by` section in the seeded `CONTEXT.md` template, so the shared repo's state can list which workspaces depend on it. Mutually exclusive with `--workspace` (a shared repo's WF is standalone; it doesn't subfolder under a workspace).
- **`bootstrap.sh --workspace <ws> --reference <shared-wf>`** — repeatable. Adds a `## Shared repos` entry (one per `--reference`) to the workspace's `workspace-CONTEXT.md` without creating a per-repo subfolder for the shared repo. **Read-only on the shared side** — never modifies the shared repo's WF or auto-memory. Works on first workspace creation AND on re-runs against an existing workspace (appends entries).
- **Template sections** — `templates/CONTEXT.md` gets an optional `## Referenced by` block; `templates/workspace/workspace-CONTEXT.md` gets an optional `## Shared repos` block. Both wrapped in `<!-- BEGIN OPTIONAL: NAME -->` / `<!-- END OPTIONAL: NAME -->` markers so default bootstrap (no flags) strips them cleanly — non-shared repos and non-referencing workspaces don't see clutter.
- **Helpers** — `strip_optional_section` / `keep_optional_section` / `append_shared_repo_entries` in `bootstrap.sh`. The append helper has three fallback paths (placeholder bullet present → insert after it; section header but no placeholder → insert after header; no section at all → append fresh section at EOF, for pre-#199 workspaces).
- **`tests/bootstrap_shared.bats`** — 13 tests covering help text, default-strip behavior, `--shared` keep behavior, mutual-exclusion errors, single + repeatable `--reference` (with argument order preserved), re-run-against-existing-workspace append, and `--dry-run` preview for all paths.
- **`SETUP.md` → "Shared repos across workspaces"** — rewritten as the first-class flag walkthrough; the existing v0.39.1 manual workaround text is refolded as a "Manual alternative" sub-section per the kit's existing pattern.

### Design call worth noting

The append helper iterates `REFERENCE_PATHS` in **reverse** when inserting into the file. Reason: awk's `-v` variables can't carry embedded newlines portably on macOS BSD awk, so we insert one entry per awk pass instead of batching. Inserting in reverse + always-after-anchor gives the final file the original argument order. Verified via the "preserves argument order" bats test.

### Bug caught by the smoke loop (worth flagging)

First implementation tried to batch entries into a single multi-line awk `-v` variable. macOS awk rejected the embedded newlines with `awk: newline in string`. Caught immediately by a 3-case smoke before any code shipped; refactored to the reverse-iteration pattern above. Test #9 (argument-order preservation) pins the fix.

## Test plan

- [x] `bats tests/bootstrap_shared.bats` — 13/13 (help, strip/keep, mutex, repeatable, re-run, dry-run)
- [x] `bats tests/*.bats` — 392/392, no failures (no cross-test regressions; existing `bootstrap_args` / `bootstrap_dry_run` / `bootstrap_constraints` all green)
- [x] Smoke: 7 manual scenarios (default strip; `--shared` keep; `--workspace --reference` populate; multi-reference order; re-run from different cwd appends; both mutex errors fire correctly)
- [x] The commit-format hook from #237 vetted this PR's `gh pr create` (allowlist let it through despite the issue-body wording)
- [ ] Render check on GitHub — SETUP section + the new template sections in `templates/CONTEXT.md` and `templates/workspace/workspace-CONTEXT.md` — Aaron to verify
- [ ] Adopter dogfood — bootstrap a `--shared` working folder for a real shared repo on this machine and a `--reference` flow on a real workspace — can do post-merge once you have a real shared repo handy

## What's next (per the plan)

- **PR B** — `scripts/convert-to-shared.sh` migration helper for existing per-repo subfolders.
- **PR C** — `/session-start` slash command surfacing of the `## Referenced by` list + ADR-0003 documenting the design + rejected alternatives.

Each stays independently reviewable.

Refs #199