### PR TITLE
fix(convert-to-shared): seed TODO placeholder in appended bullet (#243)

### DIFF
--- a/scripts/convert-to-shared.sh
+++ b/scripts/convert-to-shared.sh
@@ -245,7 +245,10 @@ append_shared_repo_entry() {
   # the entry name. Tries placeholder bullet → section header → append-at-EOF.
   local file="$1"
   local entry
-  entry="- ${REPO_BASENAME} — \`${TGT_WF}\` — moved from per-repo subfolder $(date +%Y-%m-%d) via convert-to-shared.sh"
+  # Seed a TODO: placeholder so the script's "Next" output ("replace the 'TODO:
+  # describe why this workspace uses it' placeholder") actually finds something
+  # to replace. Migration provenance follows in italics. See #243.
+  entry="- ${REPO_BASENAME} — \`${TGT_WF}\` — TODO: describe why this workspace uses it. *Migrated from per-repo subfolder $(date +%Y-%m-%d) via \`convert-to-shared.sh\`.*"
 
   local anchor=""
   if grep -Fq -- '- {{SHARED_REPO_NAME}}' "$file"; then

--- a/tests/convert_to_shared.bats
+++ b/tests/convert_to_shared.bats
@@ -217,6 +217,65 @@ EOF
   [ "$count" -eq 1 ]
 }
 
+# --- TODO placeholder seeding (issue #243) ---
+# Every append path must seed the 'TODO: describe why this workspace uses it'
+# placeholder so the script's "Next" output ("replace the 'TODO: …' placeholder
+# in the new entry") is honest. Regression: in v1.3.0 none of the three paths
+# wrote the TODO.
+
+@test "appended entry seeds TODO placeholder (placeholder-bullet path — default template)" {
+  stage_per_repo_in_workspace
+  # Default template carries `- {{SHARED_REPO_NAME}}` — the script anchors here.
+  grep -q '{{SHARED_REPO_NAME}}' "$WS/workspace-CONTEXT.md"
+
+  TGT="$TEST_TMP/target-wf"
+  run "$CONVERT" "$REPO" --to "$TGT" --yes
+  [ "$status" -eq 0 ]
+
+  # Appended bullet for our repo carries the TODO placeholder verbatim.
+  grep -q "^- $(basename "$REPO") .* TODO: describe why this workspace uses it" "$WS/workspace-CONTEXT.md"
+}
+
+@test "appended entry seeds TODO placeholder (existing-section path — section present, no placeholder bullet)" {
+  stage_per_repo_in_workspace
+  # Workspace whose Shared repos section is already populated — no placeholder.
+  cat > "$WS/workspace-CONTEXT.md" <<EOF
+# Workspace Context
+
+## Shared repos
+
+- another-repo — \`/tmp/another\` — already populated
+EOF
+  ! grep -q '{{SHARED_REPO_NAME}}' "$WS/workspace-CONTEXT.md"
+
+  TGT="$TEST_TMP/target-wf"
+  run "$CONVERT" "$REPO" --to "$TGT" --yes
+  [ "$status" -eq 0 ]
+
+  grep -q "^- $(basename "$REPO") .* TODO: describe why this workspace uses it" "$WS/workspace-CONTEXT.md"
+}
+
+@test "appended entry seeds TODO placeholder (retrofit path — pre-#199 workspace, no section)" {
+  stage_per_repo_in_workspace
+  # Pre-#199 workspace has no Shared repos section at all — the script seeds
+  # one at EOF. This is the path #243 was filed against.
+  cat > "$WS/workspace-CONTEXT.md" <<'EOF'
+# Workspace Context
+
+Pre-#199 workspace without any Shared repos section.
+EOF
+  ! grep -q '## Shared repos' "$WS/workspace-CONTEXT.md"
+
+  TGT="$TEST_TMP/target-wf"
+  run "$CONVERT" "$REPO" --to "$TGT" --yes
+  [ "$status" -eq 0 ]
+
+  # Section was seeded at EOF.
+  grep -q '## Shared repos' "$WS/workspace-CONTEXT.md"
+  # And the appended bullet carries the TODO placeholder.
+  grep -q "^- $(basename "$REPO") .* TODO: describe why this workspace uses it" "$WS/workspace-CONTEXT.md"
+}
+
 # --- Target collision ---
 
 @test "errors when --to target already exists" {


### PR DESCRIPTION
## Summary

Closes [#243](https://github.com/IamMrCupp/claude-project-kit/issues/243). `convert-to-shared.sh`'s "Next" output instructs users to *"replace the 'TODO: describe why this workspace uses it' placeholder in the new entry"*, but none of the three append paths (retrofit / existing-section / placeholder-bullet) actually wrote that TODO — the appended bullet carried migration-provenance only.

This PR makes the appended bullet match what the "Next" message promises:

**Before:**
```
- repo — `/path` — moved from per-repo subfolder 2026-05-28 via convert-to-shared.sh
```

**After:**
```
- repo — `/path` — TODO: describe why this workspace uses it. *Migrated from per-repo subfolder 2026-05-28 via `convert-to-shared.sh`.*
```

The change is one line in `append_shared_repo_entry()` (the `entry=` assignment is upstream of the three path-dispatches, so all three benefit). Migration provenance is preserved as italicized trailing context.

## Test plan

- [x] `bats tests/convert_to_shared.bats` — 15 → 18 tests (3 new, all paths covered)
- [x] `bats tests/` — full suite 416 → 419 ok / 0 failures (no regressions)
- [x] New tests assert the TODO substring appears in the appended bullet for: placeholder-bullet path (default template), existing-section path (no placeholder), retrofit path (pre-#199 workspace, no section). Locks the regression from #243.
- [x] Found organically during live-validation of v1.3.0's #199 shared-repos features (cluster-management migration out of audiophore workspace, 2026-05-28).

## Notes

- The Bash-tool's "1-line conventional commit, no body, no Co-Authored-By" override applied (kit's enforcement hook would have blocked otherwise).
- Branch was created off `main` before any edits (override of Bash-tool default).
- The script's "Next" message itself didn't change — the seeded TODO substring matches the message's quoted phrase verbatim, so users can grep `TODO: describe` and find it.

## Follow-on candidate (not in this PR)

Today's live-validation also surfaced that relative `../workspace-CONTEXT.md` and `../website/...` links inside the moved CONTEXT.md silently rot at `mv` time. Worth considering whether `convert-to-shared.sh` should grep-and-warn for `../*` references in the moved CONTEXT.md before applying. Captured in today's SESSION-LOG entry as a possible follow-on; not filed as a separate issue yet.