### PR TITLE
feat(convert-to-shared): warn about relative ../ links in moved working folder (#245)

### DIFF
--- a/scripts/convert-to-shared.sh
+++ b/scripts/convert-to-shared.sh
@@ -282,6 +282,36 @@ backup_then_run() {
   "$@"
 }
 
+warn_relative_links() {
+  # Args: <working-folder>
+  # Scan markdown files in <working-folder> for '../<path>' references that
+  # were valid while the folder lived as a per-repo subfolder but no longer
+  # resolve once it's moved out of the workspace. Warn-only — prints a
+  # punch-list to stderr and always returns 0. See #245.
+  local dir="$1"
+  local md_files=()
+  while IFS= read -r -d '' f; do
+    md_files+=("$f")
+  done < <(find "$dir" -type f -name '*.md' -print0 2>/dev/null)
+  if [ "${#md_files[@]}" -eq 0 ]; then
+    return 0
+  fi
+  local matches
+  # Match '../' only when followed by a path-like character and NOT preceded
+  # by '/' — skips absolute-URL traversal segments and bare prose mentions.
+  matches="$(grep -n -H -E '(^|[^/])\.\./[A-Za-z0-9_.-]' "${md_files[@]}" 2>/dev/null || true)"
+  if [ -z "$matches" ]; then
+    return 0
+  fi
+  local count
+  count="$(printf '%s\n' "$matches" | wc -l | tr -d ' ')"
+  echo "  ⚠ Found ${count} relative '../...' reference(s) inside the working folder:" >&2
+  printf '%s\n' "$matches" | sed 's|^|      |' >&2
+  echo "    These resolved while the working folder was a per-repo subfolder; they no" >&2
+  echo "    longer resolve from the standalone path. Rewrite to absolute paths," >&2
+  echo "    repoint at a different workspace, or remove. (See 'Next' step 4 below.)" >&2
+}
+
 # --- Print the plan ---
 
 echo "convert-to-shared.sh plan"
@@ -303,6 +333,12 @@ if [ "${#VALID_REFS[@]}" -gt 0 ]; then
   done
 fi
 echo
+
+# Surface stale '../' relative links inside the working folder so the user
+# sees them at migration time, not session-by-session afterwards. Runs in
+# both dry-run and real-run; the files are the same either way (same content,
+# just under $SRC_WF until the `mv` happens). See #245.
+warn_relative_links "$SRC_WF"
 
 if [ "$DRY_RUN" -eq 1 ]; then
   echo "=== DRY RUN — no files moved or modified ==="
@@ -354,3 +390,6 @@ echo "  3. Review the source workspace's 'Repos in this workspace' table — the
 echo "     migrated repo's row is still there; remove it if you want the table to"
 echo "     reflect the new shared status (the 'Shared repos' section now points"
 echo "     at the standalone working folder)."
+echo "  4. If the script warned about relative '../...' references above, walk that"
+echo "     punch-list and rewrite each to an absolute path or remove it — they no"
+echo "     longer resolve from the standalone working-folder path."

--- a/tests/convert_to_shared.bats
+++ b/tests/convert_to_shared.bats
@@ -276,6 +276,71 @@ EOF
   grep -q "^- $(basename "$REPO") .* TODO: describe why this workspace uses it" "$WS/workspace-CONTEXT.md"
 }
 
