### PR TITLE
fix(infer): match and expand ~/-prefixed pointers in infer_working_folder (#251)

### DIFF
--- a/scripts/lib/infer.sh
+++ b/scripts/lib/infer.sh
@@ -58,7 +58,9 @@ infer_memory_dir() {
 # $1 (default $PWD).
 #
 # Strategy: read reference_ai_working_folder.md from the repo's auto-memory
-# and extract the first backtick-quoted absolute path ending in /CONTEXT.md.
+# and extract the first backtick-quoted path ending in /CONTEXT.md. Both
+# absolute (`/Users/...`) and `~/`-prefixed (`~/Documents/...`) forms are
+# matched; tilde is expanded to $HOME at the inference layer (#251).
 # Strip the trailing /CONTEXT.md and return the parent directory.
 #
 # Returns empty string on any failure (no memory dir, no reference file,
@@ -70,17 +72,26 @@ infer_working_folder() {
   local ref_file="$memory_dir/reference_ai_working_folder.md"
   [ -f "$ref_file" ] || return 0
 
-  # Match: backtick + / + non-backtick chars + /CONTEXT.md + backtick.
-  # Example line in memory file:
-  #   - `/Users/x/Documents/Claude/Projects/foo/CONTEXT.md` — overview...
+  # Match: backtick + [/~] + non-backtick chars + /CONTEXT.md + backtick.
+  # Both absolute (`/Users/.../CONTEXT.md`) and tilde-prefixed
+  # (`~/Documents/.../CONTEXT.md`) pointer forms are valid — Cowork-migrated
+  # and hand-written memory files routinely use the tilde form. See #251.
   local match
-  match="$(grep -oE '`/[^`]+/CONTEXT\.md`' "$ref_file" 2>/dev/null | head -1)"
+  match="$(grep -oE '`[/~][^`]+/CONTEXT\.md`' "$ref_file" 2>/dev/null | head -1)"
   [ -n "$match" ] || return 0
 
   # Strip surrounding backticks and trailing /CONTEXT.md
   match="${match#\`}"
   match="${match%\`}"
   match="${match%/CONTEXT.md}"
+
+  # Expand leading tilde — kit tooling treats `~/...` and absolute pointers
+  # interchangeably (#251). The Read tool itself doesn't expand `~/`, so the
+  # expansion happens here at the inference layer.
+  case "$match" in
+    "~"|"~/"*) match="${match/#\~/$HOME}" ;;
+  esac
+
   echo "$match"
 }
 

--- a/tests/infer_working_folder.bats
+++ b/tests/infer_working_folder.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+# scripts/lib/infer.sh::infer_working_folder — read the auto-memory pointer
+# file and return the working-folder path. Both absolute and `~/`-prefixed
+# pointer forms must be supported; tilde is expanded to $HOME at the
+# inference layer (#251).
+
+load 'helpers'
+
+source "$KIT_ROOT/scripts/lib/infer.sh"
+
+# Stage a fake kit project + auto-memory + reference pointer.
+# Args:
+#   $1 — content of the reference pointer's CONTEXT.md path bullet (the line
+#        is written verbatim into reference_ai_working_folder.md).
+# Sets globals:
+#   FAKE_REPO     — the project repo path
+#   MEMORY_DIR    — derived auto-memory dir
+#   REF_FILE      — the pointer file inside MEMORY_DIR
+stage_memory_pointer() {
+  local pointer_line="$1"
+  FAKE_REPO="$TEST_TMP/repo"
+  mkdir -p "$FAKE_REPO"
+  git -C "$FAKE_REPO" init -q
+
+  # The kit's sanitization rule: absolute repo path with `/` and `.` replaced by `-`.
+  local sanitized
+  sanitized="$(echo "$FAKE_REPO" | sed 's|[/.]|-|g')"
+  MEMORY_DIR="$TEST_HOME/.claude/projects/${sanitized}/memory"
+  mkdir -p "$MEMORY_DIR"
+  REF_FILE="$MEMORY_DIR/reference_ai_working_folder.md"
+
+  cat > "$REF_FILE" <<EOF
+---
+name: AI working folder for test
+type: reference
+---
+At the start of every session, read:
+$pointer_line
+EOF
+}
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  TEST_HOME="$TEST_TMP/home"
+  mkdir -p "$TEST_HOME"
+  export HOME="$TEST_HOME"
+}
+
+teardown() {
+  [ -n "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"
+}
+
+# --- Absolute pointer (existing behavior, regression guard) ---
+
+@test "absolute-path pointer: returns the working-folder directory" {
+  WF="$TEST_TMP/wf-absolute"
+  mkdir -p "$WF"
+  stage_memory_pointer "- \`$WF/CONTEXT.md\` — overview"
+  result="$(infer_working_folder "$FAKE_REPO")"
+  [ "$result" = "$WF" ]
+}
+
+# --- Tilde-prefixed pointer (#251 regression) ---
+
+@test "tilde-prefixed pointer: expands ~/ to \$HOME and returns the directory" {
+  # Stage a real WF under $HOME so the expanded path actually exists.
+  WF_REL="Documents/Claude/Projects/tilde-test"
+  mkdir -p "$HOME/$WF_REL"
+  stage_memory_pointer "- \`~/$WF_REL/CONTEXT.md\` — overview (tilde form)"
+  result="$(infer_working_folder "$FAKE_REPO")"
+  [ "$result" = "$HOME/$WF_REL" ]
+}
+
+@test "tilde-prefixed pointer: result is an absolute path, not literal ~" {
+  WF_REL="Documents/Claude/Projects/foo"
+  mkdir -p "$HOME/$WF_REL"
+  stage_memory_pointer "- \`~/$WF_REL/CONTEXT.md\` — overview"
+  result="$(infer_working_folder "$FAKE_REPO")"
+  # Must NOT begin with literal tilde — must be fully expanded.
+  [[ "$result" != \~* ]]
+  [[ "$result" == /* ]]
+}
+
+# --- Edge cases ---
+
+@test "no pointer file: returns empty" {
+  FAKE_REPO="$TEST_TMP/no-memory-repo"
+  mkdir -p "$FAKE_REPO"
+  git -C "$FAKE_REPO" init -q
+  result="$(infer_working_folder "$FAKE_REPO")"
+  [ -z "$result" ]
+}
+
+@test "pointer file present but no /CONTEXT.md match: returns empty" {
+  stage_memory_pointer "- this line has no backtick-quoted CONTEXT.md path"
+  result="$(infer_working_folder "$FAKE_REPO")"
+  [ -z "$result" ]
+}
+
+@test "multiple pointer lines: first match wins (deterministic)" {
+  FAKE_REPO="$TEST_TMP/repo"
+  mkdir -p "$FAKE_REPO"
+  git -C "$FAKE_REPO" init -q
+  local sanitized
+  sanitized="$(echo "$FAKE_REPO" | sed 's|[/.]|-|g')"
+  MEMORY_DIR="$TEST_HOME/.claude/projects/${sanitized}/memory"
+  mkdir -p "$MEMORY_DIR"
+  REF_FILE="$MEMORY_DIR/reference_ai_working_folder.md"
+  WF_FIRST="$TEST_TMP/wf-first"
+  WF_SECOND="$TEST_TMP/wf-second"
+  mkdir -p "$WF_FIRST" "$WF_SECOND"
+  cat > "$REF_FILE" <<EOF
+- \`$WF_FIRST/CONTEXT.md\` — first match
+- \`$WF_SECOND/CONTEXT.md\` — second match
+EOF
+  result="$(infer_working_folder "$FAKE_REPO")"
+  [ "$result" = "$WF_FIRST" ]
+}


### PR DESCRIPTION
## Summary

Closes [#251](https://github.com/IamMrCupp/claude-project-kit/issues/251). `scripts/lib/infer.sh::infer_working_folder` greps the auto-memory pointer file for a backtick-quoted path ending in `/CONTEXT.md`. The original regex required `/` immediately after the opening backtick — absolute paths only. A `~/`-prefixed pointer (legitimate format, used by Cowork migrations and hand-written memory) silently didn't match, so `sync-templates`, `/session-start`, `convert-to-shared.sh`, and every other call site silently skipped the working folder without warning.

This PR makes `infer_working_folder` accept both pointer forms and expand `~/` to `$HOME` at the inference layer.

## What's in the PR

**`scripts/lib/infer.sh`** — two small changes in `infer_working_folder()`:

1. Regex: `` `[/~][^`]+/CONTEXT\.md` `` — matches both absolute (`/...`) and tilde-prefixed (`~/...`) paths.
2. Tilde expansion: `case "$match" in "~"|"~/"*) match="${match/#\~/$HOME}" ;; esac` — applied after backtick/suffix stripping, before return.

The docstring above the function is also updated to document both forms.

**`tests/infer_working_folder.bats`** — new test file with 6 cases:
- Absolute-path pointer returns the working-folder directory (regression guard for existing behavior)
- Tilde-prefixed pointer expands `~/` to `$HOME` and returns the directory (the #251 fix)
- Tilde-prefixed pointer result is an absolute path — not literal `~`
- No pointer file: returns empty
- Pointer file present but no `/CONTEXT.md` match: returns empty
- Multiple pointer lines: first match wins (deterministic)

The test file `source`s `scripts/lib/infer.sh` directly (same pattern `tests/sanitize_dotted_paths.bats` uses) and stages a fake repo + auto-memory dir + reference pointer under a sandboxed `$HOME`.

## Test plan

- [x] `bats tests/infer_working_folder.bats` — 6 new tests pass
- [x] `bats tests/` — full suite 441 → 447 ok / 0 failures (+6 new, no regressions)
- [x] Live evidence aligns with the fix: per 2026-05-26 SESSION-LOG, hand-rewriting the `obs-radio-output` pointer to absolute was the workaround; this PR makes the workaround unnecessary.

## Adoption

- `fix:` commit → release-please cuts a **patch** bump on merge (v1.5.x → **v1.5.1** after #250 lands).
- Adopters who hit the bug previously (silent skips with `~/`-prefixed pointers) start working immediately on upgrade — no per-pointer rewrites needed. Existing pointers with absolute paths keep working exactly as before.

## Notes

- Branched off fresh `main` after #249 merged. No work on main this session despite opening there.
- `feedback_hooks_for_recurring_violations` lesson holds: would have been even cleaner if the branch-first hook from #248 had already shipped to enforce that branching automatically. The next session that opens on main will benefit from #248's enforcement.