### PR TITLE
feat(scripts): convert-to-shared.sh migration helper (PR B of #199)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -576,12 +576,37 @@ If you can't run `bootstrap.sh` (no Bash available, restricted environment) or y
 1. Bootstrap the shared repo as a regular single-repo working folder (no `--workspace`, no `--shared`).
 2. Add the `## Referenced by` and `## Shared repos` sections by hand using the template shape under the `<!-- BEGIN OPTIONAL: REFERENCED_BY -->` / `<!-- BEGIN OPTIONAL: SHARED_REPOS -->` markers in `templates/CONTEXT.md` and `templates/workspace/workspace-CONTEXT.md` respectively as the reference. Drop the marker comments — they're just there so `bootstrap.sh` knows what to strip when the flags aren't passed.
 
-For converting an existing per-repo subfolder under a workspace into a standalone shared working folder (the migration path), the upcoming `scripts/convert-to-shared.sh` helper from [#199 PR B](https://github.com/IamMrCupp/claude-project-kit/issues/199) will automate it. Until then, the manual flow is: `mv` the WF to its standalone path; edit `~/.claude/projects/<sanitized-repo-path>/memory/reference_ai_working_folder.md` to point at the new path; add a `## Shared repos` entry to the original workspace's `workspace-CONTEXT.md` referring to the new standalone path.
+#### Migrating an existing per-repo subfolder into a standalone shared working folder
+
+If a repo currently lives as a per-repo subfolder under a workspace and you want to promote it to a standalone shared repo (so other workspaces can reference it), use `scripts/convert-to-shared.sh`:
+
+```bash
+# Default target path (~/Documents/Claude/Projects/<repo-basename>/)
+~/Code/claude-project-kit/scripts/convert-to-shared.sh ~/Code/shared-flux-config
+
+# Custom target + multiple workspaces get the back-reference at once
+~/Code/claude-project-kit/scripts/convert-to-shared.sh ~/Code/shared-flux-config \
+  --to ~/Documents/Claude/Projects/shared-flux/ \
+  --reference-from ~/Documents/Claude/Projects/data-platform/ \
+  --reference-from ~/Documents/Claude/Projects/ml-platform/
+
+# Preview before applying
+~/Code/claude-project-kit/scripts/convert-to-shared.sh ~/Code/shared-flux-config --dry-run
+```
+
+The script:
+
+- `mv`s the per-repo working folder out of the workspace into the standalone path (the default falls back to `<basename>-<sanitized-org>` if there's a name collision).
+- Repoints `~/.claude/projects/<sanitized-repo-path>/memory/reference_ai_working_folder.md` to the new path. **This file is normally never modified by the kit** — the migration justifies the write with a `.bak.<timestamp>` backup, a `--dry-run` preview, and a confirmation prompt (pass `--yes` to skip).
+- Appends a "Shared repos" entry to the source workspace's `workspace-CONTEXT.md` pointing at the new standalone path. Repeatable `--reference-from <other-workspace>` adds the same entry to additional workspaces in one go.
+- Backs up every mutated file before writing, so a botched migration is fully recoverable.
+- Refuses to proceed if the repo isn't currently a per-repo subfolder under a workspace, or if the target standalone path already exists.
+
+After the script runs, the source workspace's `## Repos in this workspace` table still has the old per-repo row — review and remove it by hand if you want the table to reflect the new shared status (the new `## Shared repos` section is the source of truth going forward).
 
 ### What `--workspace` does NOT do (yet)
 
 - **Interactive workspace prompt** — `--workspace` requires the explicit flag. Interactive mode still defaults to single-repo. Use the flag-based form above for workspace bootstraps.
-- **Shared-repo flags** — `--shared` and `--reference` for repos consumed by multiple workspaces. Tracked in [#199](https://github.com/IamMrCupp/claude-project-kit/issues/199); the manual pattern is documented in [Shared repos across workspaces](#shared-repos-across-workspaces) above.
 
 (Tracker config substitution into `CONTEXT.md` / `workspace-CONTEXT.md` and the Terraform sibling-repo prompt landed in v0.17.0. The interactive workspace prompt is the only remaining `--workspace` polish item.)
 

--- a/scripts/convert-to-shared.sh
+++ b/scripts/convert-to-shared.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+# convert-to-shared.sh — migrate a repo's per-repo working folder out of a
+# workspace into a standalone shared working folder (#199 PR B).
+#
+# Counterpart to `bootstrap.sh --shared / --reference`. After migration the
+# repo's working folder lives standalone (one canonical state), the auto-memory
+# pointer is repointed to the new location, and the source workspace (+ any
+# additional workspaces passed via --reference-from) gain a "Shared repos"
+# entry pointing back at the new standalone path.
+#
+# Every file mutation gets a .bak.<timestamp> backup. --dry-run previews.
+#
+# CONSTRAINT: This script never touches an external tracker. It only moves
+# local working-folder state + appends to local workspace-CONTEXT.md files +
+# updates the auto-memory pointer. See ADR-0001 D3 and the kit's
+# CONVENTIONS.md "Ticket-driven workflows → What the kit does NOT do with
+# trackers".
+set -euo pipefail
+
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "error: convert-to-shared.sh requires bash" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KIT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/infer.sh
+. "$SCRIPT_DIR/lib/infer.sh"
+
+usage() {
+  cat <<EOF
+Usage: convert-to-shared.sh <repo-path> [options]
+
+Migrate a repo's per-repo working folder out of its current workspace into a
+standalone shared working folder. The repo continues to work as a kit project;
+the workspace it left gains a "Shared repos" entry pointing at the new path.
+
+Arguments:
+  <repo-path>            Absolute path to the repo whose working folder will be
+                         migrated. Must currently be a per-repo subfolder under
+                         a workspace (i.e. its working folder's parent must
+                         contain workspace-CONTEXT.md).
+
+Options:
+  --to PATH              Target standalone working-folder path. If omitted,
+                         defaults to ~/Documents/Claude/Projects/<repo-basename>/.
+                         If that default collides with an existing directory,
+                         the script falls back to <basename>-<sanitized-org>
+                         (derived from \`git remote get-url origin\`) and
+                         prints the chosen path so you can override with --to.
+  --reference-from WS    Repeatable. Absolute path to ANOTHER workspace that
+                         should also reference the now-shared repo. One
+                         "Shared repos" bullet is appended to each WS's
+                         workspace-CONTEXT.md. The source workspace (where
+                         the per-repo subfolder currently lives) ALWAYS gets
+                         the entry; --reference-from adds additional ones.
+  --dry-run              Print the plan and exit. No files moved or modified.
+  --yes                  Skip the confirmation prompt before applying. Useful
+                         for scripted runs.
+  -h, --help             Show this help and exit.
+
+Behavior:
+  - The auto-memory file ~/.claude/projects/<sanitized-repo-path>/memory/
+    reference_ai_working_folder.md is repointed from the old per-repo subfolder
+    to the new standalone path. This file is normally never modified by the
+    kit; the migration justifies the write with a backup + dry-run preview +
+    confirmation prompt.
+  - workspace-CONTEXT.md files are appended-to in place (with backups).
+    The script never removes the existing per-repo entry from the source
+    workspace's "Repos in this workspace" table — review and edit by hand
+    after migration if you want the table to reflect the new shared status.
+
+Examples:
+  # Default (target dir from basename, source workspace gets the back-reference)
+  convert-to-shared.sh ~/Code/shared-flux-config
+
+  # Custom target path
+  convert-to-shared.sh ~/Code/shared-flux-config \\
+    --to ~/Documents/Claude/Projects/flux-shared/
+
+  # Multi-workspace reference: source workspace + two others get the entry
+  convert-to-shared.sh ~/Code/shared-flux-config \\
+    --reference-from ~/Documents/Claude/Projects/data-platform/ \\
+    --reference-from ~/Documents/Claude/Projects/ml-platform/
+
+  # Preview before applying
+  convert-to-shared.sh ~/Code/shared-flux-config --dry-run
+EOF
+}
+
+REPO_PATH=""
+TO_PATH=""
+REFERENCE_FROM=()
+DRY_RUN=0
+ASSUME_YES=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --yes) ASSUME_YES=1; shift ;;
+    --to)
+      if [ $# -lt 2 ]; then
+        echo "error: --to requires a path" >&2
+        usage >&2
+        exit 2
+      fi
+      TO_PATH="$2"; shift 2 ;;
+    --reference-from)
+      if [ $# -lt 2 ]; then
+        echo "error: --reference-from requires a path" >&2
+        usage >&2
+        exit 2
+      fi
+      REFERENCE_FROM+=("$2"); shift 2 ;;
+    --*) echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *)
+      if [ -z "$REPO_PATH" ]; then
+        REPO_PATH="$1"
+      else
+        echo "error: unexpected extra argument: $1" >&2
+        usage >&2
+        exit 2
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$REPO_PATH" ]; then
+  echo "error: <repo-path> argument is required" >&2
+  usage >&2
+  exit 2
+fi
+
+case "$REPO_PATH" in
+  "~"|"~/"*) REPO_PATH="${REPO_PATH/#\~/$HOME}" ;;
+esac
+case "$REPO_PATH" in
+  /*) ;;
+  *) echo "error: <repo-path> must be an absolute path (got: $REPO_PATH)" >&2; exit 2 ;;
+esac
+if [ ! -d "$REPO_PATH" ]; then
+  echo "error: <repo-path> does not exist: $REPO_PATH" >&2
+  exit 2
+fi
+
+# --- Resolve current working folder + workspace ---
+
+SRC_WF="$(infer_working_folder "$REPO_PATH")"
+if [ -z "$SRC_WF" ]; then
+  echo "error: no kit working folder found for $REPO_PATH" >&2
+  echo "       (no reference_ai_working_folder.md in $(infer_memory_dir "$REPO_PATH"))" >&2
+  echo "       Run bootstrap.sh on this repo first, or pass a different <repo-path>." >&2
+  exit 1
+fi
+if [ ! -d "$SRC_WF" ]; then
+  echo "error: working folder pointer exists but the target directory does not: $SRC_WF" >&2
+  exit 1
+fi
+
+# The source workspace is the parent dir of the per-repo working folder IF
+# that parent contains workspace-CONTEXT.md.
+SRC_WS="$(cd "$SRC_WF/.." 2>/dev/null && pwd)"
+SRC_WS_CTX="$SRC_WS/workspace-CONTEXT.md"
+if [ ! -f "$SRC_WS_CTX" ]; then
+  echo "error: $REPO_PATH isn't currently a per-repo subfolder under a workspace" >&2
+  echo "       Working folder is at $SRC_WF, but its parent ($SRC_WS) has no" >&2
+  echo "       workspace-CONTEXT.md. Migration only applies to repos already living" >&2
+  echo "       under a workspace." >&2
+  exit 1
+fi
+
+MEM_FILE="$(infer_memory_dir "$REPO_PATH")/reference_ai_working_folder.md"
+if [ ! -f "$MEM_FILE" ]; then
+  echo "error: auto-memory pointer missing: $MEM_FILE" >&2
+  exit 1
+fi
+
+# --- Determine target standalone path ---
+
+REPO_BASENAME="$(basename "$REPO_PATH")"
+DEFAULT_TGT="$HOME/Documents/Claude/Projects/$REPO_BASENAME"
+
+if [ -n "$TO_PATH" ]; then
+  case "$TO_PATH" in
+    "~"|"~/"*) TO_PATH="${TO_PATH/#\~/$HOME}" ;;
+  esac
+  case "$TO_PATH" in
+    /*) ;;
+    *) echo "error: --to must be an absolute path (got: $TO_PATH)" >&2; exit 2 ;;
+  esac
+  TGT_WF="$TO_PATH"
+else
+  TGT_WF="$DEFAULT_TGT"
+  # Basename-collision fallback: try <basename>-<org> from git remote.
+  if [ -e "$TGT_WF" ]; then
+    ORG=""
+    if REMOTE="$(git -C "$REPO_PATH" remote get-url origin 2>/dev/null)"; then
+      # Extract org segment from `git@host:org/repo(.git)?` or `https://host/org/repo(.git)?`.
+      ORG="$(printf '%s\n' "$REMOTE" \
+        | sed -E 's|^https?://[^/]+/||; s|^git@[^:]+:||; s|\.git$||' \
+        | awk -F'/' '{print $1}')"
+      ORG="$(printf '%s' "$ORG" | sed 's|[/.]|-|g' | tr '[:upper:]' '[:lower:]')"
+    fi
+    if [ -n "$ORG" ]; then
+      TGT_WF="$DEFAULT_TGT-$ORG"
+      echo "  ⚠ default target $DEFAULT_TGT already exists; falling back to $TGT_WF" >&2
+      echo "    Override with --to <path> if you'd rather pick the target yourself." >&2
+    fi
+  fi
+fi
+
+if [ -e "$TGT_WF" ]; then
+  echo "error: target standalone working folder already exists: $TGT_WF" >&2
+  echo "       Remove it or pass --to <different-path> and retry." >&2
+  exit 1
+fi
+
+# --- Validate --reference-from paths up front (warn-don't-fail per path) ---
+
+VALID_REFS=()
+for ws in "${REFERENCE_FROM[@]}"; do
+  case "$ws" in
+    "~"|"~/"*) ws="${ws/#\~/$HOME}" ;;
+  esac
+  if [ ! -f "$ws/workspace-CONTEXT.md" ]; then
+    echo "  ⚠ --reference-from $ws skipped (no workspace-CONTEXT.md there)" >&2
+    continue
+  fi
+  if [ "$ws" = "$SRC_WS" ]; then
+    echo "  ⚠ --reference-from $ws skipped (same as the source workspace; already covered)" >&2
+    continue
+  fi
+  VALID_REFS+=("$ws")
+done
+
+# --- Helpers (mirrors bootstrap.sh's append_shared_repo_entries; duplicated
+#     here intentionally to keep this script standalone — see #199 PR B notes) ---
+
+append_shared_repo_entry() {
+  # Args: <workspace-CONTEXT.md path>
+  # Inserts a single bullet pointing at TGT_WF, using basename "$REPO_PATH" as
+  # the entry name. Tries placeholder bullet → section header → append-at-EOF.
+  local file="$1"
+  local entry
+  entry="- ${REPO_BASENAME} — \`${TGT_WF}\` — moved from per-repo subfolder $(date +%Y-%m-%d) via convert-to-shared.sh"
+
+  local anchor=""
+  if grep -Fq -- '- {{SHARED_REPO_NAME}}' "$file"; then
+    anchor='- {{SHARED_REPO_NAME}}'
+  elif grep -Fq '## Shared repos' "$file"; then
+    anchor='## Shared repos'
+  else
+    # No section at all — append a fresh one at EOF (pre-#199 workspace path).
+    {
+      printf '\n---\n\n## Shared repos\n\n'
+      printf '%s\n\n' '<!-- Added by `convert-to-shared.sh` (workspace pre-dates #199 template; section seeded at EOF). -->'
+      printf '%s\n' "$entry"
+    } >> "$file"
+    return 0
+  fi
+
+  awk -v anchor="$anchor" -v entry="$entry" '
+    { print }
+    index($0, anchor) == 1 && !done { print entry; done = 1 }
+  ' "$file" > "$file.new" && mv "$file.new" "$file"
+}
+
+backup_then_run() {
+  # Args: <file> <command...>
+  # Creates <file>.bak.<timestamp> first, then runs the command. The command
+  # is responsible for the actual write.
+  local file="$1"; shift
+  local bak="$file.bak.$(date +%Y%m%d-%H%M%S)"
+  cp "$file" "$bak"
+  echo "    backup: $bak"
+  "$@"
+}
+
+# --- Print the plan ---
+
+echo "convert-to-shared.sh plan"
+echo
+echo "  Repo:               $REPO_PATH"
+echo "  Source workspace:   $SRC_WS"
+echo "  Current working folder: $SRC_WF"
+echo "  Target working folder:  $TGT_WF"
+echo "  Auto-memory pointer:    $MEM_FILE"
+echo
+echo "Steps the real run will take:"
+echo "  1. mv $SRC_WF → $TGT_WF (preserves all files)"
+echo "  2. backup + sed-update $MEM_FILE (paths now point at $TGT_WF)"
+echo "  3. backup + append \"Shared repos\" entry to $SRC_WS_CTX"
+if [ "${#VALID_REFS[@]}" -gt 0 ]; then
+  echo "  4. backup + append \"Shared repos\" entry to ${#VALID_REFS[@]} additional workspace(s):"
+  for ws in "${VALID_REFS[@]}"; do
+    echo "       - $ws/workspace-CONTEXT.md"
+  done
+fi
+echo
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "=== DRY RUN — no files moved or modified ==="
+  exit 0
+fi
+
+if [ "$ASSUME_YES" -eq 0 ]; then
+  printf "Proceed? [y/N]: "
+  read -r ans </dev/tty 2>/dev/null || ans=""
+  case "${ans:-}" in
+    y|Y|yes|YES) ;;
+    *) echo "Aborted."; exit 0 ;;
+  esac
+fi
+
+# --- Execute ---
+
+echo
+echo "Step 1/3: moving working folder"
+mkdir -p "$(dirname "$TGT_WF")"
+mv "$SRC_WF" "$TGT_WF"
+echo "  ✓ $SRC_WF → $TGT_WF"
+
+echo "Step 2/3: repointing auto-memory pointer"
+backup_then_run "$MEM_FILE" bash -c "
+  sed 's|$SRC_WF|$TGT_WF|g' '$MEM_FILE' > '$MEM_FILE.new' && mv '$MEM_FILE.new' '$MEM_FILE'
+"
+echo "  ✓ $MEM_FILE now points at $TGT_WF"
+
+echo "Step 3/3: appending Shared repos entries"
+backup_then_run "$SRC_WS_CTX" append_shared_repo_entry "$SRC_WS_CTX"
+echo "  ✓ appended entry to $SRC_WS_CTX"
+for ws in "${VALID_REFS[@]}"; do
+  ws_ctx="$ws/workspace-CONTEXT.md"
+  backup_then_run "$ws_ctx" append_shared_repo_entry "$ws_ctx"
+  echo "  ✓ appended entry to $ws_ctx"
+done
+
+echo
+echo "Migration complete."
+echo
+echo "Next:"
+echo "  1. Edit $TGT_WF/CONTEXT.md — if it doesn't already have a 'Referenced by'"
+echo "     section, add one and list the workspaces that reference this repo."
+echo "  2. Edit the workspace-CONTEXT.md files above — replace the 'TODO: describe"
+echo "     why this workspace uses it' placeholder in the new entry with the"
+echo "     per-workspace context (1 sentence)."
+echo "  3. Review the source workspace's 'Repos in this workspace' table — the"
+echo "     migrated repo's row is still there; remove it if you want the table to"
+echo "     reflect the new shared status (the 'Shared repos' section now points"
+echo "     at the standalone working folder)."

--- a/tests/convert_to_shared.bats
+++ b/tests/convert_to_shared.bats
@@ -1,0 +1,230 @@
+#!/usr/bin/env bats
+# scripts/convert-to-shared.sh — migrate a per-repo working folder out of a
+# workspace into a standalone shared working folder (#199 PR B).
+
+load 'helpers'
+
+CONVERT=""
+
+setup() {
+  bootstrap_setup
+  CONVERT="$KIT_ROOT/scripts/convert-to-shared.sh"
+}
+
+teardown() { bootstrap_teardown; }
+
+# Helper: stage a pre-migration state — a kit-bootstrapped repo whose working
+# folder lives as a per-repo subfolder under a workspace, with the auto-memory
+# pointer pointing at it. Sets the following globals:
+#   REPO         — the repo path (git-inited)
+#   WS           — the workspace dir (has workspace-CONTEXT.md)
+#   WS_WF        — the per-repo working folder under WS (the migration source)
+#   MEM_DIR      — the auto-memory dir for REPO
+#   MEM_POINTER  — reference_ai_working_folder.md inside MEM_DIR
+stage_per_repo_in_workspace() {
+  REPO="$TEST_TMP/repo"
+  WS="$TEST_TMP/ws"
+  WS_WF="$WS/$(basename "$REPO")"
+
+  mkdir -p "$REPO" "$WS/tickets/archive" "$WS_WF"
+  git -C "$REPO" init -q
+  cp "$KIT_ROOT/templates/workspace/workspace-CONTEXT.md" "$WS/"
+  cp "$KIT_ROOT/templates/CONTEXT.md" "$WS_WF/"
+  echo "SESSION-LOG content" > "$WS_WF/SESSION-LOG.md"
+
+  local sanitized
+  sanitized="$(echo "$REPO" | sed 's|[/.]|-|g')"
+  MEM_DIR="$TEST_HOME/.claude/projects/${sanitized}/memory"
+  mkdir -p "$MEM_DIR"
+  MEM_POINTER="$MEM_DIR/reference_ai_working_folder.md"
+  cat > "$MEM_POINTER" <<EOF
+---
+name: AI working folder for test
+type: reference
+---
+Read these files first:
+- \`$WS_WF/CONTEXT.md\` — context
+- \`$WS_WF/SESSION-LOG.md\` — log
+EOF
+}
+
+# --- Help / arg validation ---
+
+@test "convert-to-shared.sh -h prints usage with --to and --reference-from" {
+  run "$CONVERT" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: convert-to-shared.sh"* ]]
+  [[ "$output" == *"--to PATH"* ]]
+  [[ "$output" == *"--reference-from WS"* ]]
+}
+
+@test "errors when no <repo-path> given" {
+  run "$CONVERT"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"<repo-path> argument is required"* ]]
+}
+
+@test "errors on relative <repo-path>" {
+  run "$CONVERT" relative/path
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"must be an absolute path"* ]]
+}
+
+@test "errors when <repo-path> does not exist" {
+  run "$CONVERT" "$TEST_TMP/nope"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"does not exist"* ]]
+}
+
+@test "errors when --to is missing its argument" {
+  stage_per_repo_in_workspace
+  run "$CONVERT" "$REPO" --to
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--to requires a path"* ]]
+}
+
+@test "errors when --reference-from is missing its argument" {
+  stage_per_repo_in_workspace
+  run "$CONVERT" "$REPO" --reference-from
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--reference-from requires a path"* ]]
+}
+
+# --- Precondition errors ---
+
+@test "errors when repo has no kit auto-memory" {
+  REPO="$TEST_TMP/lonely-repo"
+  mkdir -p "$REPO"
+  git -C "$REPO" init -q
+  run "$CONVERT" "$REPO" --yes
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no kit working folder found"* ]]
+}
+
+@test "errors when working folder isn't under a workspace" {
+  # Standalone repo (already has a non-workspace working folder)
+  REPO="$TEST_TMP/standalone-repo"
+  STANDALONE_WF="$TEST_TMP/standalone-wf"
+  mkdir -p "$REPO" "$STANDALONE_WF"
+  git -C "$REPO" init -q
+  cp "$KIT_ROOT/templates/CONTEXT.md" "$STANDALONE_WF/"
+  local sanitized
+  sanitized="$(echo "$REPO" | sed 's|[/.]|-|g')"
+  mkdir -p "$TEST_HOME/.claude/projects/${sanitized}/memory"
+  cat > "$TEST_HOME/.claude/projects/${sanitized}/memory/reference_ai_working_folder.md" <<EOF
+- \`$STANDALONE_WF/CONTEXT.md\` — context
+EOF
+  run "$CONVERT" "$REPO" --yes
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"isn't currently a per-repo subfolder under a workspace"* ]]
+}
+
+# --- Happy path ---
+
+@test "happy path: moves WF, repoints pointer, appends entry to source WS" {
+  stage_per_repo_in_workspace
+  TGT="$TEST_TMP/target-wf"
+
+  run "$CONVERT" "$REPO" --to "$TGT" --yes
+  [ "$status" -eq 0 ]
+
+  # WF moved
+  [ ! -d "$WS_WF" ]
+  [ -f "$TGT/CONTEXT.md" ]
+  [ -f "$TGT/SESSION-LOG.md" ]
+
+  # Pointer repointed
+  grep -q "$TGT/CONTEXT.md" "$MEM_POINTER"
+  ! grep -q "$WS_WF/CONTEXT.md" "$MEM_POINTER"
+
+  # Source workspace-CONTEXT.md has the Shared repos entry
+  grep -q "$(basename "$REPO") — \`$TGT\`" "$WS/workspace-CONTEXT.md"
+
+  # Backups exist for both mutated files
+  ls "$MEM_POINTER".bak.* >/dev/null 2>&1
+  ls "$WS/workspace-CONTEXT.md".bak.* >/dev/null 2>&1
+}
+
+@test "preserves content of files inside the moved working folder" {
+  stage_per_repo_in_workspace
+  echo "MY CUSTOM CONTENT" > "$WS_WF/notes.md"
+  TGT="$TEST_TMP/target-wf"
+
+  run "$CONVERT" "$REPO" --to "$TGT" --yes
+  [ "$status" -eq 0 ]
+
+  [ -f "$TGT/notes.md" ]
+  grep -q "MY CUSTOM CONTENT" "$TGT/notes.md"
+}
+
+# --- Dry-run ---
+
+@test "--dry-run prints plan and writes nothing" {
+  stage_per_repo_in_workspace
+  TGT="$TEST_TMP/target-wf"
+
+  run "$CONVERT" "$REPO" --to "$TGT" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY RUN"* ]]
+  [[ "$output" == *"mv $WS_WF"* ]]
+
+  # Nothing actually moved or mutated
+  [ -d "$WS_WF" ]
+  [ ! -e "$TGT" ]
+  ! grep -q "$TGT" "$MEM_POINTER"
+  ! grep -q "## Shared repos" "$WS/workspace-CONTEXT.md" || \
+    ! grep -q "$(basename "$REPO") —" "$WS/workspace-CONTEXT.md"
+}
+
+# --- --reference-from ---
+
+@test "--reference-from adds the entry to additional workspaces" {
+  stage_per_repo_in_workspace
+  EXTRA_WS="$TEST_TMP/extra-ws"
+  mkdir -p "$EXTRA_WS"
+  cp "$KIT_ROOT/templates/workspace/workspace-CONTEXT.md" "$EXTRA_WS/"
+
+  TGT="$TEST_TMP/target-wf"
+  run "$CONVERT" "$REPO" --to "$TGT" --reference-from "$EXTRA_WS" --yes
+  [ "$status" -eq 0 ]
+
+  grep -q "$(basename "$REPO")" "$WS/workspace-CONTEXT.md"
+  grep -q "$(basename "$REPO")" "$EXTRA_WS/workspace-CONTEXT.md"
+  ls "$EXTRA_WS/workspace-CONTEXT.md".bak.* >/dev/null 2>&1
+}
+
+@test "--reference-from skips paths that aren't workspaces (warn, don't fail)" {
+  stage_per_repo_in_workspace
+  TGT="$TEST_TMP/target-wf"
+  BOGUS="$TEST_TMP/not-a-workspace"
+  mkdir -p "$BOGUS"
+
+  run "$CONVERT" "$REPO" --to "$TGT" --reference-from "$BOGUS" --yes
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skipped"* ]]
+}
+
+@test "--reference-from skips the source workspace if passed redundantly" {
+  stage_per_repo_in_workspace
+  TGT="$TEST_TMP/target-wf"
+
+  run "$CONVERT" "$REPO" --to "$TGT" --reference-from "$WS" --yes
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skipped"* ]]
+  # The source workspace still got exactly one entry (not duplicated)
+  local count
+  count=$(grep -c "^- $(basename "$REPO") —" "$WS/workspace-CONTEXT.md")
+  [ "$count" -eq 1 ]
+}
+
+# --- Target collision ---
+
+@test "errors when --to target already exists" {
+  stage_per_repo_in_workspace
+  TGT="$TEST_TMP/already-here"
+  mkdir -p "$TGT"
+
+  run "$CONVERT" "$REPO" --to "$TGT" --yes
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"target standalone working folder already exists"* ]]
+}


### PR DESCRIPTION
## Summary

Second of three PRs implementing #199. PR A made the shared-repos pattern *usable* for new projects ([#239 merged](https://github.com/IamMrCupp/claude-project-kit/pull/239)); this PR makes it *migratable* — existing per-repo subfolders under a workspace can be promoted to standalone shared working folders in one command.

### What lands

- **`scripts/convert-to-shared.sh <repo-path>`** — given a repo whose working folder currently lives as a per-repo subfolder under a workspace, the script:
  1. Resolves the current WF via `infer_working_folder` (the existing helper in `scripts/lib/infer.sh`).
  2. Validates the WF really is under a workspace (its parent has `workspace-CONTEXT.md`); errors clearly if not.
  3. Picks a target standalone path — default `~/Documents/Claude/Projects/<repo-basename>/`; if that collides, falls back to `<basename>-<sanitized-org>` derived from `git remote get-url origin`. `--to <path>` overrides.
  4. `mv`s the WF to the target.
  5. Backs up and `sed`-updates `~/.claude/projects/<sanitized-repo-path>/memory/reference_ai_working_folder.md` to point at the new path.
  6. Appends a `## Shared repos` entry to the source workspace's `workspace-CONTEXT.md`. Repeatable `--reference-from <other-workspace>` adds the same entry to additional workspaces.
- **`--dry-run`** previews every step + paths; writes nothing.
- **`--yes`** skips the confirmation prompt for scripted runs.
- **`.bak.<timestamp>` for every mutated file** so a botched migration is fully recoverable.

### Notable design choices

- **Justifies writing to `reference_ai_working_folder.md`.** That file is normally a never-overwrite auto-memory file. The migration justifies the write with three guards: a timestamped backup, an always-on plan preview (free with `--dry-run`), and a confirmation prompt (unless `--yes`). The `--help` text spells this out.
- **`--reference-from` validation is warn-don't-fail.** A path passed via `--reference-from` that isn't actually a workspace (no `workspace-CONTEXT.md`) gets a warning and is skipped — the migration still proceeds with valid refs. Same for redundantly passing the source workspace.
- **`append_shared_repo_entry` is duplicated from `bootstrap.sh`.** Extracting the optional-section helpers into a shared lib would tidy this, but it's a refactor that touches the bootstrap surface. Deferred — both copies are small and stable. (Worth a follow-up if a third script wants them.)
- **`Repos in this workspace` table is left intact.** The script appends the new "Shared repos" entry to the source workspace but doesn't auto-remove the migrated repo's row from the existing per-repo table — that's user judgment (some workspaces may want both views). Documented in the `Next:` hand-off output and SETUP.md.

### What this doesn't do (out of scope)

- Editing the migrated repo's `CONTEXT.md` to add a `## Referenced by` section listing workspaces. The shared side stays user-curated post-migration — same stance as `bootstrap.sh --shared` (which seeds the section but leaves entries to the user).
- Reverse-migration (standalone → per-repo subfolder). Possible follow-up if anyone needs it; not in #199's scope.

## Test plan

- [x] `bats tests/convert_to_shared.bats` — 15/15 (help, arg validation, precondition errors, happy path, content preservation, dry-run, `--reference-from` add + warn-skip + redundancy-skip, target-collision)
- [x] `bats tests/*.bats` — 407/407, no failures
- [x] Manual smoke: `-h`, missing arg, relative path, nonexistent path
- [ ] Render check on GitHub — SETUP.md migration walkthrough — Aaron to verify
- [ ] Live adopter dogfood — run against a real shared repo currently living as a per-repo subfolder on this machine (e.g. an Audiophore-workspace repo that's actually shared) — can do post-merge

## What's next

- **PR C** — `/session-start` slash command surfacing of the `## Referenced by` list + optional paired PROMPTS.md prompt + `docs/adr/0003-shared-repos-across-workspaces.md`. Closes #199.

Refs #199