### PR TITLE
feat(hooks): block edits to tracked files on protected branches (#248)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -276,6 +276,68 @@ This hook is the structural enforcement layer behind `feedback_commit_format` an
 
 ---
 
+## Optional: branch-first enforcement hook
+
+The kit's "branch first, never start work on main" rule (`feedback_no_work_on_main`, CONVENTIONS.md, and the `/plan` + `/pull-ticket` guards from #204 / #222) is guidance — the model usually honors it, but fresh sessions still open on `main` and start editing tracked files before noticing. Memory and slash-command guards don't bind the harness.
+
+**The structural fix is the sibling of the commit-format hook above.** `scripts/block-edit-on-protected-branch.sh` runs as a `PreToolUse` hook for `Edit` / `Write` / `MultiEdit` / `NotebookEdit` and denies any edit to a file inside a git work-tree when the current branch matches the protected list (default: `main`, `master`). Files outside any git repo — your private working folder at `~/Documents/Claude/Projects/<repo>/...` — are always allowed.
+
+**Wire it once, on this machine:**
+
+1. Install the script (idempotent; skipped if already present):
+
+   ```bash
+   <kit-dir>/scripts/install-scripts.sh --global
+   ```
+
+2. Add a `PreToolUse` hook entry to `~/.claude/settings.json` (back up first, then merge — don't replace existing `permissions`/`hooks` blocks):
+
+   ```bash
+   cp ~/.claude/settings.json ~/.claude/settings.json.bak.$(date +%Y%m%d-%H%M%S)
+   ```
+
+   Snippet to merge into the file (combine with existing top-level keys, and combine with the commit-format hook's `PreToolUse` array if you already wired that one):
+
+   ```json
+   {
+     "hooks": {
+       "PreToolUse": [
+         {
+           "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+           "hooks": [
+             {
+               "type": "command",
+               "command": "/Users/<you>/.claude/scripts/block-edit-on-protected-branch.sh"
+             }
+           ]
+         }
+       ]
+     }
+   }
+   ```
+
+   The `command` path must be absolute. Substitute your actual home path.
+
+3. Reload settings. New sessions pick up the hook automatically; in an existing session, open `/hooks` once to refresh, or restart.
+
+**What it does.** Any `Edit` / `Write` / `MultiEdit` / `NotebookEdit` whose target `file_path` resolves into a git work-tree currently checked out on `main` (or `master`) is **denied** by the harness with a message naming the branch, the repo, and the override mechanism. The model sees the denial and creates a branch — it doesn't retry blindly.
+
+**Override (rare).** Set the `KIT_PROTECTED_BRANCHES` env var to a space-separated list to customize:
+
+```bash
+# Add 'production' to the default list
+export KIT_PROTECTED_BRANCHES="main master production"
+
+# Disable entirely for this shell (very rare — better to use the hook)
+export KIT_PROTECTED_BRANCHES=""
+```
+
+**Review / disable.** `/hooks` in Claude Code shows every wired hook and lets you toggle it for a session.
+
+This hook is the structural enforcement layer behind `feedback_no_work_on_main` and CONVENTIONS.md's *Branch name first, then code* rule — sibling to the commit-format hook above. See [#248](https://github.com/IamMrCupp/claude-project-kit/issues/248) for the filing rationale.
+
+---
+
 ## Manual alternative
 
 If you can't run `bootstrap.sh` (no Bash available, restricted environment, or you just want to see what it does) **or** you'd rather fill the templates by hand instead of running the seed prompt, perform the same work manually.

--- a/memory-templates/feedback_no_work_on_main.md
+++ b/memory-templates/feedback_no_work_on_main.md
@@ -17,3 +17,5 @@ git checkout -b <type>/<slug>   # feat/…, fix/…, docs/…, ci/…, chore/…
 - Read-only work (reading files, `git log`, `git diff`, `gh` queries) is fine on `main` — the rule is about *edits* to tracked files.
 - Working-folder files (the private `CONTEXT.md` / `SESSION-LOG.md` outside the repo) aren't tracked repo files — editing those doesn't require a branch.
 - If the user explicitly authorizes a direct commit to `main` for a specific one-off, that's their call — but surface the branch option first and let them override.
+
+**Structural enforcement (recommended).** The kit ships a `PreToolUse` Edit/Write hook (`scripts/block-edit-on-protected-branch.sh`) that the harness uses to deny edits to in-repo files when the current branch is `main` / `master`. Wire it once per machine — see `SETUP.md` → *Optional: branch-first enforcement hook*. With the hook installed, this memory entry becomes a "why the harness just blocked me" reference rather than a guidance reminder. Sibling of the commit-format hook (`feedback_commit_format`).

--- a/scripts/block-edit-on-protected-branch.sh
+++ b/scripts/block-edit-on-protected-branch.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# claude-project-kit hook — block Edit/Write/MultiEdit/NotebookEdit on
+# protected branches (default: main, master).
+# Wired in ~/.claude/settings.json as a PreToolUse hook with matcher
+# "Edit|Write|MultiEdit|NotebookEdit". Receives Claude Code tool input as
+# JSON on stdin; outputs a deny decision JSON on stdout if the edit targets
+# a tracked file on a protected branch, otherwise exits silently.
+#
+# Behavior:
+#   - Only fires when tool_name is Edit / Write / MultiEdit / NotebookEdit.
+#   - file_path (or notebook_path for NotebookEdit) must resolve into a git
+#     work-tree. Files outside any git repo (private working folders at
+#     ~/Documents/Claude/Projects/<repo>/...) are always allowed — they're
+#     deliberately untracked.
+#   - Current branch of the resolved work-tree is checked against the
+#     protected list. Match → deny; no match → allow.
+#   - Walks up from $FILE_PATH to find an existing ancestor dir before
+#     asking git, so new-file paths (Write creating a fresh file) work.
+#
+# Configurable:
+#   KIT_PROTECTED_BRANCHES (env, default "main master")
+#     Space-separated branch names to block. Override per-session if you
+#     genuinely need to edit on main (very rare — the hook exists because
+#     "I'll just be careful" historically didn't hold).
+#
+# Triggered by claude-project-kit issue #248 (sibling to #236 commit-format
+# hook). Memory + slash-command guards (#204 / #222) cover the rule as
+# guidance, but the harness only enforces what hooks reject. Pattern
+# surfaced as 3+ sessions opening on main since v1.0.0 shipped.
+
+set -uo pipefail
+
+INPUT="$(cat)"
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || printf '')
+case "$TOOL_NAME" in
+  Edit|Write|MultiEdit|NotebookEdit) ;;
+  *) exit 0 ;;
+esac
+
+FILE_PATH=$(printf '%s' "$INPUT" \
+  | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty' 2>/dev/null \
+  || printf '')
+[ -n "$FILE_PATH" ] || exit 0
+
+# Walk up from $FILE_PATH to find an existing ancestor directory before
+# asking git. Handles both "edit existing file" (dir = dirname of file) and
+# "Write a new file under a fresh subdir" (walk up until something exists).
+DIR="$FILE_PATH"
+while [ ! -d "$DIR" ] && [ "$DIR" != "/" ] && [ -n "$DIR" ]; do
+  DIR=$(dirname "$DIR")
+done
+[ -d "$DIR" ] || exit 0
+
+GIT_ROOT=$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null || true)
+[ -n "$GIT_ROOT" ] || exit 0   # outside any git repo — allow
+
+BRANCH=$(git -C "$GIT_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+[ -n "$BRANCH" ] || exit 0     # detached HEAD or unborn — don't block
+
+PROTECTED="${KIT_PROTECTED_BRANCHES-main master}"
+[ -n "$PROTECTED" ] || exit 0  # user explicitly opted out for this session
+
+for p in $PROTECTED; do
+  if [ "$BRANCH" = "$p" ]; then
+    reason="Blocked by claude-project-kit branch-first hook: editing on protected branch '$BRANCH' in $GIT_ROOT. The kit's CONVENTIONS.md and feedback_no_work_on_main memory require a feature branch before any edit to tracked files. Create one and switch: 'git checkout -b <type>/<slug>' (feat/, fix/, docs/, ci/, chore/). Read-only work and edits to files outside any git repo (e.g. private working folders) are not blocked. To override for this session, set KIT_PROTECTED_BRANCHES to a list that excludes '$BRANCH' (or to empty to disable entirely)."
+    jq -n --arg r "$reason" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+    exit 0
+  fi
+done
+exit 0

--- a/scripts/install-scripts.sh
+++ b/scripts/install-scripts.sh
@@ -2,7 +2,7 @@
 # Install the kit's runtime helper scripts at user-level (~/.claude/scripts/)
 # or per-project (<repo>/.claude/scripts/).
 #
-# Currently ships two scripts:
+# Currently ships three scripts:
 #   - kit-print-memory-pointer.sh — the precheck helper invoked by every
 #     kit-coupled slash command and the session-summarizer agent. Extracted
 #     from the inline precheck Bash so the call is matchable by Claude
@@ -15,6 +15,11 @@
 #     settings.json as a hook entry — see SETUP.md → "Optional commit-
 #     format enforcement hook" for the copy-pasteable snippet
 #     (closes #236; #204 Option C).
+#   - block-edit-on-protected-branch.sh — PreToolUse Edit/Write/MultiEdit/
+#     NotebookEdit hook that enforces the kit's "branch first, never start
+#     work on main" rule. Same wire-once pattern as the commit-format hook
+#     — install + add the snippet in SETUP.md → "Optional branch-first
+#     enforcement hook" (closes #248; sibling of #236).
 #
 # Default behavior is write-once: never overwrites an existing file in the
 # target. Pass --force-update to overwrite kit-shipped files (with backup +
@@ -38,6 +43,7 @@ KIT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SHIPPED_SCRIPTS=(
   kit-print-memory-pointer.sh
   block-forbidden-commit-patterns.sh
+  block-edit-on-protected-branch.sh
 )
 
 usage() {

--- a/tests/block_edit_on_protected_branch.bats
+++ b/tests/block_edit_on_protected_branch.bats
@@ -1,0 +1,192 @@
+#!/usr/bin/env bats
+# scripts/block-edit-on-protected-branch.sh — the PreToolUse Edit/Write hook
+# that enforces the kit's "branch first" rule (#248 / #204 sibling to #236).
+#
+# Tests pipe a synthetic Claude Code hook-input JSON to the script and check
+# whether it emits a deny-decision JSON (block) or exits silently (allow).
+# Coverage matrix:
+#   - Tool dispatch (only Edit/Write/MultiEdit/NotebookEdit fire)
+#   - Branch dispatch (main, master block by default; feature branches pass)
+#   - Working-folder case (files outside any git repo always pass)
+#   - KIT_PROTECTED_BRANCHES env override (custom list, empty list)
+#   - New-file path (Write creating a file under a not-yet-existing subdir)
+#   - Deny message names branch, repo, override env var
+
+load 'helpers'
+
+HOOK="$KIT_ROOT/scripts/block-edit-on-protected-branch.sh"
+
+setup() {
+  # Minimal sandbox — just need a writeable TEST_TMP for git repo fixtures.
+  TEST_TMP="$(mktemp -d)"
+}
+
+teardown() {
+  [ -n "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"
+}
+
+# Helper: pipe synthetic hook-input JSON, capture stdout.
+hook_decision() {
+  local tool="$1"
+  local file_path="$2"
+  printf '{"tool_name":"%s","tool_input":{"file_path":%s}}' \
+    "$tool" \
+    "$(printf '%s' "$file_path" | jq -Rs .)" \
+    | "$HOOK"
+}
+
+decision() {
+  hook_decision "$1" "$2" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null
+}
+
+# Helper: stage a git repo at $TEST_TMP/repo with current branch set.
+# Sets REPO global.
+stage_git_repo() {
+  local branch="${1:-main}"
+  REPO="$TEST_TMP/repo"
+  mkdir -p "$REPO"
+  git -C "$REPO" init -q -b "$branch"
+  git -C "$REPO" -c user.email=t@t -c user.name=t commit --allow-empty -q -m "init"
+  # If init -b isn't supported (older git), rename:
+  if [ "$(git -C "$REPO" rev-parse --abbrev-ref HEAD)" != "$branch" ]; then
+    git -C "$REPO" branch -m "$branch"
+  fi
+  echo "tracked content" > "$REPO/tracked.md"
+  git -C "$REPO" -c user.email=t@t -c user.name=t add tracked.md
+  git -C "$REPO" -c user.email=t@t -c user.name=t commit -q -m "add tracked"
+}
+
+# --- Smoke ---
+
+@test "hook script exists and is executable" {
+  [ -x "$HOOK" ]
+}
+
+@test "hook outputs nothing and exits 0 on empty stdin" {
+  run bash -c "printf '' | $HOOK"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "hook outputs nothing on benign JSON with no tool_name" {
+  run bash -c "printf '%s' '{}' | $HOOK"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- Tool dispatch (only Edit/Write/MultiEdit/NotebookEdit fire) ---
+
+@test "passes through when tool is Bash" {
+  stage_git_repo main
+  [ -z "$(decision 'Bash' "$REPO/tracked.md")" ]
+}
+
+@test "passes through when tool is Read" {
+  stage_git_repo main
+  [ -z "$(decision 'Read' "$REPO/tracked.md")" ]
+}
+
+# --- Block cases (protected branch) ---
+
+@test "blocks Edit on main" {
+  stage_git_repo main
+  [ "$(decision 'Edit' "$REPO/tracked.md")" = "deny" ]
+}
+
+@test "blocks Write on main" {
+  stage_git_repo main
+  [ "$(decision 'Write' "$REPO/new-file.md")" = "deny" ]
+}
+
+@test "blocks MultiEdit on main" {
+  stage_git_repo main
+  [ "$(decision 'MultiEdit' "$REPO/tracked.md")" = "deny" ]
+}
+
+@test "blocks NotebookEdit on main (notebook_path field)" {
+  stage_git_repo main
+  REPO_PATH="$REPO/nb.ipynb"
+  result=$(printf '{"tool_name":"NotebookEdit","tool_input":{"notebook_path":%s}}' \
+    "$(printf '%s' "$REPO_PATH" | jq -Rs .)" \
+    | "$HOOK" | jq -r '.hookSpecificOutput.permissionDecision // empty')
+  [ "$result" = "deny" ]
+}
+
+@test "blocks Edit on master" {
+  stage_git_repo master
+  [ "$(decision 'Edit' "$REPO/tracked.md")" = "deny" ]
+}
+
+@test "blocks Write to a new file under a not-yet-existing subdir on main" {
+  stage_git_repo main
+  # Subdir doesn't exist yet — hook walks up to find existing ancestor.
+  [ "$(decision 'Write' "$REPO/new-subdir/nested/file.md")" = "deny" ]
+}
+
+# --- Allow cases ---
+
+@test "allows Edit on a feature branch" {
+  stage_git_repo feat/some-work
+  [ -z "$(decision 'Edit' "$REPO/tracked.md")" ]
+}
+
+@test "allows Edit on fix/* branch" {
+  stage_git_repo fix/bug
+  [ -z "$(decision 'Edit' "$REPO/tracked.md")" ]
+}
+
+@test "allows Edit on a file outside any git repo (working-folder case)" {
+  # No git init anywhere — simulates ~/Documents/Claude/Projects/<repo>/CONTEXT.md
+  WF="$TEST_TMP/wf"
+  mkdir -p "$WF"
+  echo "context" > "$WF/CONTEXT.md"
+  [ -z "$(decision 'Edit' "$WF/CONTEXT.md")" ]
+}
+
+@test "allows Write to a brand-new file in a non-git path" {
+  WF="$TEST_TMP/wf"
+  mkdir -p "$WF"
+  [ -z "$(decision 'Write' "$WF/brand-new.md")" ]
+}
+
+# --- KIT_PROTECTED_BRANCHES override ---
+
+@test "KIT_PROTECTED_BRANCHES override: custom list ('production') allows main" {
+  stage_git_repo main
+  result=$(printf '{"tool_name":"Edit","tool_input":{"file_path":%s}}' \
+    "$(printf '%s' "$REPO/tracked.md" | jq -Rs .)" \
+    | KIT_PROTECTED_BRANCHES="production" "$HOOK" \
+    | jq -r '.hookSpecificOutput.permissionDecision // empty')
+  [ -z "$result" ]
+}
+
+@test "KIT_PROTECTED_BRANCHES override: empty disables hook entirely" {
+  stage_git_repo main
+  result=$(printf '{"tool_name":"Edit","tool_input":{"file_path":%s}}' \
+    "$(printf '%s' "$REPO/tracked.md" | jq -Rs .)" \
+    | KIT_PROTECTED_BRANCHES="" "$HOOK" \
+    | jq -r '.hookSpecificOutput.permissionDecision // empty')
+  [ -z "$result" ]
+}
+
+@test "KIT_PROTECTED_BRANCHES override: custom list still blocks listed branches" {
+  stage_git_repo production
+  result=$(printf '{"tool_name":"Edit","tool_input":{"file_path":%s}}' \
+    "$(printf '%s' "$REPO/tracked.md" | jq -Rs .)" \
+    | KIT_PROTECTED_BRANCHES="production staging" "$HOOK" \
+    | jq -r '.hookSpecificOutput.permissionDecision // empty')
+  [ "$result" = "deny" ]
+}
+
+# --- Deny message content ---
+
+@test "deny message names the branch, the repo, and the override env var" {
+  stage_git_repo main
+  reason=$(hook_decision 'Edit' "$REPO/tracked.md" \
+    | jq -r '.hookSpecificOutput.permissionDecisionReason')
+  [[ "$reason" == *"branch 'main'"* ]]
+  [[ "$reason" == *"$REPO"* ]]
+  [[ "$reason" == *"feedback_no_work_on_main"* ]]
+  [[ "$reason" == *"git checkout -b"* ]]
+  [[ "$reason" == *"KIT_PROTECTED_BRANCHES"* ]]
+}


### PR DESCRIPTION
## Summary

Closes [#248](https://github.com/IamMrCupp/claude-project-kit/issues/248). Sibling of the #236/#237 commit-format hook on the Edit/Write side. The kit's *branch first, never start work on main* rule (memory `feedback_no_work_on_main`, MEMORY.md override-annotated index line, `/plan` + `/pull-ticket` guards from #204 / #222) is guidance — the harness doesn't enforce it. Three sessions since v1.0.0 opened on `main` regardless. Per the lesson in `feedback_hooks_for_recurring_violations.md`: when memory + slash-command guards keep getting violated, ship a hook.

## What's in the PR

- **`scripts/block-edit-on-protected-branch.sh`** — new PreToolUse hook. Fires for `Edit` / `Write` / `MultiEdit` / `NotebookEdit`. Walks up from `file_path` to find an existing ancestor dir (handles Write-to-new-file paths), then asks git for the work-tree root + current branch. If the branch is in `KIT_PROTECTED_BRANCHES` (default `main master`), emits a deny-decision JSON; otherwise exits silently. Files outside any git repo (private working folders) are always allowed.
- **`tests/block_edit_on_protected_branch.bats`** — 19 tests covering tool dispatch, branch dispatch (main/master/feat-branch), new-file-under-fresh-subdir, working-folder allow-through, `KIT_PROTECTED_BRANCHES` override (custom list / empty / additive), and deny-message content.
- **`scripts/install-scripts.sh`** — adds the new script to `SHIPPED_SCRIPTS` array; updates header comment to list three scripts instead of two.
- **`SETUP.md`** — new *Optional: branch-first enforcement hook* sub-section, parallel to the existing *Optional: commit-format enforcement hook*. Includes the install command, the `~/.claude/settings.json` snippet, and the `KIT_PROTECTED_BRANCHES` override docs.
- **`memory-templates/feedback_no_work_on_main.md`** — appended a *Structural enforcement (recommended)* note pointing at the new hook + the SETUP.md callout. Adopters with the hook installed get the harness backstop; the memory entry shifts from guidance to "why the harness blocked me" reference.

## Behavior summary

| Scenario | Result |
|---|---|
| Edit/Write/MultiEdit/NotebookEdit on `main` (in repo) | **DENY** + clear message |
| Same, on `master` | **DENY** |
| Same, on a feature branch (`feat/...`, `fix/...`, etc.) | **ALLOW** |
| Edit on a file outside any git repo (working folder) | **ALLOW** |
| Write a new file under a not-yet-existing subdir on `main` | **DENY** (walks up to find git) |
| Bash / Read / Grep / any non-Edit tool | **ALLOW** (no match) |
| `KIT_PROTECTED_BRANCHES=""` (explicit opt-out) | **ALLOW** (hook disabled) |
| `KIT_PROTECTED_BRANCHES="production"` on `main` | **ALLOW** (main not in custom list) |
| `KIT_PROTECTED_BRANCHES="production"` on `production` | **DENY** |

## Test plan

- [x] `bats tests/block_edit_on_protected_branch.bats` — 19 tests, all pass
- [x] `bats tests/` — full suite 422 → 441 ok / 0 failures
- [x] Live smoke against this PR's branch: allows on `feat/branch-first-hook` (this session is editing freely); denies cleanly when current branch is in protected list (simulated by setting `KIT_PROTECTED_BRANCHES=feat/branch-first-hook`). Deny message names branch, repo path, and the override env var.
- [x] **Branch-first respected** — branched off fresh `main` after #247 merged; no work on main this session despite opening there.

## Release impact

- `feat:` commit → release-please cuts a **minor** bump on merge (v1.4.x → **v1.5.0**).
- Adopters get the new shipped script via `upgrade.sh` (which calls `install-scripts.sh` Step 5). Wiring the hook into `~/.claude/settings.json` is a one-time manual step documented in the new SETUP.md sub-section — same shape as the commit-format hook adoption from v1.3.0.

## Notes

- The hook never fires on the kit's own working folders (those live outside any git repo by design), so SESSION-LOG / CONTEXT.md edits during normal kit work are unaffected.
- The override knob (`KIT_PROTECTED_BRANCHES`) deliberately doesn't have a "force allow this one tool call" mode — that would re-create the same "I'll be careful" footgun the hook exists to fix. Override is per-shell-session, deliberate, and visible.
- The deny message intentionally tells the model exactly how to recover (`git checkout -b <type>/<slug>`) so the next action is the right one rather than a retry of the same Edit.