+# --- Relative-link warning (issue #245) ---
+# Working-folder `../...` references valid as a per-repo subfolder rot the
+# moment the WF moves out from under the workspace. Warn-only check should
+# surface them at migration time so the user doesn't discover them
+# session-by-session afterwards.
+
+@test "warns about relative ../ references inside the moved working folder" {
+  stage_per_repo_in_workspace
+  # Plant a couple of relative references that would rot post-migration.
+  cat > "$WS_WF/CONTEXT.md" <<EOF
+# CONTEXT
+
+Workspace context lives at [\`../workspace-CONTEXT.md\`](../workspace-CONTEXT.md).
+See also [\`../tickets/FOO-1.md\`](../tickets/FOO-1.md) for the active ticket.
+EOF
+  TGT="$TEST_TMP/target-wf"
+
+  run "$CONVERT" "$REPO" --to "$TGT" --yes
+  [ "$status" -eq 0 ]
+
+  [[ "$output" == *"reference(s) inside the working folder"* ]]
+  [[ "$output" == *"../workspace-CONTEXT.md"* ]]
+  [[ "$output" == *"../tickets/FOO-1.md"* ]]
+  [[ "$output" == *"Rewrite to absolute paths"* ]]
+  # Migration still succeeded — warning is informational, not blocking.
+  [ -d "$TGT" ]
+}
+
+@test "no relative-link warning when working folder is clean" {
+  stage_per_repo_in_workspace
+  # Wipe staged .md files first — kit's CONTEXT.md template legitimately
+  # documents '../workspace-CONTEXT.md' usage and would correctly trigger
+  # the warning. We want to test the negative path (truly no '../' refs).
+  rm -f "$WS_WF"/*.md
+  cat > "$WS_WF/CONTEXT.md" <<'EOF'
+# CONTEXT
+
+No relative links here. Absolute reference: /Users/example/workspace-CONTEXT.md.
+EOF
+  TGT="$TEST_TMP/target-wf"
+
+  run "$CONVERT" "$REPO" --to "$TGT" --yes
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"reference(s) inside the working folder"* ]]
+}
+
+@test "--dry-run surfaces the relative-link warning before the DRY RUN banner" {
+  stage_per_repo_in_workspace
+  cat > "$WS_WF/CONTEXT.md" <<EOF
+# CONTEXT
+
+Link: [\`../workspace-CONTEXT.md\`](../workspace-CONTEXT.md).
+EOF
+  TGT="$TEST_TMP/target-wf"
+
+  run "$CONVERT" "$REPO" --to "$TGT" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"reference(s) inside the working folder"* ]]
+  [[ "$output" == *"../workspace-CONTEXT.md"* ]]
+  [[ "$output" == *"DRY RUN"* ]]
+  # Source WF untouched (dry-run wrote nothing).
+  [ -d "$WS_WF" ]
+  [ ! -e "$TGT" ]
+}
+
 # --- Target collision ---
 
 @test "errors when --to target already exists" {


### PR DESCRIPTION
## Summary

Closes [#245](https://github.com/IamMrCupp/claude-project-kit/issues/245). When `convert-to-shared.sh` migrates a per-repo working folder out of its workspace, relative `../workspace-CONTEXT.md` / `../tickets/...` / `../<sibling-repo>/...` references inside the moved CONTEXT.md silently rot — the new standalone path is no longer nested under the workspace, so those links no longer resolve.

This PR adds a **warn-only** check that surfaces those references at migration time. No auto-fix — rewriting `../` paths requires knowing the user's intent (point at the source workspace? a different one? remove?). The user reviews the punch-list and hand-edits.

### Behavior

- New `warn_relative_links <dir>` helper scans `*.md` files in the working folder for `../<path>` references and prints a punch-list to stderr (file:line:matched-content).
- Runs **before** the dry-run banner / proceed prompt, so users see findings before deciding to proceed.
- Same pattern matches both modes — `$SRC_WF` is the same set of files in dry-run (not yet moved) and real-run (about to be moved).
- New \"Next\" step 4 references the punch-list (\"If the script warned about relative '../...' references above, walk that punch-list…\").
- Match pattern: `(^|[^/])\.\./[A-Za-z0-9_.-]` — catches links/paths, skips absolute-URL traversal (`https://.../../...`) and bare prose mentions of `..`.

### Example output (with 2 rotted links)

```
  ⚠ Found 2 relative '../...' reference(s) inside the working folder:
      .../CONTEXT.md:13:> **Folder shape:** ...[`../workspace-CONTEXT.md`](../workspace-CONTEXT.md)...
      .../CONTEXT.md:21:This repo is the ... in [`../workspace-CONTEXT.md`](../workspace-CONTEXT.md) ...
    These resolved while the working folder was a per-repo subfolder; they no
    longer resolve from the standalone path. Rewrite to absolute paths,
    repoint at a different workspace, or remove. (See 'Next' step 4 below.)
```

## Test plan

- [x] `bats tests/convert_to_shared.bats` — 18 → 21 tests (3 new)
- [x] `bats tests/` — full suite 419 → 422 ok / 0 failures
- [x] New tests cover: (1) positive — `../` refs present, warning emitted, exit still 0; (2) negative — clean WF, no warning; (3) `--dry-run` mode — warning emitted before DRY RUN banner, source still untouched
- [x] Manual repro of yesterday's cluster-management scenario validates: the warning would have caught all 6 relative links surfaced by hand-review

## Notes

- Bash 3-compatible (the `while IFS= read -r -d ''` + array pattern works on macOS bash 3.2).
- Pattern uses BRE-compatible `grep -E` so works on both BSD and GNU grep.
- Test asserts on the unique substring `"reference(s) inside the working folder"` to avoid colliding with the Next step 4 message text (caught during test development — initial assertion was too loose and matched both).

## Branch / commit hygiene

- Branched off fresh `main` after #244 merged (avoided stacking).
- Single-line conventional commit + `-s` sign-off, no body, no `Co-Authored-By` (commit-format hook enforces — see #236/#237).