### PR TITLE
docs(context): single-source mutable conventions in auto-memory (#258)

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -135,7 +135,7 @@ When in doubt about who owns it, ask. Default to assuming externally-owned.
   - `implementation.md` gets amended when a task's approach materially changes mid-flight.
   - `plan.md` status line bumps when a phase transitions.
 - **End every session with a `SESSION-LOG.md` entry.** Append-only. Date, focus, branches/PRs, decisions, anything non-obvious for future-you.
-- **`CONTEXT.md` is the "read first" doc.** Keep it ≤300 lines. If it grows beyond that, the content belongs in one of the other docs and `CONTEXT.md` should link to it.
+- **`CONTEXT.md` is the "read first" doc.** Keep it ≤300 lines. If it grows beyond that, the content belongs in one of the other docs and `CONTEXT.md` should link to it. **Its "Working Rules" section points at auto-memory `feedback_*` for mutable conventions — it does not restate them** (see *Auto-memory* below for why).
 - **Archive resolved ticket scratchpads.** Once a ticket's work is done, move `tickets/<KEY>-<slug>.md` into `tickets/archive/` so a long-running workspace's `tickets/` folder stays scannable. Use `/archive-ticket <KEY>` (it also notes the archival in `SESSION-LOG.md`) or the terminal helper `archive-ticket.sh <KEY>`. The move never touches the external tracker — transition the ticket there yourself.
 
 ## Acceptance tests at phase boundaries
@@ -163,6 +163,8 @@ This layers on top of *automated tests preferred over manual* — that rule gove
 
 ## Auto-memory
 
+- **Auto-memory `feedback_*` files are the source of truth for mutable conventions.** Commit style, branch naming, merge strategy, and PR rules live in memory and load every session via `MEMORY.md`. **Do not also restate them in `CONTEXT.md`** — `CONTEXT.md`'s "Working Rules" should *point* at the memory (`Merge strategy → feedback_merge_strategy`), never copy the rule text. Duplicated convention prose drifts: when a rule changes, one copy goes stale, and a stale `CONTEXT.md` line can silently override the live memory an agent already loaded ([#258](https://github.com/IamMrCupp/claude-project-kit/issues/258) — a stale "squash" line in CONTEXT overrode a correct "merge commit" memory and a prod PR got squash-merged against the rule). Project-specific rules with *no* memory file are the one exception — those live in CONTEXT.md's *Project-specific* block.
+- **When a rule flips, flip the frontmatter `description:` with the body.** A memory whose headline says "merge commit" but whose `description:` still says "squash" is internally contradictory and the `description:` is what gets scanned for relevance — half-finished edits are how a correct memory still steers wrong. Edit both, or neither.
 - **Save feedback from both corrections and confirmations.** Corrections are easy to notice; quiet "yes exactly, keep doing that" moments are what keep you from drifting away from validated approaches.
 - **Structure feedback/project memories as:** the rule, then **Why:** (reason), then **How to apply:** (when/where). The `why` lets future-you judge edge cases instead of blindly following.
 - **Don't memorize what the code already tells you.** File paths, architecture, function signatures belong in the code, not in memory. Memory is for rules, preferences, external references, and project context that isn't derivable from the repo.

--- a/memory-templates/MEMORY.md
+++ b/memory-templates/MEMORY.md
@@ -6,6 +6,8 @@ Starter index. Every file in this folder is a **starting point** — copy them i
 - Prune entries that don't apply
 - Add new ones as rules come up during real work
 
+These `feedback_*` files are the **source of truth for mutable conventions** (commit style, branch naming, merge strategy, PR rules). Keep the rule here — don't also restate it in `CONTEXT.md`, which should only *point* at the memory. Two copies drift, and a stale one can silently override this one. When you flip a rule, **flip the frontmatter `description:` together with the body** — a half-edited memory whose `description:` still says the old rule steers wrong even when the body is right. See `CONVENTIONS.md` → *Auto-memory* and [#258](https://github.com/IamMrCupp/claude-project-kit/issues/258).
+
 Do not treat these as canonical without reading them first — they encode one opinionated way of working.
 
 - [User role and background](user_role.md) — who you're collaborating with, how to calibrate explanations

--- a/memory-templates/feedback_merge_strategy.md
+++ b/memory-templates/feedback_merge_strategy.md
@@ -11,5 +11,5 @@ When merging PRs, always choose **"Create a merge commit"** (the default first o
 **How to apply:**
 - In GitHub: when clicking "Merge pull request", the dropdown should default to "Create a merge commit"
 - If a repo has "Allow merge commits" disabled, re-enable it (Settings → Pull Requests)
-- For work projects that mandate squash-merge — override this rule but note it in `CONTEXT.md` so future-you doesn't fight the policy
+- For work projects that mandate squash-merge — override this rule **by editing this memory file itself** (flip the body *and* the frontmatter `description:` together), not by copying a contradicting line into `CONTEXT.md`. Memory is the single source of truth for merge strategy; a second copy in `CONTEXT.md` drifts and can silently override this one (see `CONVENTIONS.md` → *Auto-memory*, and [#258](https://github.com/IamMrCupp/claude-project-kit/issues/258))
 - Never force-push over someone else's merge commit to "clean up" — you'll rewrite history others may have pulled

--- a/templates/CONTEXT.md
+++ b/templates/CONTEXT.md
@@ -76,25 +76,31 @@ This folder uses a layered documentation system. Reuse this pattern when startin
 
 ## Working Rules
 
-### Git & commits
-- {{Conventional Commits, single line, `-s` sign-off — OR whatever this project uses}}
-- {{Branch naming convention}}
-- {{Merge strategy — merge commit / squash / rebase}}
+> **Source of truth — read this before adding a rule here.** Mutable conventions
+> (commit style, branch naming, merge strategy, PR rules) live in **auto-memory
+> `feedback_*.md`** and load into every session via `MEMORY.md`. This section only
+> **points** at them — it must never restate the rule text. Duplicated convention
+> prose drifts: when a rule changes, one copy goes stale, and a stale copy here can
+> silently override the live memory (see [#258](https://github.com/IamMrCupp/claude-project-kit/issues/258)).
+> If a convention is genuinely project-specific and has no memory file, it lives
+> under *Project-specific* below — that's the one place rules-text belongs in CONTEXT.md.
+
+### Git & commits → see auto-memory
+- Commit format → `feedback_commit_format` *(adjust the linked memory, not this line)*
+- Branch naming → `feedback_branch_naming`
+- Merge strategy → `feedback_merge_strategy`
+- {{Add a pointer line per applicable `feedback_*` memory; don't paste the rule text}}
 
 ### PRs
 - {{Template location if any}}
 - {{Required reviewers, required checks}}
 - Manual test plan required for runtime changes — see CONVENTIONS.md
-- **Branch protection on free-tier private repos:** as of 2026, GitHub gates BOTH legacy branch protection and rulesets enforcement behind paid plans (Pro for personal, Team for orgs). On a free private repo neither enforces — rulesets can be *created* but won't take effect. Fall back to manual discipline: never force-push to `main`, never delete `main`, wait for green CI before merging. A local `pre-push` git hook can add belt-and-suspenders if desired.
 
-### Shell / build
-- {{Shell in use — bash / zsh / fish / pwsh}}
-- {{Local build command}}
-- {{Local test command}}
-
-### File editing
+### Project-specific (lives only here — not in memory)
 - Repo is mounted at `{{REPO_PATH}}`
 - Claude reads + edits directly; never copy-paste code through chat
+- Shell / build / test: {{shell in use — bash / zsh / fish / pwsh; local build command; local test command}}
+- **Branch protection on free-tier private repos:** as of 2026, GitHub gates BOTH legacy branch protection and rulesets enforcement behind paid plans (Pro for personal, Team for orgs). On a free private repo neither enforces — rulesets can be *created* but won't take effect. Fall back to manual discipline: never force-push to `main`, never delete `main`, wait for green CI before merging. A local `pre-push` git hook can add belt-and-suspenders if desired.
 
 ---
 

--- a/templates/workspace/workspace-CONTEXT.md
+++ b/templates/workspace/workspace-CONTEXT.md
@@ -103,7 +103,14 @@ Active per-ticket scratchpads live under `tickets/<KEY>-<slug>.md`. Closed ticke
 
 ## Cross-repo notes
 
-{{Anything that spans multiple repos and doesn't belong in any single per-repo `CONTEXT.md` — shared dependencies, deployment ordering across repos, cross-repo PR coordination, naming conventions that hold across the workspace, etc. Keep tight; if a section grows past a paragraph, consider whether it belongs in a per-repo `CONTEXT.md` or in `implementation.md` of the relevant repo.}}
+> **Don't restate mutable conventions here.** Commit style, branch naming, merge
+> strategy, and PR rules are the source-of-truth job of auto-memory `feedback_*.md`
+> (loaded every session via `MEMORY.md`) — point at them, don't copy them. A stale
+> convention line in this file can silently override the live memory an agent already
+> loaded (see [#258](https://github.com/IamMrCupp/claude-project-kit/issues/258) and
+> `CONVENTIONS.md` → *Auto-memory*). Cross-repo *coordination* facts below are fine.
+
+{{Anything that spans multiple repos and doesn't belong in any single per-repo `CONTEXT.md` — shared dependencies, deployment ordering across repos, cross-repo PR coordination, etc. Keep tight; if a section grows past a paragraph, consider whether it belongs in a per-repo `CONTEXT.md` or in `implementation.md` of the relevant repo.}}
 
 ---
 

--- a/tests/convention_single_source.bats
+++ b/tests/convention_single_source.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+# Regression guard for #258 — mutable conventions must be single-sourced in
+# auto-memory `feedback_*.md`, not restated in the CONTEXT.md templates.
+#
+# Background: the working-folder model stored the same mutable conventions
+# (merge strategy, branch naming, commit style) in BOTH `CONTEXT.md`'s
+# "Working Rules" section AND auto-memory feedback files, with no declared
+# precedence. When a rule changed, one copy went stale and the two
+# contradicted each other. A real failure (2026-06): a stale "squash merge"
+# line in CONTEXT.md overrode a correct "merge commit" memory and a prod PR
+# got squash-merged against the rule.
+#
+# These tests assert the templates now POINT at memory rather than restating
+# rule text, and that the precedence statement is present where it's needed.
+
+load 'helpers'
+
+CONTEXT_TMPL="$KIT_ROOT/templates/CONTEXT.md"
+WORKSPACE_CONTEXT_TMPL="$KIT_ROOT/templates/workspace/workspace-CONTEXT.md"
+MEMORY_INDEX="$KIT_ROOT/memory-templates/MEMORY.md"
+MERGE_MEM="$KIT_ROOT/memory-templates/feedback_merge_strategy.md"
+CONVENTIONS="$KIT_ROOT/CONVENTIONS.md"
+
+# Extract the "## Working Rules" section of the CONTEXT template (up to the
+# next top-level heading) so keyword checks are scoped, not whole-file.
+working_rules_section() {
+  awk '/^## Working Rules/{f=1} f&&/^## /&&!/^## Working Rules/{if(seen){exit}} /^## Working Rules/{seen=1} f' "$CONTEXT_TMPL"
+}
+
+@test "template + convention files exist" {
+  [ -f "$CONTEXT_TMPL" ]
+  [ -f "$WORKSPACE_CONTEXT_TMPL" ]
+  [ -f "$MEMORY_INDEX" ]
+  [ -f "$MERGE_MEM" ]
+  [ -f "$CONVENTIONS" ]
+}
+
+@test "CONTEXT.md Working Rules declares auto-memory as source of truth" {
+  section="$(working_rules_section)"
+  echo "$section" | grep -qi 'source of truth' \
+    || { echo "Working Rules section missing 'source of truth' precedence statement"; return 1; }
+  echo "$section" | grep -q 'feedback_' \
+    || { echo "Working Rules section does not point at feedback_* memory"; return 1; }
+}
+
+@test "CONTEXT.md Working Rules points at merge-strategy memory, does not restate it" {
+  section="$(working_rules_section)"
+  # Must reference the memory file by name (pointer form).
+  echo "$section" | grep -q 'feedback_merge_strategy' \
+    || { echo "Working Rules section missing feedback_merge_strategy pointer"; return 1; }
+  # Must NOT restate the actual merge-policy verbs that belong in the memory.
+  if echo "$section" | grep -qiE 'squash|rebase-merge|create a merge commit'; then
+    echo "Working Rules section restates merge-policy text instead of pointing at memory"
+    return 1
+  fi
+}
+
+@test "merge-strategy memory no longer tells users to copy overrides into CONTEXT.md" {
+  # The old anti-pattern: "override this rule but note it in CONTEXT.md".
+  if grep -qiE 'note it in .?CONTEXT' "$MERGE_MEM"; then
+    echo "feedback_merge_strategy.md still instructs copying overrides into CONTEXT.md"
+    return 1
+  fi
+}
+
+@test "CONVENTIONS.md Auto-memory section declares single-source + frontmatter-flip rules" {
+  # Source-of-truth precedence.
+  grep -qi 'source of truth for mutable conventions' "$CONVENTIONS" \
+    || { echo "CONVENTIONS.md missing source-of-truth precedence rule"; return 1; }
+  # Frontmatter description must flip with the body.
+  grep -qi 'description:' "$CONVENTIONS" \
+    || { echo "CONVENTIONS.md missing frontmatter description-flip guidance"; return 1; }
+}
+
+@test "MEMORY.md template header carries the single-source + description-flip hygiene note" {
+  grep -qi 'source of truth for mutable conventions' "$MEMORY_INDEX" \
+    || { echo "MEMORY.md header missing source-of-truth note"; return 1; }
+  grep -qi 'description:' "$MEMORY_INDEX" \
+    || { echo "MEMORY.md header missing description-flip hygiene note"; return 1; }
+}
+
+@test "workspace-CONTEXT.md warns against restating conventions in cross-repo notes" {
+  grep -qiE "don't restate|do not restate" "$WORKSPACE_CONTEXT_TMPL" \
+    || { echo "workspace-CONTEXT.md missing 'don't restate conventions' guard"; return 1; }
+}


### PR DESCRIPTION
## What

Closes the docs/template half of #258 (issue fixes 1, 2, 4). Mutable working conventions (commit style, branch naming, merge strategy, PR rules) now have **one declared source of truth — auto-memory `feedback_*.md`** — and the `CONTEXT.md` templates *point* at them instead of restating them.

### Why

#258 documents a real, irreversible failure: a workspace's merge convention changed to merge-commits-only in auto-memory + `MEMORY.md`, but a stale "squash merge" line was left in `CONTEXT.md`. The agent followed the stale CONTEXT prose and **squash-merged a production PR against the rule** — even though the *correct* rule was loaded in context. Duplicated mutable state with no precedence is a structural trap the kit was actively inviting.

### Changes

- **`templates/CONTEXT.md`** — "Working Rules" rewritten: a precedence header declaring auto-memory as source of truth, the Git/commit rules converted from prose copies to pointer lines (`Merge strategy → feedback_merge_strategy`), and a new *Project-specific* block for the genuinely CONTEXT-only items (repo path, free-tier branch-protection note, build/test commands).
- **`CONVENTIONS.md`** → *Auto-memory* — two new kit-level rules: (1) `feedback_*` is source of truth, don't restate in `CONTEXT.md`; (2) when a rule flips, flip the frontmatter `description:` with the body (the #258 memory was internally contradictory — headline "merge," description still "squash").
- **`memory-templates/feedback_merge_strategy.md`** — the starter literally told users to *"override this rule but note it in `CONTEXT.md`"* — the exact trap. Reworded to record overrides **in the memory file itself**.
- **`memory-templates/MEMORY.md`** — header gains the single-source + description-flip hygiene note.
- **`templates/workspace/workspace-CONTEXT.md`** — "Cross-repo notes" gains a "don't restate conventions here" guard (it previously invited "naming conventions that hold across the workspace").

The CI-memory references to `CONTEXT.md` (Jenkins host, approval gates, inventory layout) were intentionally left — those are project-specific *facts* with no memory file, which is the documented exception.

### Test plan

- [x] New `tests/convention_single_source.bats` (7 tests) — asserts the Working Rules section declares source-of-truth, points at `feedback_merge_strategy` without restating merge-policy verbs, the merge memory no longer says "note it in CONTEXT.md", and CONVENTIONS/MEMORY/workspace carry their guards.
- [x] Full bats suite green: **454 ok, zero failures** (447 prior + 7 new).
- [x] No broken relative links (cross-doc references are prose; `#258` links are external, skipped by lychee offline).

Fix 3 (consistency lint — `check-convention-drift.sh` wired into `/session-verify`) follows in a separate PR.